### PR TITLE
build: increase build no-output timeout limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,15 @@ jobs:
       - run:
           name: Build
           command: make
+          no_output_timeout: 30m
       - run:
           name: Build
           command: make SUBTARGET=mikrotik
+          no_output_timeout: 30m
       - run:
           name: Build
           command: make MAINTARGET=ath79
+          no_output_timeout: 30m
       - run:
           name: Compress build files
           command: tar -cjf ~/${CIRCLE_BRANCH}_${ARTIFACTS_FILE} -C ${MY_WORKING_DIRECTORY}/${ARTIFACTS_DIR} .


### PR DESCRIPTION
increase no-output timeout from 10m to 30m