### PR TITLE
Stop creating 'config alerts' on every reboot.

### DIFF
--- a/files/etc/init.d/local
+++ b/files/etc/init.d/local
@@ -95,9 +95,7 @@ boot() {
     shift
   done
 
-  # set local alerts if available
-  local alertslocalpath=$(uci -q get aredn.@alerts[0].localpath)
-  if [ -z "$alertslocalpath" ]; then
+  if [ -z "$(uci -q get aredn.@alerts[0])" ]; then
       uci -q add aredn alerts
       uci -q commit aredn
   fi


### PR DESCRIPTION
A 'config alerts' section was being added to the config on every reboot because this check will always be true if an alerts URI hasn't been set. Now it will only get added if it doesn't exist which seems more correct.