### PR TITLE
Link led fixes

### DIFF
--- a/files/usr/local/bin/mgr/linkled.lua
+++ b/files/usr/local/bin/mgr/linkled.lua
@@ -43,17 +43,25 @@ function linkled()
     else
         -- Reset leds
         write_all(link .. "/trigger", "none")
-        write_all(link .. "/brightness", "0")
+        write_all(link .. "/brightness", "1")
+
+		-- Wait for 2 minutes before monitoring status. During this time the led is on
+		wait_for_ticks(120)
 
         while true
         do
             local nei = fetch_json("http://127.0.0.1:9090/neighbors")
             if nei and #nei.neighbors > 0 then
+				-- Led on when link established. Retest every 10 seconds
                 write_all(link .. "/brightness", "1")
+				wait_for_ticks(10)
             else
+				-- Flash led slowly - off 3 seconds, on 3 seconds - when no links
                 write_all(link .. "/brightness", "0")
+				wait_for_ticks(3)
+				write_all(link .. "/brightness", "1")
+				wait_for_ticks(3)
             end
-            wait_for_ticks(11)
         end
     end
 end


### PR DESCRIPTION
* Flash the LED slowly when no link found.
* Handle the LED exceptions where there is no 'correct' definition in board.json
   We should fix the board.json creation process to add the correct link led definition, but for now just reflect the
   exceptions currently in the Perl code. In fact, these aren't necessarily correct (the one I checked wasn't) so it
   probably requires someone with access to devices actually making sure we do the right thing.
   Spreadsheet of leds according to the current build code: https://docs.google.com/spreadsheets/d/1-kUm4GpUwlrVnHdr4xzSoVxGtPmMZS8x/edit?usp=sharing&ouid=104861343244109655077&rtpof=true&sd=true
* See https://github.com/aredn/aredn/issues/203
* Also https://github.com/aredn/aredn/issues/211