### PR TITLE
remove hostname case manipulation

### DIFF
--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -49,7 +49,6 @@ require("iwinfo")
 -------------------------------------
 local model = {}
 
-
 -------------------------------------
 -- Get FIRST_BOOT status
 -------------------------------------
@@ -526,7 +525,6 @@ function model.getLocalHosts()
 	local hosts, line
 	if nixio.fs.access("/etc/hosts") then
 		for line in io.lines("/etc/hosts") do
---			line = line:lower()
 			local data = line:match("^([^#;]+)[#;]*(.*)$")  -- skip comment lines
 			if data then
 				local hostname, entries

--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -512,7 +512,7 @@ function model.getLocalCnxType(hostname)
 		return "Loopback"
 	elseif string.match(hostname,"dtdlink") then
 		return "DTD"
-	elseif hostname == string.lower( model.getNodeName() ) then
+	elseif hostname == model.getNodeName() then
 		return "RF"
 	else
 		return "LAN"
@@ -526,9 +526,8 @@ function model.getLocalHosts()
 	local hosts, line
 	if nixio.fs.access("/etc/hosts") then
 		for line in io.lines("/etc/hosts") do
-			line = line:lower()
-			-- line is not a comment
-			local data = line:match("^([^#;]+)[#;]*(.*)$")
+--			line = line:lower()
+			local data = line:match("^([^#;]+)[#;]*(.*)$")  -- skip comment lines
 			if data then
 				local hostname, entries
 				local ip, entries = data:match("^%s*([%[%]%x%.%:]+)%s+(%S.-%S)%s*$")

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -72,8 +72,8 @@ function model.getCurrentNeighbors(RFinfo)
     info[remip]['neighborLinkQuality']=v['neighborLinkQuality']
 	  if remhost ~= nil then
     	host = string.gsub(remhost,"^mid%d+.", "")
-      host = string.gsub(remhost,"^dtdlink%.", "")
-      host = string.gsub(remhost,".local.mesh$","")
+      host = string.gsub(host,"^dtdlink%.", "")
+      host = string.gsub(host,".local.mesh$","")
     	info[remip]['hostname']=host
 	  else
 		  info[remip]['hostname']=remip

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -62,7 +62,6 @@ function model.getCurrentNeighbors(RFinfo)
   local info={}
   local links=model.getOLSRLinks()
   for k,v in pairs(links) do
-    local host
     local remip=v['remoteIP']
     local remhost=nslookup(remip)
     info[remip]={}
@@ -71,13 +70,10 @@ function model.getCurrentNeighbors(RFinfo)
     info[remip]['linkQuality']=v['linkQuality']
     info[remip]['neighborLinkQuality']=v['neighborLinkQuality']
 	  if remhost ~= nil then
-      host = string.lower(remhost)
-	  end
-	  if host ~= nil then
-    	host = string.gsub(host,"mid%d+.", "")
-      host = string.gsub(host,"dtdlink%.", "")
-      host = string.gsub(host,".local.mesh$","")
-    	info[remip]['hostname']=host
+    	remhost = string.gsub(remhost,"^mid%d+.", "")
+      remhost = string.gsub(remhost,"^dtdlink%.", "")
+      remhost = string.gsub(remhost,".local.mesh$","")
+    	info[remip]['hostname']=remhost
 	  else
 		  info[remip]['hostname']=remip
 	  end

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -62,6 +62,7 @@ function model.getCurrentNeighbors(RFinfo)
   local info={}
   local links=model.getOLSRLinks()
   for k,v in pairs(links) do
+    local host
     local remip=v['remoteIP']
     local remhost=nslookup(remip)
     info[remip]={}

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -70,10 +70,10 @@ function model.getCurrentNeighbors(RFinfo)
     info[remip]['linkQuality']=v['linkQuality']
     info[remip]['neighborLinkQuality']=v['neighborLinkQuality']
 	  if remhost ~= nil then
-    	remhost = string.gsub(remhost,"^mid%d+.", "")
-      remhost = string.gsub(remhost,"^dtdlink%.", "")
-      remhost = string.gsub(remhost,".local.mesh$","")
-    	info[remip]['hostname']=remhost
+    	host = string.gsub(remhost,"^mid%d+.", "")
+      host = string.gsub(remhost,"^dtdlink%.", "")
+      host = string.gsub(remhost,".local.mesh$","")
+    	info[remip]['hostname']=host
 	  else
 		  info[remip]['hostname']=remip
 	  end
@@ -90,7 +90,7 @@ function model.getCurrentNeighbors(RFinfo)
 		  	local mac=string.match(mac_host, "^(.-)\-")
 			  mac=mac:upper()
 			  local node=string.match(mac_host, "\-(.*)")
-			  if host == node or remip == node then
+			  if remhost == node or remip == node then
 				  for stn in pairs(RFneighbors) do
 					  stnInfo=iwinfo['nl80211'].assoclist(wlan)[mac]
 					  if stnInfo ~= nil then


### PR DESCRIPTION
Remove hostname case manipulation from **info.lua** & **olsr.lua** to leave hostname as natural mixed case.  Verify that string.gsub and string.match lines still work as planned to remove _dtdlink_ & _midxx_ prefixes as well as _.local.mesh_ suffixes.