### PR TITLE
aredn: Load leaflet assets asynchronously on setup page.

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -543,24 +543,91 @@ my ($rc, $maptiles, $leafletcss, $leafletjs);
 
 http_header() unless $debug == 2;
 html_header(nvram_get("node") . " setup", 0);
-if(($pingOk) || ($leafletcss =~ ".local.mesh")) {
-  print "<link rel='stylesheet' href='${leafletcss}' />\n";
-}
-if(($pingOk) || ($leafletjs =~ ".local.mesh")) {
-  print "<script src='${leafletjs}'></script>\n";
-}
-print "</head>";
-print "<body><center>\n";
 
-print "
+print <<EOF;
 <script>
+
+function loadCSS(url, callback) {
+   var head = document.getElementsByTagName('head')[0];
+   var stylesheet = document.createElement('link');
+   stylesheet.rel = 'stylesheet';
+   stylesheet.type = 'text/css';
+   stylesheet.href = url;
+   stylesheet.onload = callback;
+
+   head.appendChild(stylesheet);
+}  
+
+function loadScript(url, callback) {
+   var head = document.getElementsByTagName('head')[0];
+   var script = document.createElement('script');
+   script.type = 'text/javascript';
+   script.src = url;
+   script.onload = callback;
+
+   head.appendChild(script);
+}
+
+var map;
+var marker;
+
+var leafletLoad = function() {
+    map = L.map('map').setView([0.0, 0.0], 1);
+    var dotIcon = L.icon({iconUrl: '/dot.png'});
+EOF
+print "L.tileLayer('$maptiles',";
+print <<EOF;
+    {
+        maxZoom: 18,
+        attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+            '<a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>, ' +
+            'Imagery &copy;<a href="http://stamen.com">Stamen Design</a>',
+        id: 'mapbox.streets'
+    }).addTo(map);
+EOF
+
+if($lat and $lon)
+{
+    print "marker= new L.marker([$lat,$lon],{draggable: true, icon: dotIcon});";
+    print "map.addLayer(marker);";
+    print "map.setView([$lat,$lon],13);";
+    print "marker.on('drag', onMarkerDrag);";
+} else {
+    print "map.on('click', onMapClick);";
+}
+
+print <<EOF;
+}
+
+function onMapClick(e) {
+    marker= new L.marker(e.latlng.wrap(),{draggable: true, icon: dotIcon});
+    map.addLayer(marker);
+    document.getElementsByName('latitude')[0].value=e.latlng.wrap().lat.toFixed(6).toString();
+    document.getElementsByName('longitude')[0].value=e.latlng.wrap().lng.toFixed(6).toString();
+    map.off('click', onMapClick);
+    marker.on('drag', onMarkerDrag);
+}
+
+function onMarkerDrag(e) {
+    var m = e.target;
+    var p = m.getLatLng().wrap();
+    document.getElementsByName('latitude')[0].value=p.lat.toFixed(6).toString();
+    document.getElementsByName('longitude')[0].value=p.lng.toFixed(6).toString();
+}
+
+EOF
+
+# On page load, attempt loading of Leaflet CSS, then Leaflet JS if that works, and finally initialise the map if both have worked.
+if(($pingOk) || ($leafletcss =~ ".local.mesh" && $leafletjs =~ ".local.mesh")) {
+    print "window.onload = function (event) { loadCSS('${leafletcss}',function () { loadScript('${leafletjs}', leafletLoad); }); };";
+}
+print <<EOF;
 
 function findLocation() {
     navigator.geolocation.getCurrentPosition(foundLocation, noLocation);
 }
 
-function foundLocation(position)
-{
+function foundLocation(position) {
     var jlat = position.coords.latitude;
     var jlon = position.coords.longitude;
     // update the fields
@@ -575,10 +642,10 @@ function foundLocation(position)
     }
 }
 
-function noLocation()
-{
+function noLocation() {
     alert('Could not find location.  Try pinning it on the map.');
 }
+
 function updDist(x) {
     var dvs= calcDistance(x);
     var xcm=dvs['miles'];
@@ -596,7 +663,6 @@ function updDist(x) {
     distBox.className = 'dist-norm';
 }
 
-
 function calcDistance(x) {
     // x is in KILOMETERS
     var dvs = new Object();
@@ -604,9 +670,15 @@ function calcDistance(x) {
     dvs['meters']=Math.ceil(x*1000);
     dvs['kilometers']=x;
     return dvs;
-}";
+}
 
-print "
+function doSubmit() {
+    var desc_text = document.mainForm.description_node.value;
+    var singleLine = desc_text.replace(new RegExp( "\\n", "g" ), " ");
+    document.mainForm.description_node.value = singleLine;
+    return true;
+}
+
 function toggleMap(toggleButton) {
     var mapdiv=document.getElementById('map');
     if(toggleButton.value=='hide') {
@@ -621,11 +693,15 @@ function toggleMap(toggleButton) {
         toggleButton.innerHTML='Hide Map';
     }
     // force the map to redraw
-    map.invalidateSize();
+    if(typeof map !== 'undefined') map.invalidateSize();
     return false;
-}";
+}
 
-print "</script>";
+</script>
+EOF
+
+print "</head>";
+print "<body><center>\n";
 
 alert_banner();
 print "<form onSubmit='doSubmit();' name='mainForm' method=post action=/cgi-bin/setup enctype='multipart/form-data'>\n" unless $debug == 2;
@@ -1227,60 +1303,5 @@ show_parse_errors();
 
 page_footer();
 
-print <<EOF;
-<script>
-
-function doSubmit() {
-        var desc_text = document.mainForm.description_node.value;
-        var singleLine = desc_text.replace(new RegExp( "\\n", "g" ), " ");
-        document.mainForm.description_node.value = singleLine;
-        return true;
-}
-
-var map = L.map('map').setView([0.0, 0.0], 1);
-var dotIcon = L.icon({iconUrl: '/dot.png'});
-EOF
-print "L.tileLayer('$maptiles',";
-print <<EOF;
-    {
-            maxZoom: 18,
-            attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-                '<a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>, ' +
-                'Imagery &copy;<a href="http://stamen.com">Stamen Design</a>',
-            id: 'mapbox.streets'
-    }).addTo(map);
-
-var marker;
-
-function onMapClick(e) {
-    marker= new L.marker(e.latlng.wrap(),{draggable: true, icon: dotIcon});
-    map.addLayer(marker);
-    document.getElementsByName('latitude')[0].value=e.latlng.wrap().lat.toFixed(6).toString();
-    document.getElementsByName('longitude')[0].value=e.latlng.wrap().lng.toFixed(6).toString();
-    map.off('click', onMapClick);
-    marker.on('drag', onMarkerDrag);
-}
-EOF
-
-    if($lat and $lon)
-    {
-        print "marker= new L.marker([$lat,$lon],{draggable: true, icon: dotIcon});";
-        print "map.addLayer(marker);";
-        print "map.setView([$lat,$lon],13);";
-        print "marker.on('drag', onMarkerDrag);";
-    } else {
-        print "map.on('click', onMapClick);";
-    }
-
-    print <<EOF;
-    function onMarkerDrag(e) {
-        var m = e.target;
-        var p = m.getLatLng().wrap();
-        document.getElementsByName('latitude')[0].value=p.lat.toFixed(6).toString();
-        document.getElementsByName('longitude')[0].value=p.lng.toFixed(6).toString();
-    }
-    </script>
-EOF
-#}
 print "</body>\n";
 print "</html>\n";


### PR DESCRIPTION
Issue: When accessing an internet-connected node's setup page from behind a non-internet-connected node, the /cgi-bin/setup page fails to load as the leaflet CSS & JS are enabled, the ping check works, but the assets are not accessible from the client, and so block the client's page load.

This proposed change keeps the same server-side perl logic to enable the leaflet request, but then adds the stylesheet and script dynamically in the client javascript, meaning that the page loads and fully functions (other than the map) even if the assets are unreachable (such as in the case described above.)
Tested successfully in FF 93, Chromium 91, IE 11, Edge 95.

This may open up the possibility of allowing the client page to always try loading the Leaflet assets even if the server-side ping check fails, but I've not made that change here.