### PR TITLE
aredn: changes for sysinfo.json link_info from info.lua

### DIFF
--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -71,13 +71,15 @@ function model.getCurrentNeighbors(RFinfo)
     local host
     local linkip=v['remoteIP']
 
+    local linkhost=nslookup(linkip) -- TOTO: stop using nslookup? use /var/run/olsr_hosts
+    linkip=iplookup(linkhost)
+
     info[linkip]={}
     info[linkip]['olsrInterface']=v['olsrInterface']
     info[linkip]['linkType']= model.getOLSRInterfaceType(v['olsrInterface'])  -- RF or DTD or TUN
     info[linkip]['linkQuality']=v['linkQuality']
     info[linkip]['neighborLinkQuality']=v['neighborLinkQuality']
 
-    local linkhost=nslookup(linkip) -- TOTO: stop using nslookup? use /var/run/olsr_hosts
     if linkhost~=nil then
       host = string.gsub(linkhost,"mid%d+.", "")
       host = string.gsub(host,"dtdlink%.", "")

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -66,63 +66,73 @@ end
 function model.getCurrentNeighbors(RFinfo)
   local RFinfo = RFinfo or false
   local info={}
-  local links=model.getOLSRLinks()  -- Get info for all current neighbors
+  local links=model.getOLSRLinks() -- Get info for all current neighbors
   for k,v in pairs(links) do
-    local host
-    local linkip=v['remoteIP']
+    local host=nslookup(v['remoteIP'])
+    local mainip=iplookup(host)
+    info[mainip]={}
 
-    local linkhost=nslookup(linkip) -- TOTO: stop using nslookup? use /var/run/olsr_hosts
-    linkip=iplookup(linkhost)
-
-    info[linkip]={}
-    info[linkip]['olsrInterface']=v['olsrInterface']
-    info[linkip]['linkType']= model.getOLSRInterfaceType(v['olsrInterface'])  -- RF or DTD or TUN
-    info[linkip]['linkQuality']=v['linkQuality']
-    info[linkip]['neighborLinkQuality']=v['neighborLinkQuality']
-
-    if linkhost~=nil then
-      host = string.gsub(linkhost,"mid%d+.", "")
+    if host~=nil then
+      host = string.gsub(host,"mid%d+.", "")
       host = string.gsub(host,"dtdlink%.", "")
       host = string.gsub(host,".local.mesh$","")
-      info[linkip]['hostname']=host
+      info[mainip]['hostname']=host
     else
-      info[linkip]['hostname']=linkip
+      info[mainip]['hostname']=mainip
     end
 
-    if info[linkip]['linkType'] == "RF" and RFinfo then  -- get additional info for RF link
-      require("iwinfo")
-      info[linkip]["rfip"] = linkip
+    info[mainip]['olsrInterface']=v['olsrInterface']
+    info[mainip]['linkType']= model.getOLSRInterfaceType(v['olsrInterface'])    -- RF or DTD or TUN
+    info[mainip]['linkQuality']=v['linkQuality']
+    info[mainip]['neighborLinkQuality']=v['neighborLinkQuality']
+
+    -- additional info about each link
+    info[mainip]['validityTime']=v['validityTime']
+    info[mainip]['symmetryTime']=v['symmetryTime']
+    info[mainip]['asymmetryTime']=v['asymmetryTime']
+    info[mainip]['vtime']=v['vtime']
+    info[mainip]['currentLinkStatus']=v['currentLinkStatus']
+    info[mainip]['previousLinkStatus']=v['previousLinkStatus']
+    info[mainip]['hysteresis']=v['hysteresis']
+    info[mainip]['pending']=v['pending']
+    info[mainip]['lostLinkTime']=v['lostLinkTime']
+    info[mainip]['helloTime']=v['helloTime']
+    info[mainip]['lastHelloTime']=v['lastHelloTime']
+    info[mainip]['seqnoValid']=v['seqnoValid']
+    info[mainip]['seqno']=v['seqno']
+    info[mainip]['lossHelloInterval']=v['lossHelloInterval']
+    info[mainip]['lossTime']=v['lossTime']
+    info[mainip]['lossMultiplier']=v['lossMultiplier']
+    info[mainip]['linkCost']=v['linkCost']
+
+    
+    if info[mainip]['linkType'] == "RF" and RFinfo then
+      -- get additional info for RF link
+		  require("iwinfo")
+
       local radio = ai.getMeshRadioDevice()
       local bandwidth = tonumber(ai.getChannelBW(radio))
-      local wlan=get_ifname('wifi')
-      local RFneighbors=iwinfo['nl80211'].assoclist(wlan)
-      local mac2node=mac2host()
-      for i, mac_host in pairs(mac2node) do
-        local mac=string.match(mac_host, "^(.-)\-")
-        mac=mac:upper()
-        local node=string.match(mac_host, "\-(.*)")  -- add error checking here?
-        if node == "" then node=linkhost end
-        if linkhost == node or linkip == node then
-          for stn in pairs(RFneighbors) do
-            stnInfo=iwinfo['nl80211'].assoclist(wlan)[mac]
-            if stnInfo ~= nil then
-              info[linkip]["signal"]=tonumber(stnInfo.signal)
-              info[linkip]["noise"]=tonumber(stnInfo.noise)
-              info[linkip]["tx_rate"]=adjust_rate(stnInfo.tx_rate/1000,bandwidth)
-              info[linkip]["rx_rate"]=adjust_rate(stnInfo.rx_rate/1000,bandwidth)
-              info[linkip]["expected_throughput"]=adjust_rate(stnInfo.expected_throughput/1000,bandwidth)
-            end
-          end
-        end
-      end
-    else  -- Get RF IP for non-RF nodes to display services keyed to RF IP
-      local allhosts=ai.all_hosts()
-      for k,v in pairs(allhosts) do
-        if linkhost == v['name'] or host == v['name'] then
-          info[linkip]["rfip"]=v['ip']
-        end
-      end
-    end
+		  local wlan=get_ifname('wifi')
+		  local RFneighbors=iwinfo['nl80211'].assoclist(wlan)
+		  local mac2node=mac2host()
+		  for i, mac_host in pairs(mac2node) do
+		  	local mac=string.match(mac_host, "^(.-)\-")
+			  mac=mac:upper()
+			  local node=string.match(mac_host, "\-(.*)")
+			  if host == node or mainip == node then
+				  for stn in pairs(RFneighbors) do
+					  stnInfo=iwinfo['nl80211'].assoclist(wlan)[mac]
+					  if stnInfo ~= nil then
+						  info[mainip]["signal"]=tonumber(stnInfo.signal)
+						  info[mainip]["noise"]=tonumber(stnInfo.noise)
+						  info[mainip]["tx_rate"]=adjust_rate(stnInfo.tx_rate/1000,bandwidth)
+						  info[mainip]["rx_rate"]=adjust_rate(stnInfo.rx_rate/1000,bandwidth)
+              					  info[mainip]["expected_throughput"]=adjust_rate(stnInfo.expected_throughput/1000,bandwidth)
+					  end
+				  end
+			  end
+		  end
+	  end
   end
   return info
 end

--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -258,6 +258,20 @@ function nslookup(ip)
 end
 
 -------------------------------------
+-- Returns first IP of given host
+-------------------------------------
+function iplookup(host)
+	local ip=nil
+	local nso=nil
+	if host:find("dtd.*%.") or host:find("mid%d%.") then
+		shortname=host:match("%.(.*)")
+	end
+	nso=capture("nslookup "..host)
+	ip=nso:match("Address 1: (.*)%c")
+	return ip
+end
+
+-------------------------------------
 -- Returns traceroute
 -------------------------------------
 function getTraceroute(target)

--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -264,7 +264,7 @@ function iplookup(host)
 	local ip=nil
 	local nso=nil
 	if host:find("dtd.*%.") or host:find("mid%d%.") then
-		shortname=host:match("%.(.*)")
+		host=host:match("%.(.*)")
 	end
 	nso=capture("nslookup "..host)
 	ip=nso:match("Address 1: (.*)%c")


### PR DESCRIPTION
changes the sysinfo_json?link_info=1 information to use the actual mesh IP of the DTD and Tunnel linked nodes rather than the internal routing IP's used before.
More consistant with topology output about linked nodes.