### PR TITLE
bugfix: uci_set_indexed_option() inserting multiple empty sections

### DIFF
--- a/files/www/cgi-bin/ucifunc.pm
+++ b/files/www/cgi-bin/ucifunc.pm
@@ -38,7 +38,7 @@
 sub uci_get_sectiontype_count()
 {
     my ($config, $stype)=@_;
-    my $cmd=sprintf('uci show %s|egrep %s\.\@%s.*=%s|wc -l',$config,$stype,$stype,$stype);
+    my $cmd=sprintf('uci show %s|egrep %s\.\@%s.*=%s|wc -l',$config,$config,$stype,$stype);
     my $res=`$cmd`;
     my $rc=$?;
     chomp($res);


### PR DESCRIPTION
uci_set_indexed_option() inserted an empty section on every call
because uci_get_sectiontype_count() always returned 0