### PR TITLE
aredn: Add dnsmasq DNS hostnames override for configured NTP server.

### DIFF
--- a/files/etc/config.mesh/_setup
+++ b/files/etc/config.mesh/_setup
@@ -42,6 +42,7 @@ wan_dns2 = 8.8.4.4
 dtdlink_ip=10.<DTDMAC>
 
 time_zone = UTC
+ntp_override_hosts = 
 ntp_server = us.pool.ntp.org
 
 description_node = 

--- a/files/etc/config.mesh/_setup.default
+++ b/files/etc/config.mesh/_setup.default
@@ -44,6 +44,7 @@ dtdlink_ip=10.<DTDMAC>
 
 time_zone = UTC
 time_zone_name = UTC
+ntp_override_hosts = 
 ntp_server = us.pool.ntp.org
 
 description_node = 

--- a/files/etc/dnsmasq.conf
+++ b/files/etc/dnsmasq.conf
@@ -13,6 +13,7 @@ resolv-file=/tmp/resolv.conf.auto
 
 # include olsr nameservice
 addn-hosts=/var/run/hosts_olsr
+addn-hosts=/etc/hosts_override
 
 dhcp-authoritative
 dhcp-leasefile=/tmp/dhcp.leases

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -536,6 +536,19 @@ system $cmd;
 #
 system('/usr/local/bin/wifi-setup');
 
+#
+# Generate additional DNS hosts file for ntp hostname override
+#
+open(OUT, ">/etc/hosts_override") or die;
+if ($cfg{ntp_server} ne "")
+{
+  @ntp_override_hosts_array = split /,/, $cfg{ntp_override_hosts};
+  foreach $ntp_override_host (@ntp_override_hosts_array) {
+    print OUT "$cfg{ntp_server} $ntp_override_host\n";
+  }
+}
+close(OUT);
+
 unless($auto)
 {
   print "configuration complete.\n";

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -1252,13 +1252,9 @@ foreach my $tz (@$tz_db_names) {
     selopt($name, $tz, $time_zone_name);
 }
 
-print "</select></td><td align=left>NTP Server</td><td><input type=text name=ntp_server size=20 value='$ntp_server'></td>";
-
-print "</table></td></tr>";
-
-
-
-print "</table>\n";
+print "</select></td><td align=left>NTP Server</td><td><input type=text name=ntp_server size=20 value='$ntp_server'></td></tr>";
+print "<tr><td colspan=2></td><td align=left>DNS names to override for NTP<br>(comma-separated list)</td><td><textarea id=node_ntp_override_hosts rows=2 cols=30 name=ntp_override_hosts>$ntp_override_hosts</textarea></td>";
+print "</tr></table>";
 
 push @hidden, "<input type=hidden name=reload value=1>";
 push @hidden, "<input type=hidden name=dtdlink_ip value='$dtdlink_ip'>";


### PR DESCRIPTION
I'm putting this up in case there's alternative ideas or strong opinions on this, but marking as a draft until I've done some more testing to make sure it performs the role I'm intending, which may be useful to others as well.

We're planning (and are currently simulating across my home) a mostly-offline AREDN network with a single internet-connected node. This internet-connected node has a Raspberry Pi server, with local services including ntpd on battery-backed RTC to provide accurate time to the mesh (synced to NTP Pool when internet is available).

Client laptops and other devices connecting to other (offline) nodes in the mesh will not be able to access their default internet time servers (time.apple.com, time.windows.com, ntp.ubuntu.com, etc.), and so the idea here is to override the DNS response in dnsmasq on the nodes to return the IP of the node-configured NTP server instead (which for us is the Raspberry Pi with the RTC), allowing these devices to achieve time sync without additional client configuration.

Screenshot of the result on an Ubuntu client laptop with default ntpd configuration, connected to an offline node in the mesh:
![dns-ntp-override](https://user-images.githubusercontent.com/873295/140627928-6f01f17e-d956-476f-afb3-18d815c48444.png)
