### PR TITLE
bugfix: Tunnel servers limited to 9 - same fix as vtundsrv in f4a1e73

### DIFF
--- a/files/etc/init.d/vtund
+++ b/files/etc/init.d/vtund
@@ -68,7 +68,7 @@ to_server_config() {
 	local new_file="$2"	
 	local enabled host pwd net node netip clientip serverip
 		
-	if [ $TUNNUM -lt $MAXTUNNUM ]
+	if [ $TUNNUM -le $MAXTUNNUM ]
 	then
 		config_get_bool enabled "$cfg" enabled
 		config_get node "$cfg" node


### PR DESCRIPTION
Trivial fix, same as the one to vtundsrv in f4a1e73189862f6308de54deffa2862b2fafb17c