### PR TITLE
Remove local.mesh suffix from Local Hosts for newui

### DIFF
--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -144,9 +144,9 @@ function model.getArednAlert()
 			afile:close()
 		end
 	end
-        if #alert~=0 then return alert                                                                    
-        else return ""                                                                                    
-        end 
+        if #alert~=0 then return alert
+        else return ""
+        end
 end
 
 -------------------------------------
@@ -162,9 +162,9 @@ function model.getLocalAlert()
 			afile:close()
 		end
 	end
-        if #alert~=0 then return alert                                                                    
-        else return ""                                                                                    
-        end 
+        if #alert~=0 then return alert
+        else return ""
+        end
 end
 
 
@@ -525,6 +525,7 @@ function model.getLocalHosts()
 					}
 					local index = 0
 					for hostname in entries:gmatch("%S+") do
+						hostname = string.gsub(hostname,".local.mesh$","")
 						entry["hostnames"][index] = hostname
 						index = index + 1
 					end

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -76,7 +76,7 @@ function model.getCurrentNeighbors(RFinfo)
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d.", "")
       host = string.gsub(host,".local.mesh$","")
-      host = string.upper(host)
+      host = string.lower(host)
     	info[remip]['hostname']=host
 	  else
 		  info[remip]['hostname']=remip

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -76,6 +76,7 @@ function model.getCurrentNeighbors(RFinfo)
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d.", "")
       host = string.gsub(host,".local.mesh$","")
+      host = string.upper(host)
     	info[remip]['hostname']=host
 	  else
 		  info[remip]['hostname']=remip

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -75,8 +75,9 @@ function model.getCurrentNeighbors(RFinfo)
 	  end
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d.", "")
+      host = string.gsub(host,".local.mesh$","")
     	info[remip]['hostname']=host
-	  else 
+	  else
 		  info[remip]['hostname']=remip
 	  end
     -- services


### PR DESCRIPTION
This removes the local.mesh suffix from hostnames returned through the **api** for the Local Hosts display in the newui.  Similar change as was submitted for the Current Neighbors display earlier.