### PR TITLE
openwrt: bump version to 19.07.08 to address security fixes

### DIFF
--- a/openwrt.mk
+++ b/openwrt.mk
@@ -2,5 +2,5 @@
 OPENWRT_SRC=https://github.com/openwrt/openwrt.git
 
 # what branch, tag or commit in this repo?
-OPENWRT_COMMIT=v19.07.7
+OPENWRT_COMMIT=v19.07.8
 


### PR DESCRIPTION
Security fixes
Fix FragAttacks (fragmentation and aggregation attacks) vulnerabilities in cfg80211, mac80211, ath10k and ath10k-ct
We are not sure if some closed source firmware files are still affected by these problems.
Security Advisory 2021-08-01-1 - XSS via missing input validation of host names displayed (CVE-2021-32019)
Security Advisory 2021-08-01-2 - Stored XSS in hostname UCI variable (CVE-2021-33425)
Security Advisory 2021-08-01-3 - luci-app-ddns: Multiple authenticated RCEs (CVE-2021-28961)
Various security fixes in packages