### PR TITLE
api: show version in info table

### DIFF
--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -52,6 +52,7 @@ os.capture = capture
 
 function getSysinfo()
 	local info={}
+	info['api_version']=API_VERSION
 	info['node']=aredn_info.getNodeName()
 	info['description']=aredn_info.getNodeDescription()
 	info['firmware_version']=aredn_info.getFirmwareVersion()


### PR DESCRIPTION
Include the api_version in the info table so it can be displayed in System card on newui.