### PR TITLE
Meshoween: Mesh status page optimizations

### DIFF
--- a/files/etc/config.mesh/aredn
+++ b/files/etc/config.mesh/aredn
@@ -11,3 +11,5 @@ config map
         option leafletjs 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js'
         option leafletcss 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css'
         option maptiles 'http://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg'
+
+config meshstatus

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -163,6 +163,18 @@ push @setting, {
   postcallback => "adjustTunnelInterfaceCount()"
 };
 push @setting, {
+  key => "aredn.\@meshstatus[0].lowmem",
+  type => "string",
+  desc => "Specifies the low memory threshold (in KB) when we will truncate the mesh status page",
+  default => "10000"
+};
+push @setting, {
+  key => "aredn.\@meshstatus[0].lowroutes",
+  type => "string",
+  desc => "When low memory is detected, limit the number of routes shown on the mesh status page",
+  default => "1000"
+};
+push @setting, {
   key => "aredn.olsr.restart",
   type => "none",
   desc => "Will restart OLSR when saving setting -- wait up to 2 or 3 minutes to receive response.",

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -156,7 +156,7 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
     $links{$ip} = {
         lq => $lq,
         nlq => $nlq,
-        mbps => "0.0"
+        mbps => ""
     };
     $neighbor{$ip} = 1;
 
@@ -184,10 +184,7 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
                 $mbps = $1*$3/100;
             }
         }
-        if ($mbps)
-        {
-            $links{$ip}{mbps} = sprintf "%.1f",$mbps / $chanbw;
-        }
+        $links{$ip}{mbps} = $mbps ? sprintf "%.1f", $mbps / $chanbw : "0.0";
     }
 }
 foreach(`echo /hna | nc 127.0.0.1 2006 2>>$tmperr`)

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -123,13 +123,15 @@ system "touch /tmp/web/automesh" if $parms{auto};
 system "rm -f /tmp/web/automesh" if $parms{stop};
 
 #get location info if available
+open my $rcgood, '<', '/etc/latlon';
+if ($rcgood)
+{
+    $lat_lon = "<center><strong>Location: </strong> " . <$rcgood> . <$rcgood> . "</center>";
+    close $rcgood;
+}
+else
+{
 $lat_lon = "<strong>Location Not Available</strong>";
-if(-f "/etc/latlon") {
-    my $rcgood=open(FILE, "/etc/latlon");
-    if($rcgood) {
-        while(<FILE>){
-            chomp;
-            push @lat_lon,$_;
         }
     }
     close(FILE);

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -85,8 +85,8 @@ use perlfunc;
 
 # Limit displayed nodes and services to the most reachable routes if memory on the node is small
 %lowMemoryLimits = (
-        memory => 10000,
-        routes => 1000,
+        memory => `/sbin/uci -q get aredn.\@meshstatus[0].lowmem` || 10000,
+        routes => `/sbin/uci -q get aredn.\@meshstatus[0].lowroutes` || 1000,
 );
 
 sub get_available_mem

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -158,7 +158,10 @@ if ($olsrTotal > $lowMemoryLimits{routes} and get_available_mem() < $lowMemoryLi
       delete $routes{$_};
     }
 }
-@arps = `grep ${wifiif} /proc/net/arp | grep -v "00:00:00:00:00:00"`;
+@arps = {};
+open my $fh, '<', '/proc/net/arp';
+foreach (<$fh>) { push @arps, $_ if (/$wifiif/ and !/00:00:00:00:00:00/) }
+close $fh;
 foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
 {
     next if /^\D/;
@@ -174,30 +177,33 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
     $mac =~ s/^.*(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w).*$/$1/;
     chomp $mac;
 
-    my @csv = `cat /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv 2>/dev/null`;
-    if ( $mac and @csv )
+    open my $fh, '<', "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac/rc_stats_csv";
+    if ( $mac and $fh )
     {
-	#802.11b/n
+        my @csv = <$fh>;
+        close $fh;
+    #802.11b/n
     my ($mbps) = grep /^([^,]*,){3}A/, @csv;
-	if ($mbps)
-	{
-		my ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
-		$rate =~ s/[ \t]//g;
-		$mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
-	}
-	else
-	{
-		#802.11a/b/g
+    if ($mbps)
+    {
+        my ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
+        $rate =~ s/[ \t]//g;
+        $mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
+    }
+    else
+    {
+        #802.11a/b/g
         ($mbps) = grep /^A/, @csv;
-		if ($mbps)
-		{
-		$mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
-		$mbps = $1*$3/100;
-		}
-	}
+        if ($mbps)
+        {
+        $mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
+        $mbps = $1*$3/100;
+        }
+    }
         $links{$ip}{mbps} = $mbps ? sprintf "%.1f", $mbps / $chanbw : "0.0";
     }
 }
+undef @arps;
 foreach(`echo /hna | nc 127.0.0.1 2006 2>>$tmperr`)
 {
     next if /^\D/;
@@ -223,7 +229,9 @@ $txtinfo_err = $parts[4];
 unlink $tmperr;
 
 # load the local hosts file
-foreach(`cat /etc/hosts`)
+
+open my $fh, '<', '/etc/hosts';
+foreach (<$fh>)
 {
     next unless /^10[.]/;
     chomp;
@@ -240,9 +248,11 @@ foreach(`cat /etc/hosts`)
     if($tactical eq "#NOPROP") { push @{$localhosts{$my_ip}{noprops}}, $name; }
     if($tactical eq "#ALIAS") { push @{$localhosts{$my_ip}{aliases}}, $name; }
 }
+close $fh;
 
 # load the olsr hosts file
-foreach(`cat /var/run/hosts_olsr 2>/dev/null`)
+open my $fh, '<', '/var/run/hosts_olsr';
+foreach (<$fh>)
 {
     next unless /^\d/;
     chomp;
@@ -283,12 +293,14 @@ foreach(`cat /var/run/hosts_olsr 2>/dev/null`)
         push @{$hosts{$originator}{hosts}}, $name;
     }
 }
+close $fh;
 
 # Discard
 undef %routes;
 
 # load the olsr services file
-foreach(`cat /var/run/services_olsr 2>/dev/null`)
+open my $fh, '<', '/var/run/services_olsr';
+foreach (<$fh>)
 {
     next unless /^\w/;
     chomp;
@@ -311,9 +323,11 @@ foreach(`cat /var/run/services_olsr 2>/dev/null`)
 
     $services{$host}{$name} = $port ? "<a href='${protocol}://${host}:${port}/${path}' target='_blank'>$name</a>" : $name;
 }
+close $fh;
 
 # load the node history
-foreach(`cat /tmp/node.history 2>/dev/null`)
+open my $fh, '<', '/tmp/node.history';
+foreach (<$fh>)
 {
     chomp;
     ($ip, $age, $host) = split / /, $_;
@@ -323,6 +337,7 @@ foreach(`cat /tmp/node.history 2>/dev/null`)
     $history{$ip}{age} = $age;
     $history{$ip}{host} = $host;
 }
+close $fh;
 
 #delete $hosts{"127.0.0.1"};
 

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -42,46 +42,46 @@ BEGIN {push @INC, '/www/cgi-bin'};
 use perlfunc;
 
 %rateL = (
-        '1.0M' => '1',   # CCP LP
-        '2.0M' => '2',   # CCP LP
-        '5.5M' => '5.5', # CCP LP
-        'MCS0' => '6.5', # HT20 LGI
-        '11.0M'=> '11',  # CCP LP
-        'MCS1' => '13',  # HT20 LGI...
-        'MCS2' => '19.5',
-        'MCS3' => '26',
-        'MCS4' => '39',
-        'MCS5' => '52',
-        'MCS6' => '58.5',
-        'MCS7' => '65',
-        'MCS8' => '13',
-        'MCS9' => '26',
-        'MCS10' => '39',
-        'MCS11' => '52',
-        'MCS12' => '78',
-        'MCS13' => '104',
-        'MCS14' => '117',
-        'MCS15' => '130',
+	'1.0M' => '1',   # CCP LP
+	'2.0M' => '2',   # CCP LP
+	'5.5M' => '5.5', # CCP LP
+	'MCS0' => '6.5', # HT20 LGI
+	'11.0M'=> '11',  # CCP LP
+	'MCS1' => '13',  # HT20 LGI...
+	'MCS2' => '19.5',
+	'MCS3' => '26',
+	'MCS4' => '39',
+	'MCS5' => '52',
+	'MCS6' => '58.5',
+	'MCS7' => '65',
+	'MCS8' => '13',
+	'MCS9' => '26',
+	'MCS10' => '39',
+	'MCS11' => '52',
+	'MCS12' => '78',
+	'MCS13' => '104',
+	'MCS14' => '117',
+	'MCS15' => '130',
 );
 
 %rateS = (
-        'MCS0' => '7.2',
-        'MCS1' => '14.4',
-        'MCS2' => '21.7',
-        'MCS3' => '28.9',
-        'MCS4' => '43.3',
-        'MCS5' => '57.8',
-        'MCS6' => '65',
-        'MCS7' => '72.2',
-        'MCS8' => '14.4',
-        'MCS9' => '28.9',
-        'MCS10' => '43.3',
-        'MCS11' => '57.8',
-        'MCS12' => '86.7',
-        'MCS13' => '115.6',
-        'MCS14' => '130',
-        'MCS15' => '144.4',
-);
+	'MCS0' => '7.2',
+	'MCS1' => '14.4',
+	'MCS2' => '21.7',
+	'MCS3' => '28.9',
+	'MCS4' => '43.3',
+	'MCS5' => '57.8',
+	'MCS6' => '65',
+	'MCS7' => '72.2',
+	'MCS8' => '14.4',
+	'MCS9' => '28.9',
+	'MCS10' => '43.3',
+	'MCS11' => '57.8',
+	'MCS12' => '86.7',
+	'MCS13' => '115.6',
+	'MCS14' => '130',
+	'MCS15' => '144.4',
+	);
 
 # Limit displayed nodes and services to the most reachable routes if memory on the node is small
 %lowMemoryLimits = (
@@ -122,7 +122,7 @@ if(-f "/etc/latlon") {
         }
     }
     close(FILE);
-        $lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
+	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
 }
 $olsrTotal = `/sbin/ip route list table 30 | wc -l`; #num hosts olsr is keeping track of
 $olsrNodes = `/sbin/ip route list table 30 | egrep "/" | wc -l`; #num *nodes* on the network (minus other hosts)
@@ -166,24 +166,24 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
 
     if ( $mac and -e "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac" )
     {
-        #802.11b/n
-        $mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
-        if ($mbps)
-        {
-            ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
-            $rate =~ s/[ \t]//g;
-            $mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
-        }
-        else
-        {
-            #802.11a/b/g
-            $mbps = `egrep \"^A" /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
-            if ($mbps)
-            {
-                $mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
-                $mbps = $1*$3/100;
-            }
-        }
+	#802.11b/n
+	$mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
+	if ($mbps)
+	{
+		($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
+		$rate =~ s/[ \t]//g;
+		$mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
+	}
+	else
+	{
+		#802.11a/b/g
+		$mbps = `egrep \"^A" /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
+		if ($mbps)
+		{
+		$mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
+		$mbps = $1*$3/100;
+		}
+	}
         $links{$ip}{mbps} = $mbps ? sprintf "%.1f", $mbps / $chanbw : "0.0";
     }
 }
@@ -221,9 +221,9 @@ foreach(`cat /etc/hosts`)
     if ( $name !~ /\./ ) { $name="${name}.local.mesh"; }
     if($ip eq $my_ip)
     {
-        $tactical = "" unless $tactical;
-        $localhosts{$ip}{tactical} = $tactical;
-        $localhosts{$ip}{name} = $name;
+	$tactical = "" unless $tactical;
+	$localhosts{$ip}{tactical} = $tactical;
+	$localhosts{$ip}{name} = $name;
     }
     else { push @{$localhosts{$my_ip}{hosts}}, $name; }
     if($tactical eq "#NOPROP") { push @{$localhosts{$my_ip}{noprops}}, $name; }
@@ -383,42 +383,41 @@ if(keys %localhosts)
 
     foreach $ip (keys %localhosts)
     {
-        $host = $localhosts{$ip}{name};
+	$host = $localhosts{$ip}{name};
         $localpart = $host =~ s/.local.mesh//r;
-        $tactical = $localhosts{$ip}{tactical} ? " / " . $localhosts{$ip}{tactical} : "";
-        $rows{$host} = sprintf "<tr><td valign=top><nobr>%s</nobr>", $localpart . $tactical;
+	$tactical = $localhosts{$ip}{tactical} ? " / " . $localhosts{$ip}{tactical} : "";
+	$rows{$host} = sprintf "<tr><td valign=top><nobr>%s</nobr>", $localpart . $tactical;
 
         if ( $wangateway{$ip} ) { $nodeiface =  "wan" ; }
-        if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
+	if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
 
-        $rows{$host} .= "</td><td colspan=3>&nbsp;</td><td>\n" ;
+	$rows{$host} .= "</td><td colspan=3>&nbsp;</td><td>\n" ;
 
-        foreach(sort keys %{$services{$host}})
-        {
-            $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
-        }
-        $rows{$host} .= "</td></tr>\n";
+	foreach(sort keys %{$services{$host}})
+	{
+	    $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
+	}
+	$rows{$host} .= "</td></tr>\n";
 
-        # add locally advertised dmz hosts
-        foreach $dmzhost (@{$localhosts{$ip}{hosts}})
-        {
+	# add locally advertised dmz hosts
+	foreach $dmzhost (@{$localhosts{$ip}{hosts}})
+	{
         #find non-propagated and aliased hosts and change color
         $nopropd = 0;
-        $aliased = 0;
+	$aliased = 0;
         if(grep { /$dmzhost/ } @{$localhosts{$ip}{noprops}}) { $nopropd = 1; }
-        if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
+	if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
         $localpart = $dmzhost =~ s/.local.mesh//r;
-            if(!$nopropd and !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-            elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top title='Aliased Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-            else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top title='Non Propagated Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-            
-            $rows{$host} .= "<td colspan=3></td><td>\n";
-            foreach(sort keys %{$services{$dmzhost}})
-            {
-                $rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
-            }
-            $rows{$host} .= "</td></tr>\n";
-        }
+	    if(!$nopropd and !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top title='Aliased Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top title='Non Propagated Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    $rows{$host} .= "<td colspan=3></td><td>\n";
+	    foreach(sort keys %{$services{$dmzhost}})
+	    {
+		$rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
+	    }
+	    $rows{$host} .= "</td></tr>\n";
+	}
     }
 
     foreach(sort keys %rows) { print $rows{$_} }
@@ -451,7 +450,7 @@ foreach $ip (keys %hosts)
     undef $nodeiface;
     if ( $dtd{$ip} )
     {
-        if ( $midcount{$ip} ) { $midcount{$ip} -= 1; } # extra mid entry matching and with dtdlink in hosts_olsrd
+	if ( $midcount{$ip} ) { $midcount{$ip} -= 1; } # extra mid entry matching and with dtdlink in hosts_olsrd
     }
     if ( $hosts{$ip}{tactical} ) { $midcount{$ip} -= 1; } # extra mid entry if tactical name defined
     if ( $midcount{$ip} )  {  $nodeiface = "tun*$midcount{$ip}" ;  }
@@ -462,7 +461,7 @@ foreach $ip (keys %hosts)
     $rows{$host} .= sprintf "</nobr></td><td></td><td align=right valign=top>%s</td><td></td><td>\n", $etx;
     foreach(sort keys %{$services{$host}})
     {
-        $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
+	$rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
     }
     $rows{$host} .= "</td></tr>\n";
 
@@ -470,13 +469,13 @@ foreach $ip (keys %hosts)
     foreach $dmzhost (@{$hosts{$ip}{hosts}})
     {
         $localpart = $dmzhost =~ s/.local.mesh//r;
-        $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
-        $rows{$host} .= "<td colspan=3></td><td>\n";
-        foreach(sort keys %{$services{$dmzhost}})
-        {
-            $rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
-        }
-        $rows{$host} .= "</td></tr>\n";
+	$rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
+	$rows{$host} .= "<td colspan=3></td><td>\n";
+	foreach(sort keys %{$services{$dmzhost}})
+	{
+	    $rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
+	}
+	$rows{$host} .= "</td></tr>\n";
     }
     $sortrows{$ip}=$host;
 }
@@ -507,45 +506,45 @@ if(keys %links)
 
     foreach $ip (keys %links)
     {
-        $ipmain = exists $ipalias{$ip} ? $ipalias{$ip} : $ip ;
-        $host = $hosts{$ipmain}{name} ? $hosts{$ipmain}{name} : $ipmain;
+	$ipmain = exists $ipalias{$ip} ? $ipalias{$ip} : $ip ;
+	$host = $hosts{$ipmain}{name} ? $hosts{$ipmain}{name} : $ipmain;
         $localpart = $host =~ s/.local.mesh//r;
-        $tactical = $hosts{$ipmain}{tactical} ? " / " . $hosts{$ipmain}{tactical} : "";
+	$tactical = $hosts{$ipmain}{tactical} ? " / " . $hosts{$ipmain}{tactical} : "";
         if ( $rows{$host} ) { $host .= " " ; } # avoid collision 2 links to same host {rf, dtd}
 
-        $no_space_host=$host;
-        $no_space_host =~ s/\s+$//;
-        $rows{$host} = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
+	$no_space_host=$host;
+	$no_space_host =~ s/\s+$//;
+	$rows{$host} = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
 
-        undef $nodeiface;
-        if ( $ipmain ne $ip ) # indicate if dtd or tunnel interface to neighbor
-        {
-            if    ( $links{$ip}{dtd} ){ $nodeiface="dtd" ; }   
-            elsif ( $links{$ip}{tun} ){ $nodeiface="tun" ; }                                                                                                                           
-            else        				  { $nodeiface="?" ; }
-        }
+	undef $nodeiface;
+	if ( $ipmain ne $ip ) # indicate if dtd or tunnel interface to neighbor
+	{
+            if    ( $links{$ip}{dtd} ){ $nodeiface="dtd" ; }
+	    elsif ( $links{$ip}{tun} ){ $nodeiface="tun" ; }
+            else { $nodeiface="?" ; }
+	}
 
-        if ( $wangateway{$ip} or $wangateway{$ipmain} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" :  "wan" ; }
+	if ( $wangateway{$ip} or $wangateway{$ipmain} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" :  "wan" ; }
         if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
 
         $rows{$host} .= sprintf ("</nobr></td><td></td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%s</td><td></td><td>\n", 100*$links{$ip}{lq}, 100*$links{$ip}{nlq},$links{$ip}{mbps});
 
-        if ( ! exists $neighservices{$host} )
-            {
-            foreach(sort keys %{$services{$host}}) { $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n" }
+	if ( ! exists $neighservices{$host} )
+	    {
+	    foreach(sort keys %{$services{$host}}) { $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n" }
 
-            $rows{$host} .= "</td></tr>\n";
+	    $rows{$host} .= "</td></tr>\n";
 
-            # add advertised dmz hosts
-            foreach $dmzhost (@{$hosts{$ipmain}{hosts}})
-            {
+	    # add advertised dmz hosts
+	    foreach $dmzhost (@{$hosts{$ipmain}{hosts}})
+	    {
                 $localpart = $dmzhost =~ s/.local.mesh//r;
-                $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td><td colspan=5></td><td>\n";
-                foreach(sort keys %{$services{$dmzhost}}) { $rows{$host} .= $services{$dmzhost}{$_} . "<br>\n" }
-                $rows{$host} .= "</td></tr>\n";
-            }
-            $neighservices{$host}=1;
-        }
+	        $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td><td colspan=5></td><td>\n";
+	        foreach(sort keys %{$services{$dmzhost}}) { $rows{$host} .= $services{$dmzhost}{$_} . "<br>\n" }
+	        $rows{$host} .= "</td></tr>\n";
+	    }
+	    $neighservices{$host}=1;
+	}
     }
 
     foreach(sort keys %rows) { print $rows{$_} }
@@ -578,13 +577,13 @@ foreach $ip (keys %history)
     $rows{$age} .= "</td><td valign=top><nobr>";
     if($age < 3600)
     {
-        $val = int($age/60);
-        $rows{$age} .= $val == 1 ? "1 minute ago" : "$val minutes ago";
+	$val = int($age/60);
+	$rows{$age} .= $val == 1 ? "1 minute ago" : "$val minutes ago";
     }
     else
     {
-        $val = sprintf "%.1f", $age/3660;
-        $rows{$age} .= $val eq "1.0" ? "1 hour ago" : "$val hours ago";
+	$val = sprintf "%.1f", $age/3660;
+	$rows{$age} .= $val eq "1.0" ? "1 hour ago" : "$val hours ago";
     }
     $rows{$age} .= "</nobr></td></tr>\n";
 }
@@ -615,26 +614,26 @@ if($debug)
     print "localhosts\n";
     foreach $ip (sort keys %localhosts)
     {
-        printf "%s %s", $ip, $localhosts{$ip}{name};
-        printf "/%s", $localhosts{$ip}{tactical} if $localhosts{$ip}{tactical};
-        foreach(@{$localhosts{$ip}{hosts}}) { print ":$_" }
-        print "\n";
+	printf "%s %s", $ip, $localhosts{$ip}{name};
+	printf "/%s", $localhosts{$ip}{tactical} if $localhosts{$ip}{tactical};
+	foreach(@{$localhosts{$ip}{hosts}}) { print ":$_" }
+	print "\n";
     }
 
     print "\nhosts\n";
     foreach $ip (sort keys %hosts)
     {
-        $hosts{$ip}{name} = "" unless $hosts{$ip}{name};
-        printf "%s %s", $ip, $hosts{$ip}{name};
-        printf "/%s", $hosts{$ip}{tactical} if $hosts{$ip}{tactical};
-        foreach(@{$hosts{$ip}{hosts}}) { print ":$_" }
-        printf(" %d", $hosts{$ip}{mid}) if $hosts{$ip}{mid};
+	$hosts{$ip}{name} = "" unless $hosts{$ip}{name};
+	printf "%s %s", $ip, $hosts{$ip}{name};
+	printf "/%s", $hosts{$ip}{tactical} if $hosts{$ip}{tactical};
+	foreach(@{$hosts{$ip}{hosts}}) { print ":$_" }
+	printf(" %d", $hosts{$ip}{mid}) if $hosts{$ip}{mid};
     }
 
     print "\nlinks\n";
     foreach(sort keys %links)
     {
-        print "$_\n";
+	print "$_\n";
     }
 
     print "</pre>\n";

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -131,15 +131,13 @@ if ($rcgood)
 }
 else
 {
-$lat_lon = "<strong>Location Not Available</strong>";
-        }
-    }
-    close(FILE);
-	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
+    $lat_lon = "<strong>Location Not Available</strong>";
 }
-$olsrTotal = `/sbin/ip route list table 30 | wc -l`; #num hosts olsr is keeping track of
-$olsrNodes = `/sbin/ip route list table 30 | egrep "/" | wc -l`; #num *nodes* on the network (minus other hosts)
+@route30 = `/sbin/ip route list table 30`;
+$olsrTotal = scalar @route30;
+$olsrNodes = scalar grep /\//, @route30;
 $node_desc = `/sbin/uci -q get system.\@system[0].description`; #pull the node description from uci
+undef @route30;
 
 # parse the txtinfo output
 

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -42,45 +42,51 @@ BEGIN {push @INC, '/www/cgi-bin'};
 use perlfunc;
 
 %rateL = (
-	'1.0M' => '1',   # CCP LP
-	'2.0M' => '2',   # CCP LP
-	'5.5M' => '5.5', # CCP LP
-	'MCS0' => '6.5', # HT20 LGI
-	'11.0M'=> '11',  # CCP LP
-	'MCS1' => '13',  # HT20 LGI...
-	'MCS2' => '19.5',
-	'MCS3' => '26',
-	'MCS4' => '39',
-	'MCS5' => '52',
-	'MCS6' => '58.5',
-	'MCS7' => '65',
-	'MCS8' => '13',
-	'MCS9' => '26',
-	'MCS10' => '39',
-	'MCS11' => '52',
-	'MCS12' => '78',
-	'MCS13' => '104',
-	'MCS14' => '117',
-	'MCS15' => '130',
+        '1.0M' => '1',   # CCP LP
+        '2.0M' => '2',   # CCP LP
+        '5.5M' => '5.5', # CCP LP
+        'MCS0' => '6.5', # HT20 LGI
+        '11.0M'=> '11',  # CCP LP
+        'MCS1' => '13',  # HT20 LGI...
+        'MCS2' => '19.5',
+        'MCS3' => '26',
+        'MCS4' => '39',
+        'MCS5' => '52',
+        'MCS6' => '58.5',
+        'MCS7' => '65',
+        'MCS8' => '13',
+        'MCS9' => '26',
+        'MCS10' => '39',
+        'MCS11' => '52',
+        'MCS12' => '78',
+        'MCS13' => '104',
+        'MCS14' => '117',
+        'MCS15' => '130',
 );
 
 %rateS = (
-	'MCS0' => '7.2',
-	'MCS1' => '14.4',
-	'MCS2' => '21.7',
-	'MCS3' => '28.9',
-	'MCS4' => '43.3',
-	'MCS5' => '57.8',
-	'MCS6' => '65',
-	'MCS7' => '72.2',
-	'MCS8' => '14.4',
-	'MCS9' => '28.9',
-	'MCS10' => '43.3',
-	'MCS11' => '57.8',
-	'MCS12' => '86.7',
-	'MCS13' => '115.6',
-	'MCS14' => '130',
-	'MCS15' => '144.4',
+        'MCS0' => '7.2',
+        'MCS1' => '14.4',
+        'MCS2' => '21.7',
+        'MCS3' => '28.9',
+        'MCS4' => '43.3',
+        'MCS5' => '57.8',
+        'MCS6' => '65',
+        'MCS7' => '72.2',
+        'MCS8' => '14.4',
+        'MCS9' => '28.9',
+        'MCS10' => '43.3',
+        'MCS11' => '57.8',
+        'MCS12' => '86.7',
+        'MCS13' => '115.6',
+        'MCS14' => '130',
+        'MCS15' => '144.4',
+);
+
+# Limit displayed nodes and services to the most reachable routes if memory on the node is small
+%lowMemoryLimits = (
+        memory => 10000,
+        routes => 1000,
 );
 
 # collect some variables
@@ -116,7 +122,7 @@ if(-f "/etc/latlon") {
         }
     }
     close(FILE);
-	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
+        $lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
 }
 $olsrTotal = `/sbin/ip route list table 30 | wc -l`; #num hosts olsr is keeping track of
 $olsrNodes = `/sbin/ip route list table 30 | egrep "/" | wc -l`; #num *nodes* on the network (minus other hosts)
@@ -127,84 +133,79 @@ $node_desc = `/sbin/uci -q get system.\@system[0].description`; #pull the node d
 $table = "none";
 chomp($tmperr = `mktemp /tmp/web/nc.XXXXXX`);
 
-foreach(`echo /all | nc 127.0.0.1 2006 2>$tmperr`)
+foreach(`echo /rou | nc 127.0.0.1 2006 2>>$tmperr`)
 {
-    if(/^Table: (\w+)/)
+    next if /^\D/;
+    ($ip, $junk, $junk, $etx) = split /\s+/, $_;
+    ($net, $cidr) = split /\//, $ip;
+    if ( $etx <= 50 ) { $routes{$net}{etx} = $etx; }
+}
+if ($olsrTotal > $lowMemoryLimits{routes} and get_free_mem() < $lowMemoryLimits{memory})
+{
+    @oroutes = sort { $routes{$a}{etx} <=> $routes{$b}{etx} } keys %routes;
+    foreach ( @oroutes[$lowMemoryLimits{routes} .. $#oroutes] )
     {
-	$table = $1;
-	next;
+      delete $routes{$_};
     }
+    undef @oroutes;
+}
+foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
+{
+    next if /^\D/;
+    ($junk, $ip, $junk, $lq, $nlq) = split /\s+/, $_;
+    $links{$ip} = {
+        lq => $lq,
+        nlq => $nlq,
+        mbps => "0.0"
+    };
+    $neighbor{$ip} = 1;
 
-    next if /^\s*$/ or /^\D/;
+    $mac = `grep $ip /proc/net/arp | grep ${wifiif} | grep -v "00:00:00:00:00:00" | head -1`;
+    $mac =~ s/^.*(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w).*$/$1/;
+    chomp $mac;
 
-    if($table eq "Links")
+    if ( $mac and -e "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac" )
     {
-	($junk, $ip, $junk, $lq, $nlq) = split /\s+/, $_;
-	$links{$ip}{lq} = $lq;
-	$links{$ip}{nlq} = $nlq;
-
-	$mac = `grep $ip /proc/net/arp | grep ${wifiif} | grep -v "00:00:00:00:00:00" | head -1`;
-	$mac =~ s/^.*(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w).*$/$1/;
-	chomp $mac;
-
-        if (! $mac or ! -e "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac" )
-	{
-		$mbps = "";
-	}
+        #802.11b/n
+        $mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
+        if ($mbps)
+        {
+            ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
+            $rate =~ s/[ \t]//g;
+            $mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
+        }
         else
         {
-		#802.11b/n
-		$mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
-		if ($mbps)
-		{
-			($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
-			$rate =~ s/[ \t]//g;
-			$mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
-		}
-		else
-		{
-			#802.11a/b/g
-			$mbps = `egrep \"^A" /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
-			if ($mbps)
-			{
-				$mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
-				$mbps = $1*$3/100;
-			}
-			else { $mbps = "0"; }
-		}
-		if ( ! $mbps eq "" )
-                {
-			$mbps /= $chanbw;
-			$links{$ip}{mbps} = sprintf "%.1f",$mbps;
-		}
-		else {  $links{$ip}{mbps} = "0.0"; }
-	}
+            #802.11a/b/g
+            $mbps = `egrep \"^A" /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
+            if ($mbps)
+            {
+                $mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
+                $mbps = $1*$3/100;
+            }
+        }
+        if ($mbps)
+        {
+            $links{$ip}{mbps} = sprintf "%.1f",$mbps / $chanbw;
+        }
     }
-    elsif($table eq "Neighbors")
+}
+foreach(`echo /hna | nc 127.0.0.1 2006 2>>$tmperr`)
+{
+    next if /^\D/;
+    ($iproute, $ip) = split /\s+/, $_;
+    ($net, $cidr) = split /\//, $iproute;
+    if ( $net eq "0.0.0.0" ) {  $wangateway{$ip} = 1; }
+}
+foreach(`echo /mid | nc 127.0.0.1 2006 2>>$tmperr`)
+{
+    next if /^\D/;
+    ($ip, $junk) = $_ =~ /^(\S+)\s+(.*)$/;
+    foreach $aip ( split /\s+/, $junk )
     {
-    }
-    elsif($table eq "Topology")
-    {
-    }
-    elsif($table eq "HNA")
-    {
-	($iproute, $ip) = split /\s+/, $_;
-	($net, $cidr) = split /\//, $iproute;
-	if ( $net eq "0.0.0.0" ) {  $wangateway{$ip} = 1; }
-    }
-    elsif($table eq "MID")
-    {
-	($ip, $junk) = $_ =~ /^(\S+)\s+(.*)$/;
-	foreach $aip ( split /\s+/, $junk ) { $ipalias{$aip} = $ip }
-    }
-    elsif($table eq "Routes")
-    {
-	($ip, $junk, $junk, $etx) = split /\s+/, $_;
-	($net, $cidr) = split /\//, $ip;
-	$routes{$net}{cidr} = $cidr;
-	$routes{$net}{etx} = $etx;
-	$routes{$net}{value} = ip2decimal($net);
-	$routes{$net}{mask} = 0xffffffff - ((1 << (32 - $cidr)) - 1);
+        $ipalias{$aip} = $ip;
+        $neighbor{$aip} = 1;
+        if ( $links{$aip} ) { $neighbor{$ip} = 1 }
     }
 }
 
@@ -223,9 +224,9 @@ foreach(`cat /etc/hosts`)
     if ( $name !~ /\./ ) { $name="${name}.local.mesh"; }
     if($ip eq $my_ip)
     {
-	$tactical = "" unless $tactical;
-	$localhosts{$ip}{tactical} = $tactical;
-	$localhosts{$ip}{name} = $name;
+        $tactical = "" unless $tactical;
+        $localhosts{$ip}{tactical} = $tactical;
+        $localhosts{$ip}{name} = $name;
     }
     else { push @{$localhosts{$my_ip}{hosts}}, $name; }
     if($tactical eq "#NOPROP") { push @{$localhosts{$my_ip}{noprops}}, $name; }
@@ -240,38 +241,43 @@ foreach(`cat /var/run/hosts_olsr 2>/dev/null`)
     ($ip, $name, undef, $originator, undef, undef) = split /\s+/, $_;
     next unless $originator;
     next if $originator eq "myself";
+    # Filter hosts which are unreachable
+    next unless $routes{$ip} or $routes{$originator};
+
+    $etx = $routes{$ip}{etx} ? $routes{$ip}{etx} : $routes{$originator}{etx};
 
     if (( $name !~ /\./ ) || ( $name =~ /^mid\.[^\.]*$/ )) { $name="${name}.local.mesh"; }
 
     if ( $ip eq $originator )
     {
-        if($hosts{$ip}{name}) { $hosts{$ip}{tactical} = $name }
+        if ($hosts{$ip}{name})
+        {
+            $hosts{$ip}{tactical} = $name;
+        }
         else
-	    {
-		$hosts{$ip}{name} = $name;
-		if ( $routes{$ip} ) {  $hosts{$ip}{etx} = $routes{$ip}{etx} ; }
-		else { $hosts{$ip}{etx} = "99.000"; }
-	    }
-    }
-    elsif ( $name =~ /^dtdlink\..*$/ )
         {
             $hosts{$ip}{name} = $name;
-	    $dtd{$originator} = 1;
-	    if ( $routes{$ip} ) {  $hosts{$ip}{etx} = $routes{$ip}{etx} ; }
-	    else { $hosts{$ip}{etx} = "99.000"; }
+            $hosts{$ip}{etx} = $etx;
         }
-        elsif ( $name =~ /^mid\d+\..*$/  )
-            {
-	        $midcount{$originator} = $midcount{$originator} ? $midcount{$originator}+1: 1 ;
-                if (! $hosts{$ip}{name} )
-		{
-		    if ( $routes{$ip} ) {  $hosts{$ip}{etx} = $routes{$ip}{etx} ; }
-	    	    else { $hosts{$ip}{etx} = "99.000"; }
-		    $hosts{$ip}{name} = $name;
-		}
-            }
-            else  { push @{$hosts{$originator}{hosts}}, $name; }
+    }
+    elsif ( $name =~ /^dtdlink\..*$/ )
+    {
+        $dtd{$originator} = 1;
+        if ( $links{$ip} ) { $links{$ip}{dtd} = 1 }
+    }
+    elsif ( $name =~ /^mid\d+\..*$/  )
+    {
+        $midcount{$originator} = $midcount{$originator} ? $midcount{$originator}+1: 1 ;
+        if ( $links{$ip} ) { $links{$ip}{tun} = 1 }
+    }
+    else
+    {
+        push @{$hosts{$originator}{hosts}}, $name;
+    }
 }
+
+# Discard
+undef %routes;
 
 # load the olsr services file
 foreach(`cat /var/run/services_olsr 2>/dev/null`)
@@ -286,6 +292,9 @@ foreach(`cat /var/run/services_olsr 2>/dev/null`)
     $name =~ s/\s+$//;
 
     if ( $host !~ /\./ ) { $host="${host}.local.mesh"; }
+
+    # Filter services for unreachable hosts
+    next unless $hosts{$originator}{name} or $originator eq " my own service";
 
     # attempt to work around olsr never forgetting defunct services
     # assume that the first entry in the file by this name is the most recent, ignore the rest
@@ -377,42 +386,42 @@ if(keys %localhosts)
 
     foreach $ip (keys %localhosts)
     {
-	$host = $localhosts{$ip}{name};
+        $host = $localhosts{$ip}{name};
         $localpart = $host =~ s/.local.mesh//r;
-	$tactical = $localhosts{$ip}{tactical} ? " / " . $localhosts{$ip}{tactical} : "";
-	$rows{$host} = sprintf "<tr><td valign=top><nobr>%s</nobr>", $localpart . $tactical;
+        $tactical = $localhosts{$ip}{tactical} ? " / " . $localhosts{$ip}{tactical} : "";
+        $rows{$host} = sprintf "<tr><td valign=top><nobr>%s</nobr>", $localpart . $tactical;
 
         if ( $wangateway{$ip} ) { $nodeiface =  "wan" ; }
-	if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
+        if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
 
-	$rows{$host} .= "</td><td colspan=3>&nbsp;</td><td>\n" ;
+        $rows{$host} .= "</td><td colspan=3>&nbsp;</td><td>\n" ;
 
-	foreach(sort keys %{$services{$host}})
-	{
-	    $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
-	}
-	$rows{$host} .= "</td></tr>\n";
+        foreach(sort keys %{$services{$host}})
+        {
+            $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
+        }
+        $rows{$host} .= "</td></tr>\n";
 
-	# add locally advertised dmz hosts
-	foreach $dmzhost (@{$localhosts{$ip}{hosts}})
-	{
+        # add locally advertised dmz hosts
+        foreach $dmzhost (@{$localhosts{$ip}{hosts}})
+        {
         #find non-propagated and aliased hosts and change color
         $nopropd = 0;
-	$aliased = 0;
+        $aliased = 0;
         if(grep { /$dmzhost/ } @{$localhosts{$ip}{noprops}}) { $nopropd = 1; }
-	if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
+        if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
         $localpart = $dmzhost =~ s/.local.mesh//r;
-	    if(!$nopropd and !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-	    elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top title='Aliased Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-	    else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top title='Non Propagated Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-	    
-	    $rows{$host} .= "<td colspan=3></td><td>\n";
-	    foreach(sort keys %{$services{$dmzhost}})
-	    {
-		$rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
-	    }
-	    $rows{$host} .= "</td></tr>\n";
-	}
+            if(!$nopropd and !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+            elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top title='Aliased Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+            else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top title='Non Propagated Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+            
+            $rows{$host} .= "<td colspan=3></td><td>\n";
+            foreach(sort keys %{$services{$dmzhost}})
+            {
+                $rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
+            }
+            $rows{$host} .= "</td></tr>\n";
+        }
     }
 
     foreach(sort keys %rows) { print $rows{$_} }
@@ -433,29 +442,19 @@ print "<tr><td colspan=5><hr></td></tr>\n";
 %sortrows = ();
 foreach $ip (keys %hosts)
 {
-    next if $links{$ip};
-    next if $ipalias{$ip};
-
-    $isNeig=0;
-    foreach $aip (keys %ipalias)
-	{
-	    if ($ipalias{$aip} eq $ip )  { if ($links{$aip} ) { $isNeig=1; last;}  }
-	}
-    next if $isNeig;
-
+    next if $neighbor{$ip};
     $host = $hosts{$ip}{name};
+    next unless $host;
     $localpart = $host =~ s/.local.mesh//r;
     $tactical = $hosts{$ip}{tactical} ? " / " . $hosts{$ip}{tactical} : "";
     $etx = sprintf "%.2f", $hosts{$ip}{etx};
-    next if ($etx > 50 );
-    next if ($etx == 0 );
 
     $rows{$host}  = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $host, $localpart . $tactical;
 
     undef $nodeiface;
     if ( $dtd{$ip} )
     {
-	if ( $midcount{$ip} ) { $midcount{$ip} -= 1; } # extra mid entry matching and with dtdlink in hosts_olsrd
+        if ( $midcount{$ip} ) { $midcount{$ip} -= 1; } # extra mid entry matching and with dtdlink in hosts_olsrd
     }
     if ( $hosts{$ip}{tactical} ) { $midcount{$ip} -= 1; } # extra mid entry if tactical name defined
     if ( $midcount{$ip} )  {  $nodeiface = "tun*$midcount{$ip}" ;  }
@@ -466,7 +465,7 @@ foreach $ip (keys %hosts)
     $rows{$host} .= sprintf "</nobr></td><td></td><td align=right valign=top>%s</td><td></td><td>\n", $etx;
     foreach(sort keys %{$services{$host}})
     {
-	$rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
+        $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
     }
     $rows{$host} .= "</td></tr>\n";
 
@@ -474,13 +473,13 @@ foreach $ip (keys %hosts)
     foreach $dmzhost (@{$hosts{$ip}{hosts}})
     {
         $localpart = $dmzhost =~ s/.local.mesh//r;
-	$rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
-	$rows{$host} .= "<td colspan=3></td><td>\n";
-	foreach(sort keys %{$services{$dmzhost}})
-	{
-	    $rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
-	}
-	$rows{$host} .= "</td></tr>\n";
+        $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
+        $rows{$host} .= "<td colspan=3></td><td>\n";
+        foreach(sort keys %{$services{$dmzhost}})
+        {
+            $rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
+        }
+        $rows{$host} .= "</td></tr>\n";
     }
     $sortrows{$ip}=$host;
 }
@@ -508,45 +507,45 @@ if(keys %links)
 
     foreach $ip (keys %links)
     {
-	$ipmain = exists $ipalias{$ip} ? $ipalias{$ip} : $ip ;
-	$host = $hosts{$ipmain}{name} ? $hosts{$ipmain}{name} : $ipmain;
+        $ipmain = exists $ipalias{$ip} ? $ipalias{$ip} : $ip ;
+        $host = $hosts{$ipmain}{name} ? $hosts{$ipmain}{name} : $ipmain;
         $localpart = $host =~ s/.local.mesh//r;
-	$tactical = $hosts{$ipmain}{tactical} ? " / " . $hosts{$ipmain}{tactical} : "";
+        $tactical = $hosts{$ipmain}{tactical} ? " / " . $hosts{$ipmain}{tactical} : "";
         if ( $rows{$host} ) { $host .= " " ; } # avoid collision 2 links to same host {rf, dtd}
 
-	$no_space_host=$host;
-	$no_space_host =~ s/\s+$//;
-	$rows{$host} = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
+        $no_space_host=$host;
+        $no_space_host =~ s/\s+$//;
+        $rows{$host} = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
 
-	undef $nodeiface;
-	if ( $ipmain ne $ip ) # indicate if dtd or tunnel interface to neighbor
-	{
-	    if    ( $hosts{$ip}{name} =~ /^dtdlink\..*$/ ){ $nodeiface="dtd" ; }
-	    elsif ( $hosts{$ip}{name} =~ /^mid\d+\..*$/ ) { $nodeiface="tun" ; }
+        undef $nodeiface;
+        if ( $ipmain ne $ip ) # indicate if dtd or tunnel interface to neighbor
+        {
+            if    ( $links{$ip}{dtd} ){ $nodeiface="dtd" ; }   
+            elsif ( $links{$ip}{tun} ){ $nodeiface="tun" ; }                                                                                                                           
             else        				  { $nodeiface="?" ; }
-	}
+        }
 
-	if ( $wangateway{$ip} or $wangateway{$ipmain} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" :  "wan" ; }
+        if ( $wangateway{$ip} or $wangateway{$ipmain} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" :  "wan" ; }
         if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
 
         $rows{$host} .= sprintf ("</nobr></td><td></td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%s</td><td></td><td>\n", 100*$links{$ip}{lq}, 100*$links{$ip}{nlq},$links{$ip}{mbps});
 
-	if ( ! exists $neighservices{$host} )
-	    {
-	    foreach(sort keys %{$services{$host}}) { $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n" }
+        if ( ! exists $neighservices{$host} )
+            {
+            foreach(sort keys %{$services{$host}}) { $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n" }
 
-	    $rows{$host} .= "</td></tr>\n";
+            $rows{$host} .= "</td></tr>\n";
 
-	    # add advertised dmz hosts
-	    foreach $dmzhost (@{$hosts{$ipmain}{hosts}})
-	    {
+            # add advertised dmz hosts
+            foreach $dmzhost (@{$hosts{$ipmain}{hosts}})
+            {
                 $localpart = $dmzhost =~ s/.local.mesh//r;
-	        $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td><td colspan=5></td><td>\n";
-	        foreach(sort keys %{$services{$dmzhost}}) { $rows{$host} .= $services{$dmzhost}{$_} . "<br>\n" }
-	        $rows{$host} .= "</td></tr>\n";
-	    }
-	    $neighservices{$host}=1;
-	}
+                $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td><td colspan=5></td><td>\n";
+                foreach(sort keys %{$services{$dmzhost}}) { $rows{$host} .= $services{$dmzhost}{$_} . "<br>\n" }
+                $rows{$host} .= "</td></tr>\n";
+            }
+            $neighservices{$host}=1;
+        }
     }
 
     foreach(sort keys %rows) { print $rows{$_} }
@@ -578,13 +577,13 @@ foreach $ip (keys %history)
     $rows{$age} .= "</td><td valign=top><nobr>";
     if($age < 3600)
     {
-	$val = int($age/60);
-	$rows{$age} .= $val == 1 ? "1 minute ago" : "$val minutes ago";
+        $val = int($age/60);
+        $rows{$age} .= $val == 1 ? "1 minute ago" : "$val minutes ago";
     }
     else
     {
-	$val = sprintf "%.1f", $age/3660;
-	$rows{$age} .= $val eq "1.0" ? "1 hour ago" : "$val hours ago";
+        $val = sprintf "%.1f", $age/3660;
+        $rows{$age} .= $val eq "1.0" ? "1 hour ago" : "$val hours ago";
     }
     $rows{$age} .= "</nobr></td></tr>\n";
 }
@@ -615,26 +614,26 @@ if($debug)
     print "localhosts\n";
     foreach $ip (sort keys %localhosts)
     {
-	printf "%s %s", $ip, $localhosts{$ip}{name};
-	printf "/%s", $localhosts{$ip}{tactical} if $localhosts{$ip}{tactical};
-	foreach(@{$localhosts{$ip}{hosts}}) { print ":$_" }
-	print "\n";
+        printf "%s %s", $ip, $localhosts{$ip}{name};
+        printf "/%s", $localhosts{$ip}{tactical} if $localhosts{$ip}{tactical};
+        foreach(@{$localhosts{$ip}{hosts}}) { print ":$_" }
+        print "\n";
     }
 
     print "\nhosts\n";
     foreach $ip (sort keys %hosts)
     {
-	$hosts{$ip}{name} = "" unless $hosts{$ip}{name};
-	printf "%s %s", $ip, $hosts{$ip}{name};
-	printf "/%s", $hosts{$ip}{tactical} if $hosts{$ip}{tactical};
-	foreach(@{$hosts{$ip}{hosts}}) { print ":$_" }
-	printf(" %d", $hosts{$ip}{mid}) if $hosts{$ip}{mid};
+        $hosts{$ip}{name} = "" unless $hosts{$ip}{name};
+        printf "%s %s", $ip, $hosts{$ip}{name};
+        printf "/%s", $hosts{$ip}{tactical} if $hosts{$ip}{tactical};
+        foreach(@{$hosts{$ip}{hosts}}) { print ":$_" }
+        printf(" %d", $hosts{$ip}{mid}) if $hosts{$ip}{mid};
     }
 
     print "\nlinks\n";
     foreach(sort keys %links)
     {
-	print "$_\n";
+        print "$_\n";
     }
 
     print "</pre>\n";

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -158,6 +158,7 @@ if ($olsrTotal > $lowMemoryLimits{routes} and get_available_mem() < $lowMemoryLi
       delete $routes{$_};
     }
 }
+@arps = `grep ${wifiif} /proc/net/arp | grep -v "00:00:00:00:00:00"`;
 foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
 {
     next if /^\D/;
@@ -169,14 +170,15 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
     };
     $neighbor{$ip} = 1;
 
-    my $mac = `grep $ip /proc/net/arp | grep ${wifiif} | grep -v "00:00:00:00:00:00" | head -1`;
+    my ($mac) = grep /^$ip/, @arps;
     $mac =~ s/^.*(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w).*$/$1/;
     chomp $mac;
 
-    if ( $mac and -e "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac" )
+    my @csv = `cat /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv 2>/dev/null`;
+    if ( $mac and @csv )
     {
 	#802.11b/n
-	my $mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
+    my ($mbps) = grep /^([^,]*,){3}A/, @csv;
 	if ($mbps)
 	{
 		my ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
@@ -186,7 +188,7 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
 	else
 	{
 		#802.11a/b/g
-		$mbps = `egrep \"^A" /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
+        ($mbps) = grep /^A/, @csv;
 		if ($mbps)
 		{
 		$mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -182,24 +182,24 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
     {
         my @csv = <$fh>;
         close $fh;
-    #802.11b/n
-    my ($mbps) = grep /^([^,]*,){3}A/, @csv;
-    if ($mbps)
-    {
-        my ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
-        $rate =~ s/[ \t]//g;
-        $mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
-    }
-    else
-    {
-        #802.11a/b/g
-        ($mbps) = grep /^A/, @csv;
+        #802.11b/n
+        my ($mbps) = grep /^([^,]*,){3}A/, @csv;
         if ($mbps)
         {
-        $mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
-        $mbps = $1*$3/100;
+            my ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
+            $rate =~ s/[ \t]//g;
+            $mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
         }
-    }
+        else
+        {
+            #802.11a/b/g
+            ($mbps) = grep /^A/, @csv;
+            if ($mbps)
+            {
+            $mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;
+            $mbps = $1*$3/100;
+            }
+        }
         $links{$ip}{mbps} = $mbps ? sprintf "%.1f", $mbps / $chanbw : "0.0";
     }
 }

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -445,20 +445,20 @@ print "<tr><td>&nbsp;</td></tr>\n";
 print "<tr><th align=left><nobr>Remote Nodes</nobr></th><th>&nbsp;&nbsp;</th><th>ETX</th><th>&nbsp;&nbsp;</th><th align=left>Services</th></tr>\n";
 print "<tr><td colspan=5><hr></td></tr>\n";
 
-%rows = ();
-foreach $ip (keys %hosts)
+my $row;
+foreach $ip (sort { $hosts{$a}{etx} <=> $hosts{$b}{etx} } keys %hosts)
 {
     next if $neighbor{$ip};
-    $host = $hosts{$ip}{name};
+    my $host = $hosts{$ip}{name};
     next unless $host;
-    $localpart = $host =~ s/.local.mesh//r;
-    $tactical = $hosts{$ip}{tactical} ? " / " . $hosts{$ip}{tactical} : "";
-    $etx = sprintf "%.2f", $hosts{$ip}{etx};
+    my $localpart = $host =~ s/.local.mesh//r;
+    my $tactical = $hosts{$ip}{tactical} ? " / " . $hosts{$ip}{tactical} : "";
+    my $etx = sprintf "%.2f", $hosts{$ip}{etx};
 
     $row  = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $host, $localpart . $tactical;
 
-    undef $nodeiface;
-    $mcount = 0 + $midcount{$ip};
+    my $nodeiface;
+    my $mcount = 0 + $midcount{$ip};
     if ( $dtd{$ip} ) { $mcount -= 1; } # extra mid entry matching and with dtdlink in hosts_olsrd
     if ( $hosts{$ip}{tactical} ) { $mcount -= 1; } # extra mid entry if tactical name defined
     if ( $mcount > 0 ) { $nodeiface = "tun*$mcount" ;  }
@@ -476,7 +476,7 @@ foreach $ip (keys %hosts)
     # add advertised dmz hosts
     foreach $dmzhost (@{$hosts{$ip}{hosts}})
     {
-        $localpart = $dmzhost =~ s/.local.mesh//r;
+        my $localpart = $dmzhost =~ s/.local.mesh//r;
 	$row .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
 	$row .= "<td colspan=3></td><td>\n";
 	foreach(sort keys %{$services{$dmzhost}})
@@ -485,16 +485,12 @@ foreach $ip (keys %hosts)
 	}
 	$row .= "</td></tr>\n";
     }
-    $rows{$ip}=$row;
+    print $row;
 }
 
 undef %neighbor;
 
-if(keys %rows)
-{
-    foreach(sort { $hosts{$a}{etx} <=> $hosts{$b}{etx} } keys %rows) { print $rows{$_} }
-}
-else
+if(!$row)
 {
     print "<tr><td>none</td></tr>\n";
 }

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -105,7 +105,7 @@ $node = nvram_get("node");
 $node = "NOCALL" if $node eq "";
 $tactical = nvram_get("tactical");
 $config = nvram_get("config");
-$config = "not set" if $config eq "" or not -d "/etc/config.mesh";
+$config = "not set" if $config eq "" || not -d "/etc/config.mesh";
 ($my_ip) = get_ip4_network(get_interface("wifi"));
 ${wifiif} = `uci -q get 'network.wifi.ifname'`;
 chomp ${wifiif};
@@ -150,7 +150,7 @@ foreach(`echo /rou | nc 127.0.0.1 2006 2>>$tmperr`)
     my ($net, $cidr) = split /\//, $ip;
     if ( $etx <= 50 ) { $routes{$net}{etx} = $etx; }
 }
-if ($olsrTotal > $lowMemoryLimits{routes} and get_available_mem() < $lowMemoryLimits{memory})
+if ($olsrTotal > $lowMemoryLimits{routes} && get_available_mem() < $lowMemoryLimits{memory})
 {
     my @oroutes = sort { $routes{$a}{etx} <=> $routes{$b}{etx} } keys %routes;
     foreach ( @oroutes[$lowMemoryLimits{routes} .. $#oroutes] )
@@ -160,7 +160,7 @@ if ($olsrTotal > $lowMemoryLimits{routes} and get_available_mem() < $lowMemoryLi
 }
 @arps = {};
 open my $fh, '<', '/proc/net/arp';
-foreach (<$fh>) { push @arps, $_ if (/$wifiif/ and !/00:00:00:00:00:00/) }
+foreach (<$fh>) { push @arps, $_ if (/$wifiif/ && !/00:00:00:00:00:00/) }
 close $fh;
 foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
 {
@@ -178,7 +178,7 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
     chomp $mac;
 
     open my $fh, '<', "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac/rc_stats_csv";
-    if ( $mac and $fh )
+    if ( $mac && $fh )
     {
         my @csv = <$fh>;
         close $fh;
@@ -260,7 +260,7 @@ foreach (<$fh>)
     next unless $originator;
     next if $originator eq "myself";
     # Filter hosts which are unreachable
-    next unless $routes{$ip} or $routes{$originator};
+    next unless $routes{$ip} || $routes{$originator};
 
     my $etx = $routes{$ip}{etx} ? $routes{$ip}{etx} : $routes{$originator}{etx};
 
@@ -311,7 +311,7 @@ foreach (<$fh>)
     my ($name, $originator) = split /\#/, $name;
 
     # Filter services for unreachable hosts
-    next unless $hosts{$originator}{name} or $originator eq " my own service";
+    next unless $hosts{$originator}{name} || $originator eq " my own service";
 
     $name =~ s/\s+$//;
 
@@ -386,7 +386,7 @@ if($txtinfo_err)
 
 print "</nobr><br><br>\n";
 
-unless(keys %localhosts or keys %links)
+unless(keys %localhosts || keys %links)
 {
     print "No other nodes are available.\n";
     print "</center></form>";
@@ -435,7 +435,7 @@ if(keys %localhosts)
         if(grep { /$dmzhost/ } @{$localhosts{$ip}{noprops}}) { $nopropd = 1; }
 	if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
         $localpart = $dmzhost =~ s/.local.mesh//r;
-	    if(!$nopropd and !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    if(!$nopropd && !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
 	    elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top title='Aliased Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
 	    else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top title='Non Propagated Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
 	    $rows{$host} .= "<td colspan=3></td><td>\n";
@@ -543,7 +543,7 @@ if(keys %links)
             else { $nodeiface="?" ; }
 	}
 
-	if ( $wangateway{$ip} or $wangateway{$ipmain} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" :  "wan" ; }
+	if ( $wangateway{$ip} || $wangateway{$ipmain} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" :  "wan" ; }
         if ( $nodeiface ) { $row .= " &nbsp; <small>($nodeiface)</small>"; }
 
         $row .= sprintf ("</nobr></td><td></td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%s</td><td></td><td>\n", 100*$links{$ip}{lq}, 100*$links{$ip}{nlq},$links{$ip}{mbps});

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -89,6 +89,17 @@ use perlfunc;
         routes => 1000,
 );
 
+sub get_available_mem
+{
+  foreach(`free`)
+  {
+    next unless /^Mem[:]/;
+    my @tmp = split /\s+/, $_;
+    return $tmp[6];
+  }
+  return "N/A";
+}
+
 # collect some variables
 $node = nvram_get("node");
 $node = "NOCALL" if $node eq "";
@@ -140,7 +151,7 @@ foreach(`echo /rou | nc 127.0.0.1 2006 2>>$tmperr`)
     ($net, $cidr) = split /\//, $ip;
     if ( $etx <= 50 ) { $routes{$net}{etx} = $etx; }
 }
-if ($olsrTotal > $lowMemoryLimits{routes} and get_free_mem() < $lowMemoryLimits{memory})
+if ($olsrTotal > $lowMemoryLimits{routes} and get_available_mem() < $lowMemoryLimits{memory})
 {
     @oroutes = sort { $routes{$a}{etx} <=> $routes{$b}{etx} } keys %routes;
     foreach ( @oroutes[$lowMemoryLimits{routes} .. $#oroutes] )

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -435,7 +435,6 @@ print "<tr><th align=left><nobr>Remote Nodes</nobr></th><th>&nbsp;&nbsp;</th><th
 print "<tr><td colspan=5><hr></td></tr>\n";
 
 %rows = ();
-%sortrows = ();
 foreach $ip (keys %hosts)
 {
     next if $neighbor{$ip};
@@ -445,47 +444,44 @@ foreach $ip (keys %hosts)
     $tactical = $hosts{$ip}{tactical} ? " / " . $hosts{$ip}{tactical} : "";
     $etx = sprintf "%.2f", $hosts{$ip}{etx};
 
-    $rows{$host}  = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $host, $localpart . $tactical;
+    $row  = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $host, $localpart . $tactical;
 
     undef $nodeiface;
-    if ( $dtd{$ip} )
-    {
-	if ( $midcount{$ip} ) { $midcount{$ip} -= 1; } # extra mid entry matching and with dtdlink in hosts_olsrd
-    }
-    if ( $hosts{$ip}{tactical} ) { $midcount{$ip} -= 1; } # extra mid entry if tactical name defined
-    if ( $midcount{$ip} )  {  $nodeiface = "tun*$midcount{$ip}" ;  }
+    $mcount = 0 + $midcount{$ip};
+    if ( $dtd{$ip} ) { $mcount -= 1; } # extra mid entry matching and with dtdlink in hosts_olsrd
+    if ( $hosts{$ip}{tactical} ) { $mcount -= 1; } # extra mid entry if tactical name defined
+    if ( $mcount > 0 ) { $nodeiface = "tun*$mcount" ;  }
     if ( $wangateway{$ip} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" : "wan" ; }
 
-    if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
+    if ( $nodeiface ) { $row .= " &nbsp; <small>($nodeiface)</small>"; }
 
-    $rows{$host} .= sprintf "</nobr></td><td></td><td align=right valign=top>%s</td><td></td><td>\n", $etx;
+    $row .= sprintf "</nobr></td><td></td><td align=right valign=top>%s</td><td></td><td>\n", $etx;
     foreach(sort keys %{$services{$host}})
     {
-	$rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
+	$row .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n";
     }
-    $rows{$host} .= "</td></tr>\n";
+    $row .= "</td></tr>\n";
 
     # add advertised dmz hosts
     foreach $dmzhost (@{$hosts{$ip}{hosts}})
     {
         $localpart = $dmzhost =~ s/.local.mesh//r;
-	$rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
-	$rows{$host} .= "<td colspan=3></td><td>\n";
+	$row .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
+	$row .= "<td colspan=3></td><td>\n";
 	foreach(sort keys %{$services{$dmzhost}})
 	{
-	    $rows{$host} .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
+	    $row .= "<nobr>" . $services{$dmzhost}{$_} . "</nobr><br>\n";
 	}
-	$rows{$host} .= "</td></tr>\n";
+	$row .= "</td></tr>\n";
     }
-    $sortrows{$ip}=$host;
+    $rows{$ip}=$row;
 }
 
 undef %neighbor;
 
 if(keys %rows)
 {
-    foreach(sort { $hosts{$a}{etx} <=> $hosts{$b}{etx} } keys %sortrows) { print $rows{$sortrows{$_}} }
-    undef %sortrows;
+    foreach(sort { $hosts{$a}{etx} <=> $hosts{$b}{etx} } keys %rows) { print $rows{$_} }
 }
 else
 {
@@ -514,7 +510,7 @@ if(keys %links)
 
 	$no_space_host=$host;
 	$no_space_host =~ s/\s+$//;
-	$rows{$host} = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
+	$row = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
 
 	undef $nodeiface;
 	if ( $ipmain ne $ip ) # indicate if dtd or tunnel interface to neighbor
@@ -525,26 +521,28 @@ if(keys %links)
 	}
 
 	if ( $wangateway{$ip} or $wangateway{$ipmain} ) { $nodeiface = $nodeiface ? $nodeiface . ",wan" :  "wan" ; }
-        if ( $nodeiface ) { $rows{$host} .= " &nbsp; <small>($nodeiface)</small>"; }
+        if ( $nodeiface ) { $row .= " &nbsp; <small>($nodeiface)</small>"; }
 
-        $rows{$host} .= sprintf ("</nobr></td><td></td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%s</td><td></td><td>\n", 100*$links{$ip}{lq}, 100*$links{$ip}{nlq},$links{$ip}{mbps});
+        $row .= sprintf ("</nobr></td><td></td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%.0f%%</td><td align=right valign=top>%s</td><td></td><td>\n", 100*$links{$ip}{lq}, 100*$links{$ip}{nlq},$links{$ip}{mbps});
 
 	if ( ! exists $neighservices{$host} )
 	    {
-	    foreach(sort keys %{$services{$host}}) { $rows{$host} .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n" }
+	    foreach(sort keys %{$services{$host}}) { $row .= "<nobr>" . $services{$host}{$_} . "</nobr><br>\n" }
 
-	    $rows{$host} .= "</td></tr>\n";
+	    $row .= "</td></tr>\n";
 
 	    # add advertised dmz hosts
 	    foreach $dmzhost (@{$hosts{$ipmain}{hosts}})
 	    {
                 $localpart = $dmzhost =~ s/.local.mesh//r;
-	        $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td><td colspan=5></td><td>\n";
-	        foreach(sort keys %{$services{$dmzhost}}) { $rows{$host} .= $services{$dmzhost}{$_} . "<br>\n" }
-	        $rows{$host} .= "</td></tr>\n";
+	        $row .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td><td colspan=5></td><td>\n";
+	        foreach(sort keys %{$services{$dmzhost}}) { $row .= $services{$dmzhost}{$_} . "<br>\n" }
+	        $row .= "</td></tr>\n";
 	    }
 	    $neighservices{$host}=1;
 	}
+
+	$rows{$host}=$row;
     }
 
     foreach(sort keys %rows) { print $rows{$_} }

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -125,7 +125,7 @@ system "rm -f /tmp/web/automesh" if $parms{stop};
 #get location info if available
 $lat_lon = "<strong>Location Not Available</strong>";
 if(-f "/etc/latlon") {
-    $rcgood=open(FILE, "/etc/latlon");
+    my $rcgood=open(FILE, "/etc/latlon");
     if($rcgood) {
         while(<FILE>){
             chomp;
@@ -141,29 +141,27 @@ $node_desc = `/sbin/uci -q get system.\@system[0].description`; #pull the node d
 
 # parse the txtinfo output
 
-$table = "none";
 chomp($tmperr = `mktemp /tmp/web/nc.XXXXXX`);
 
 foreach(`echo /rou | nc 127.0.0.1 2006 2>>$tmperr`)
 {
     next if /^\D/;
-    ($ip, $junk, $junk, $etx) = split /\s+/, $_;
-    ($net, $cidr) = split /\//, $ip;
+    my ($ip, $junk, $junk, $etx) = split /\s+/, $_;
+    my ($net, $cidr) = split /\//, $ip;
     if ( $etx <= 50 ) { $routes{$net}{etx} = $etx; }
 }
 if ($olsrTotal > $lowMemoryLimits{routes} and get_available_mem() < $lowMemoryLimits{memory})
 {
-    @oroutes = sort { $routes{$a}{etx} <=> $routes{$b}{etx} } keys %routes;
+    my @oroutes = sort { $routes{$a}{etx} <=> $routes{$b}{etx} } keys %routes;
     foreach ( @oroutes[$lowMemoryLimits{routes} .. $#oroutes] )
     {
       delete $routes{$_};
     }
-    undef @oroutes;
 }
 foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
 {
     next if /^\D/;
-    ($junk, $ip, $junk, $lq, $nlq) = split /\s+/, $_;
+    my ($junk, $ip, $junk, $lq, $nlq) = split /\s+/, $_;
     $links{$ip} = {
         lq => $lq,
         nlq => $nlq,
@@ -171,17 +169,17 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
     };
     $neighbor{$ip} = 1;
 
-    $mac = `grep $ip /proc/net/arp | grep ${wifiif} | grep -v "00:00:00:00:00:00" | head -1`;
+    my $mac = `grep $ip /proc/net/arp | grep ${wifiif} | grep -v "00:00:00:00:00:00" | head -1`;
     $mac =~ s/^.*(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w).*$/$1/;
     chomp $mac;
 
     if ( $mac and -e "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac" )
     {
 	#802.11b/n
-	$mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
+	my $mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
 	if ($mbps)
 	{
-		($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
+		my ($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
 		$rate =~ s/[ \t]//g;
 		$mbps =  $gi eq "SGI" ?  $rateS{$rate}*$ewma/100 : $rateL{$rate}*$ewma/100 ;
 	}
@@ -201,14 +199,14 @@ foreach(`echo /lin | nc 127.0.0.1 2006 2>>$tmperr`)
 foreach(`echo /hna | nc 127.0.0.1 2006 2>>$tmperr`)
 {
     next if /^\D/;
-    ($iproute, $ip) = split /\s+/, $_;
-    ($net, $cidr) = split /\//, $iproute;
+    my ($iproute, $ip) = split /\s+/, $_;
+    my ($net, $cidr) = split /\//, $iproute;
     if ( $net eq "0.0.0.0" ) {  $wangateway{$ip} = 1; }
 }
 foreach(`echo /mid | nc 127.0.0.1 2006 2>>$tmperr`)
 {
     next if /^\D/;
-    ($ip, $junk) = $_ =~ /^(\S+)\s+(.*)$/;
+    my ($ip, $junk) = $_ =~ /^(\S+)\s+(.*)$/;
     foreach $aip ( split /\s+/, $junk )
     {
         $ipalias{$aip} = $ip;
@@ -227,7 +225,7 @@ foreach(`cat /etc/hosts`)
 {
     next unless /^10[.]/;
     chomp;
-    ($ip, $name, $tactical) = split /\s+/, $_;
+    my ($ip, $name, $tactical) = split /\s+/, $_;
     next if $name =~ /^(localhost|localnode|localap|dtdlink\..*)$/;
     if ( $name !~ /\./ ) { $name="${name}.local.mesh"; }
     if($ip eq $my_ip)
@@ -246,13 +244,13 @@ foreach(`cat /var/run/hosts_olsr 2>/dev/null`)
 {
     next unless /^\d/;
     chomp;
-    ($ip, $name, undef, $originator, undef, undef) = split /\s+/, $_;
+    my ($ip, $name, undef, $originator, undef, undef) = split /\s+/, $_;
     next unless $originator;
     next if $originator eq "myself";
     # Filter hosts which are unreachable
     next unless $routes{$ip} or $routes{$originator};
 
-    $etx = $routes{$ip}{etx} ? $routes{$ip}{etx} : $routes{$originator}{etx};
+    my $etx = $routes{$ip}{etx} ? $routes{$ip}{etx} : $routes{$originator}{etx};
 
     if (( $name !~ /\./ ) || ( $name =~ /^mid\.[^\.]*$/ )) { $name="${name}.local.mesh"; }
 
@@ -292,17 +290,18 @@ foreach(`cat /var/run/services_olsr 2>/dev/null`)
 {
     next unless /^\w/;
     chomp;
-    ($url, $junk, $name) = split /\|/, $_;
+    my ($url, $junk, $name) = split /\|/, $_;
     next unless defined $name;
-    ($protocol, $host, $port, $path) = $url =~ /^(\w+):\/\/([\w\-\.]+):(\d+)\/(.*)/;
+    my ($protocol, $host, $port, $path) = $url =~ /^(\w+):\/\/([\w\-\.]+):(\d+)\/(.*)/;
     next unless defined $path;
-    ($name, $originator) = split /\#/, $name;
-    $name =~ s/\s+$//;
-
-    if ( $host !~ /\./ ) { $host="${host}.local.mesh"; }
+    my ($name, $originator) = split /\#/, $name;
 
     # Filter services for unreachable hosts
     next unless $hosts{$originator}{name} or $originator eq " my own service";
+
+    $name =~ s/\s+$//;
+
+    if ( $host !~ /\./ ) { $host="${host}.local.mesh"; }
 
     # attempt to work around olsr never forgetting defunct services
     # assume that the first entry in the file by this name is the most recent, ignore the rest
@@ -390,13 +389,13 @@ print "<tr><td colspan=5><hr></td></tr>\n";
 
 if(keys %localhosts)
 {
-    %rows = ();
+    my %rows = ();
 
     foreach $ip (keys %localhosts)
     {
-	$host = $localhosts{$ip}{name};
-        $localpart = $host =~ s/.local.mesh//r;
-	$tactical = $localhosts{$ip}{tactical} ? " / " . $localhosts{$ip}{tactical} : "";
+	my $host = $localhosts{$ip}{name};
+        my $localpart = $host =~ s/.local.mesh//r;
+	my $tactical = $localhosts{$ip}{tactical} ? " / " . $localhosts{$ip}{tactical} : "";
 	$rows{$host} = sprintf "<tr><td valign=top><nobr>%s</nobr>", $localpart . $tactical;
 
         if ( $wangateway{$ip} ) { $nodeiface =  "wan" ; }
@@ -414,8 +413,8 @@ if(keys %localhosts)
 	foreach $dmzhost (@{$localhosts{$ip}{hosts}})
 	{
         #find non-propagated and aliased hosts and change color
-        $nopropd = 0;
-	$aliased = 0;
+        my $nopropd = 0;
+	my $aliased = 0;
         if(grep { /$dmzhost/ } @{$localhosts{$ip}{noprops}}) { $nopropd = 1; }
 	if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
         $localpart = $dmzhost =~ s/.local.mesh//r;
@@ -505,21 +504,21 @@ print "<tr><td colspan=7><hr></td></tr>\n";
 
 if(keys %links)
 {
-    %rows = ();
+    my %rows = ();
 
     foreach $ip (keys %links)
     {
-	$ipmain = exists $ipalias{$ip} ? $ipalias{$ip} : $ip ;
-	$host = $hosts{$ipmain}{name} ? $hosts{$ipmain}{name} : $ipmain;
-        $localpart = $host =~ s/.local.mesh//r;
-	$tactical = $hosts{$ipmain}{tactical} ? " / " . $hosts{$ipmain}{tactical} : "";
+	my $ipmain = exists $ipalias{$ip} ? $ipalias{$ip} : $ip ;
+	my $host = $hosts{$ipmain}{name} ? $hosts{$ipmain}{name} : $ipmain;
+        my $localpart = $host =~ s/.local.mesh//r;
+	my $tactical = $hosts{$ipmain}{tactical} ? " / " . $hosts{$ipmain}{tactical} : "";
         if ( $rows{$host} ) { $host .= " " ; } # avoid collision 2 links to same host {rf, dtd}
 
-	$no_space_host=$host;
+	my $no_space_host=$host;
 	$no_space_host =~ s/\s+$//;
-	$row = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
+	my $row = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $no_space_host, $localpart . $tactical;
 
-	undef $nodeiface;
+	my $nodeiface;
 	if ( $ipmain ne $ip ) # indicate if dtd or tunnel interface to neighbor
 	{
             if    ( $links{$ip}{dtd} ){ $nodeiface="dtd" ; }
@@ -541,7 +540,7 @@ if(keys %links)
 	    # add advertised dmz hosts
 	    foreach $dmzhost (@{$hosts{$ipmain}{hosts}})
 	    {
-                $localpart = $dmzhost =~ s/.local.mesh//r;
+                my $localpart = $dmzhost =~ s/.local.mesh//r;
 	        $row .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td><td colspan=5></td><td>\n";
 	        foreach(sort keys %{$services{$dmzhost}}) { $row .= $services{$dmzhost}{$_} . "<br>\n" }
 	        $row .= "</td></tr>\n";

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -481,9 +481,12 @@ foreach $ip (keys %hosts)
     $sortrows{$ip}=$host;
 }
 
+undef %neighbor;
+
 if(keys %rows)
 {
     foreach(sort { $hosts{$a}{etx} <=> $hosts{$b}{etx} } keys %sortrows) { print $rows{$sortrows{$_}} }
+    undef %sortrows;
 }
 else
 {
@@ -552,6 +555,7 @@ else
     print "<tr><td>none</td></tr>\n";
 }
 
+undef %services;
 
 # show previous neighbors
 

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -341,9 +341,19 @@ close $fh;
 
 #delete $hosts{"127.0.0.1"};
 
+# compress the output if we can                                                                                            
+if ( $ENV{HTTP_ACCEPT_ENCODING} =~ /gzip/ )                                                                                
+{                                                                                                                          
+    print "Content-type: text/html\r\nCache-Control: no-store\r\nContent-Encoding: gzip\r\n\r\n";                      
+    open my $zout, "|gzip";                                                                                            
+    select $zout;                                                                                                      
+}                                                                                                                          
+else                                                                                                                       
+{                                                                                                                          
+    print "Content-type: text/html\r\nCache-Control: no-store\r\n\r\n";                                                
+}    
 
 # generate the page
-http_header();
 html_header("$node mesh status", 0);
 print "<meta http-equiv='refresh' content='10;url=/cgi-bin/mesh'>\n" if -f "/tmp/web/automesh";
 print "</head>\n";


### PR DESCRIPTION
Based on feedback from the Meshoween event, this diff does a few things:

1. Remove a nested loop which was filtering out neighbor nodes in the "Remote Nodes" section. This scaled O(N^2) as the number of mesh nodes increased and was probably the big reason mesh status ground to a halt on resource constrained nodes.
2. Reduce the size of various in-memory hash tables built when generating the page and discarding them sooner.
3. Detect low memory nodes and limit the size of the mesh status page generated to only closer nodes.
4. For the Remote Nodes section, print as we go. This can get big so let's not keep it in memory.
5. When reading link speeds, reduce reads of the arp tables and wifi files as these are slow.
6. A bunch of little things for small speedups and memory savings.

Note: I haven't written Perl code in 15 years (and then not much) so feedback appreciated.