### PR TITLE
Add Default Value for Description

### DIFF
--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -94,6 +94,7 @@ end
 -------------------------------------
 function model.getNodeDescription()
 	css=aredn_uci.getUciConfType("system", "system")
+	css[1]['description'] = css[1]['description'] or "None"
 	return css[1]['description']
 end
 


### PR DESCRIPTION
Add a default value of _None_ if no description exists.
This could be handled in the newui, but if no description exists then the description key will never appear in the data returned by the _api_.  This way, something is always returned and the key will always appear in the data.