### PR TITLE
admin page: Fix validateFirmwareFilename() for underscore in ath79 filenames

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@ Eric Satterlee - KG6WXC <kg6wxc@gmail.com>
 Ray Suelzer - KK6RAY <rsuelzer@gmail.com>
 Steve Lewis - AB7PA <ab7pa.radio@gmail.com>
 Tim Wilkinson - KN6PLV <tim.j.wilkinson@gmail.com>
+Phil Crump - M0DNY <phil@philcrump.co.uk>

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -634,7 +634,7 @@ print <<EOF;
                 searchstring= ".*wbs" + hwtype + "-sysupgrade.bin$\";
                 efn = "aredn-$fw_version-$mfgprefix${hardwaretypev}-sysupgrade.bin";
             } else {
-                searchstring= ".*-" + hwtype + "-sysupgrade.bin$\";
+                searchstring= ".*(-|_)" + hwtype + "-sysupgrade.bin$\";
                 efn = "aredn-$fw_version-$mfgprefix-${hardwaretypev}-sysupgrade.bin";
             }
         } else {


### PR DESCRIPTION
Fixes ath79 validation issue reported at https://www.arednmesh.org/content/upgrade-issue-ath79-nightly-filename

The regex now matches either underscore or hyphen character between hwmanuf and model, tested locally with different filenames and appears to solve the issue as reported.

(Deliberately modifying as little of the logic here as possible as I'm not the original author.)