### PR TITLE
bugfix: remove freifunk feeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ openwrt-clean: stamp-clean-openwrt-cleaned .stamp-openwrt-cleaned
 	rm -f .stamp-unpatched
 	ln -sf $(TOP_DIR)/patches $(OPENWRT_DIR)/
 	ln -sf $(TOP_DIR)/files   $(OPENWRT_DIR)/
+	sed -i "s/^.*freifunk.*$$//" $(OPENWRT_DIR)/feeds.conf.default
 	touch $@
 
 # update openwrt and checkout specified commit


### PR DESCRIPTION
temporary fix until received from upstream

The feed is being removed because:
a) it is an external project and the OpenWrt team does not have access to it.
b) upon original addition of the feed, there was only a very weak tendency for the addition.
c) there is a general lack of interest in the freifunk repo to review and/or merge pull requests.
d) as far as can be found, all projects which use the freifunk feed have their own make system and self-maintained feeds list. They do not use the feeds.conf.default from the openwrt repo.

more information can be read at the following links:

http://lists.openwrt.org/pipermail/openwrt-devel/2021-February/033807.html
freifunk/openwrt-packages#37