### PR TITLE
aredn: Fix validateFirmwareFilename() on admin page

### DIFF
--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -630,12 +630,13 @@ print <<EOF;
         var searchstring = "";
         var efn = "";
         if(hwmfg != "cpe"){
-            if ($mfgprefix == "wbs") {
+            if (hwmfg == "wbs") {
                 searchstring= ".*wbs" + hwtype + "-sysupgrade.bin$\";
-                efn = "aredn-$fw_version-$mfgprefix${hardwaretypev}-sysupgrade.$
+                efn = "aredn-$fw_version-$mfgprefix${hardwaretypev}-sysupgrade.bin";
             } else {
                 searchstring= ".*-" + hwtype + "-sysupgrade.bin$\";
                 efn = "aredn-$fw_version-$mfgprefix-${hardwaretypev}-sysupgrade.bin";
+            }
         } else {
             searchstring= ".*cpe" + hwtype + "-sysupgrade.bin$\";
             efn = "aredn-$fw_version-$mfgprefix${hardwaretypev}-sysupgrade.bin";


### PR DESCRIPTION
Using the current main build (304540d) on FF 93.0, the page /cgi-bin/admin throws a syntax error in validateFirmwareFilename()
![image](https://user-images.githubusercontent.com/873295/138520365-f0722b9f-b0b7-4b37-9b6f-8facb794d12a.png)
This syntax error prevents the validation of the firmware filename, and hence the reflashing of the firmware on a ubnt loco-m-xw.

With the change below I can successfully reflash from this page the firmware on a ubnt loco-m-xw.
I have also changed '$mfgprefix' to use the 'hwmfg' JS variable which is set to '$mfgprefix' 5 lines up. I believe this improves the readability in the client-side JS.

Cheers,
Phil M0DNY