### PR TITLE
remove 'trunk' from snapshots path

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -12,7 +12,7 @@ MAKE_ARGS=-j3
 # Where will the installed image find add-on Packages to download?
 # This URL must contain the packages from this build
 # downloading packages within the AREDN UI uses signatures 
-PRIVATE_BUILD_PACKAGES=http://downloads.arednmesh.org/snapshots/trunk
+PRIVATE_BUILD_PACKAGES=http://downloads.arednmesh.org/snapshots
 
 # These options are for more complex changes
 SHELL:=$(shell which bash)

--- a/files/etc/uci-defaults/45_aredn_reset_paths
+++ b/files/etc/uci-defaults/45_aredn_reset_paths
@@ -5,7 +5,7 @@
 DISTRIB_TARGET=$(grep DISTRIB_TARGET /etc/openwrt_release|cut -d'=' -f2|tr -d "'")
 DISTRIB_RELEASE=$(grep DISTRIB_RELEASE /etc/openwrt_release|cut -d'=' -f2|tr -d "'")
 SERVER_PREFIX='http://downloads.arednmesh.org/'
-SNAPSHOT_PREFIX='snapshots/trunk/'
+SNAPSHOT_PREFIX='snapshots/'
 
 getReleasePrefix()
 {

--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -2202,7 +2202,7 @@ sub getRelease {
 #  my $target = getDistTarget();
 #  my $release = getRelease();
 #  if ($release !~ /\./) {
-#    return "http://downloads.arednmesh.org/snapshots/trunk/" . $target;
+#    return "http://downloads.arednmesh.org/snapshots/" . $target;
 #  } else {
 #    return "http://downloads.arednmesh.org/firmware";
 #  }
@@ -2222,7 +2222,7 @@ sub defaultPackageRepos {
     $urlprefix .= "/releases/" . $nums[0] . "/" . $nums[1] . "/" . $release . "/";
   } else {
     #nightly build or self built firmware
-    $urlprefix .= "/snapshots/trunk/";
+    $urlprefix .= "/snapshots/";
   }
   # have prefix (hopefully), now finish the rest of the url
   if ($repo =~ "aredn_core") {


### PR DESCRIPTION
standardize the nightly build/snapshots directory paths to remove the 'trunk' from /snapshots/trunk/
in support of the AREDN Firmware Selector tool
Also need to modify the CircleCI environment variable NIGHTLY_DIR before merging