### PR TITLE
bug: Fix spike to zero in SNR Chart

### DIFF
--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -146,15 +146,15 @@ function getSignal(realtime)
 
 		-- snrlog sometimes has the string "null" for signal/noise, if so then assume they are zero
 		if signal_dbm=="null" then
-			signal_dbm = 0
+			signal_dbm = -95
 		end
 		if noise_dbm=="null" then
-			noise_dbm = 0
+			noise_dbm = -95
 		end
 
 		-- signal and noise might also be nil, so convert them to numbers
-		signal_dbm = tonumber(signal_dbm or 0)
-		noise_dbm = tonumber(noise_dbm or 0)
+		signal_dbm = tonumber(signal_dbm or -95)
+		noise_dbm = tonumber(noise_dbm or -95)
 
 		--snrlog sometimes has -1 for mcs indices, if so then make them undefined
 		if tx_rate_mcs_index == -1 or tx_rate_mcs_index == "-1" then


### PR DESCRIPTION
Fix spike to zero in SNR Chart.

Chart before fix:
![1-existing-API-value-without-fix](https://user-images.githubusercontent.com/69524416/113776991-5ef63800-96df-11eb-916e-d68bd94a93c9.png)

Chart after fix:
![2-new-Chart-values-with-fix](https://user-images.githubusercontent.com/69524416/113777011-6584af80-96df-11eb-9613-5ef0babb848c.png)
