### PR TITLE
Remove local.mesh suffix from CurrentNeighbor hostname

### DIFF
--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -76,7 +76,7 @@ function model.getCurrentNeighbors(RFinfo)
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d.", "")
       host = string.gsub(host,".local.mesh$","")
-      host = string.upper(host)
+      host = string.lower(host)
     	info[remip]['hostname']=host
 	  else
 		  info[remip]['hostname']=remip

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -76,6 +76,7 @@ function model.getCurrentNeighbors(RFinfo)
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d.", "")
       host = string.gsub(host,".local.mesh$","")
+      host = string.upper(host)
     	info[remip]['hostname']=host
 	  else
 		  info[remip]['hostname']=remip

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -75,8 +75,9 @@ function model.getCurrentNeighbors(RFinfo)
 	  end
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d.", "")
+      host = string.gsub(host,".local.mesh$","")
     	info[remip]['hostname']=host
-	  else 
+	  else
 		  info[remip]['hostname']=remip
 	  end
     -- services


### PR DESCRIPTION
In olsr.lua there are gsubs to remove dtdlink and mid prefixes.  Add a gsub to remove the local.mesh suffix from hostname too.