### PR TITLE
Fix regex for current neighbor midxx.hostname

### DIFF
--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -75,7 +75,7 @@ function model.getCurrentNeighbors(RFinfo)
 	  end
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d+.", "")
-      host = string.gsub(remhost,"dtdlink%.", "")
+      host = string.gsub(host,"dtdlink%.", "")
       host = string.gsub(host,".local.mesh$","")
     	info[remip]['hostname']=host
 	  else

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -71,7 +71,7 @@ function model.getCurrentNeighbors(RFinfo)
     info[remip]['linkQuality']=v['linkQuality']
     info[remip]['neighborLinkQuality']=v['neighborLinkQuality']
 	  if remhost ~= nil then
-      host = string.lower(host)
+      host = string.lower(remhost)
 	  end
 	  if host ~= nil then
     	host = string.gsub(host,"mid%d+.", "")

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -71,12 +71,12 @@ function model.getCurrentNeighbors(RFinfo)
     info[remip]['linkQuality']=v['linkQuality']
     info[remip]['neighborLinkQuality']=v['neighborLinkQuality']
 	  if remhost ~= nil then
-    	host = string.gsub(remhost,"dtdlink%.", "")
+      host = string.lower(host)
 	  end
 	  if host ~= nil then
-    	host = string.gsub(host,"mid%d.", "")
+    	host = string.gsub(host,"mid%d+.", "")
+      host = string.gsub(remhost,"dtdlink%.", "")
       host = string.gsub(host,".local.mesh$","")
-      host = string.lower(host)
     	info[remip]['hostname']=host
 	  else
 		  info[remip]['hostname']=remip


### PR DESCRIPTION
Fix regex for mid%d.hostname. It's possible that there may be more than a single digit. This PR also puts all the string.gsub processing in the if-else for _host_ rather than _remhost_.