### PR TITLE
Link info changes

### DIFF
--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -71,6 +71,7 @@ function model.getCurrentNeighbors(RFinfo)
     local host
     local remip=v['remoteIP']
     local remhost=nslookup(remip)
+    remip=iplookup(remhost)
     info[remip]={}
     info[remip]['olsrInterface']=v['olsrInterface']
     info[remip]['linkType']= model.getOLSRInterfaceType(v['olsrInterface'])    -- RF or DTD or TUN

--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -259,12 +259,11 @@ end
 
 function iplookup(host)
 	local ip=nil
-	local shortname=nil
 	local nso=nil
 	if host:find("dtd.*%.") or host:find("mid%d%.") then
 		shortname=host:match("%.(.*)")
 	end
-	nso=capture("nslookup "..shortname)
+	nso=capture("nslookup "..host)
 	ip=nso:match("Address 1: (.*)%c")
 	return ip
 end

--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -261,7 +261,7 @@ function iplookup(host)
 	local ip=nil
 	local shortname=nil
 	local nso=nil
-	if host:find("%.") then
+	if host:find("dtd.*%.") or host:find("mid%d%.") then
 		shortname=host:match("%.(.*)")
 	end
 	nso=capture("nslookup "..shortname)

--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -257,6 +257,18 @@ function nslookup(ip)
         end
 end
 
+function iplookup(host)
+	local ip=nil
+	local shortname=nil
+	local nso=nil
+	if host:find("%.") then
+		shortname=host:match("%.(.*)")
+	end
+	nso=capture("nslookup "..shortname)
+	ip=nso:match("Address 1: (.*)%c")
+	return ip
+end
+
 -------------------------------------
 -- Returns traceroute
 -------------------------------------


### PR DESCRIPTION
changes the sysinfo_json?link_info=1 information to use the actual mesh IP of the DTD and Tunnel linked nodes rather than the internal routing IP's used before.