### PR TITLE
Snr zero spike fix

### DIFF
--- a/files/usr/local/bin/snrlog
+++ b/files/usr/local/bin/snrlog
@@ -282,7 +282,7 @@ local f = io.open(pidfile,"r")
 if (f) then
   local oldpid = f:read("*number")
   f:close()
-  if (oldpid ~= nill and dir_exists("/proc/" .. oldpid)) then
+  if (oldpid ~= nil and dir_exists("/proc/" .. oldpid)) then
     return
   end
 end
@@ -300,7 +300,7 @@ local f = io.open(rssifile,"r")
 if (f) then
   local oldpid = f:read("*number")
   f:close()
-  if (oldpid ~= nill and dir_exists("/proc/" .. oldpid)) then
+  if (oldpid ~= nil and dir_exists("/proc/" .. oldpid)) then
     os.remove(pidfile)
     return
   end

--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -146,15 +146,15 @@ function getSignal(realtime)
 
 		-- snrlog sometimes has the string "null" for signal/noise, if so then assume they are zero
 		if signal_dbm=="null" then
-			signal_dbm = 0
+			signal_dbm = -95
 		end
 		if noise_dbm=="null" then
-			noise_dbm = 0
+			noise_dbm = -95
 		end
 
 		-- signal and noise might also be nil, so convert them to numbers
-		signal_dbm = tonumber(signal_dbm or 0)
-		noise_dbm = tonumber(noise_dbm or 0)
+		signal_dbm = tonumber(signal_dbm or -95)
+		noise_dbm = tonumber(noise_dbm or -95)
 
 		--snrlog sometimes has -1 for mcs indices, if so then make them undefined
 		if tx_rate_mcs_index == -1 or tx_rate_mcs_index == "-1" then

--- a/files/www/cgi-bin/sysinfo.json
+++ b/files/www/cgi-bin/sysinfo.json
@@ -88,7 +88,7 @@ info['node_details']['mesh_gateway']=aredn_info.getMeshGatewaySetting()
 info['meshrf']={}
 local radio=aredn_info.getMeshRadioDevice()
 
-if ( radio ~= nill and radio ~= "" ) then
+if ( radio ~= nil and radio ~= "" ) then
 	info['meshrf']['status']="on"
 	info['meshrf']['ssid']=aredn_info.getSSID()
 	info['meshrf']['channel']=aredn_info.getChannel(radio)


### PR DESCRIPTION
Fix the SNR spike to zero on the Charts.  This sets the value to the default floor.