### PR TITLE
api: add RF IP for non-RF links

### DIFF
--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -327,8 +327,8 @@ function model.all_hosts()
 				local ip, name=string.match(data,"^([%x%.%:]+)%s+(%S.*)\t%s*$")
 				if ip and name then
 					if not string.match(name,"^(dtdlink[.]).*") then
-						if not string.match(name,"^(mid[0-9][.]).*") then
-							host['name']=name:upper()
+						if not string.match(name,"^(mid%d+[.]).*") then
+							host['name']=name
 							host['ip']=ip
 							table.insert(hosts,host)
 						end
@@ -517,7 +517,7 @@ function model.getLocalCnxType(hostname)
 		return "Loopback"
 	elseif string.match(hostname,"dtdlink") then
 		return "DTD"
-	elseif hostname == string.lower( model.getNodeName() ) then
+	elseif hostname:lower() == string.lower( model.getNodeName() ) then
 		return "RF"
 	else
 		return "LAN"
@@ -531,9 +531,7 @@ function model.getLocalHosts()
 	local hosts, line
 	if nixio.fs.access("/etc/hosts") then
 		for line in io.lines("/etc/hosts") do
-			line = line:lower()
-			-- line is not a comment
-			local data = line:match("^([^#;]+)[#;]*(.*)$")
+			local data = line:match("^([^#;]+)[#;]*(.*)$")  -- line is not a comment
 			if data then
 				local hostname, entries
 				local ip, entries = data:match("^%s*([%[%]%x%.%:]+)%s+(%S.-%S)%s*$")
@@ -548,7 +546,7 @@ function model.getLocalHosts()
 					for hostname in entries:gmatch("%S+") do
 						hostname = string.gsub(hostname,".local.mesh$","")
 						entry["cnxtype"] = model.getLocalCnxType(hostname)
-						entry["hostnames"][index] = hostname:upper()
+						entry["hostnames"][index] = hostname
 						index = index + 1
 					end
 					hosts = hosts or { }

--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -123,17 +123,17 @@ end
 
 function getRemoteNodes()
 	local info={}
-	
+
 	local mynode = aredn_info.getNodeName()
 	local allhosts = aredn_info.all_hosts()
 	local cn = aredn_olsr.getCurrentNeighbors()
 	local routes = aredn_olsr.getOLSRRoutes()
 	for k, v in pairs(allhosts) do
-		local node={}	
+		local node={}
 		-- skip currentneighbors, myself, and MID*. entries
 		for cnk, cnv in pairs(cn) do
-			if not (cnk == allhosts[k].ip or allhosts[k].name == mynode or (allhosts[k].name:match("^MID%d+%.") ~= nil)) then
-				node=allhosts[k]	
+			if not (cnk == allhosts[k].ip or allhosts[k].name == mynode or (allhosts[k].name:match("^mid%d+%.") ~= nil)) then
+				node=allhosts[k]
 			end
 		end
 


### PR DESCRIPTION
Add the RF IP address for non-RF linked devices. This allows the services to be displayed for non-RF Current Neighbors.