### PR TITLE
Make sure wifi is up before letting OLSRD run

### DIFF
--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -56,6 +56,17 @@ if ( $UCI_CONF_FILE eq "olsrd6" ) {
   exit 0;
 }
 
+# Make sure wifi exists and is up to avoid OLSRD nameservice problems later.
+# This is not the perfect place to do this, but it avoids changing more core functions.
+if (system "ubus -t 10 wait_for network.interface.wifi" == 0)
+{
+  for ($i = 0; $i < 10; $i++)
+  {
+    chomp($wifiup = `ubus -S call network.interface.wifi status | jsonfilter -e '@.up'`);
+    last if ($wifiup eq "true");
+    sleep 2;
+  }
+}
 
 @names = @hosts = @services = @tunnels = ();
 


### PR DESCRIPTION
This is a fix for a long running problem where, very occasionally, nodes don't publish their name until OLSRD is restarted.

The situation happens when OLSRD starts before the Wifi interface is completely up. At startup the name service plugin in OLSRD checks the list of names and services it has configured and removes any which don't have a corresponding, valid, interface. Unfortunately, if an interface becomes valid later, these entries are not added back in. They're gone until OLSRD restarts.

This fix waits until the wifi interface is available and up before allowing OLSRD to startup.

The code is not ideally placed, but I think better here than changing the OLSRD name service to fix the issue, or modifying core packages. I'm open to other options for where this could go.

Should fix: https://github.com/aredn/aredn/issues/21 and https://github.com/aredn/aredn/issues/25