### PR TITLE
Use develop branch for packages

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,1 +1,1 @@
-src-git arednpackages git://github.com/aredn/aredn_packages;3.21.4.0
+src-git arednpackages git://github.com/aredn/aredn_packages;develop


### PR DESCRIPTION
Switch to using develop branch of aredn_packages so we can include new fixes.