### PR TITLE
Move multi ant detection into main run method

### DIFF
--- a/files/usr/local/bin/mgr/rssi_monitor.lua
+++ b/files/usr/local/bin/mgr/rssi_monitor.lua
@@ -54,18 +54,19 @@ if not file_exists(logfile) then
     io.open(logfile, "w+"):close()
 end
 
-local wifiiface = get_ifname("wifi")
-
 local multiple_ant = false
-if read_all("/sys/kernel/debug/ieee80211/" .. iwinfo.nl80211.phyname(wifiiface) .. "/ath9k/tx_chainmask"):chomp() ~= "1" then
-    multiple_ant = true
-end
 
 local log = aredn.log.open(logfile, 16000)
 
 function run_monitor()
 
     local now = nixio.sysinfo().uptime
+
+    local wifiiface = get_ifname("wifi")
+
+    if read_all("/sys/kernel/debug/ieee80211/" .. iwinfo.nl80211.phyname(wifiiface) .. "/ath9k/tx_chainmask"):chomp() ~= "1" then
+        multiple_ant = true
+    end
 
     -- load history
     local rssi_hist = {}


### PR DESCRIPTION
This avoids some startup failures where we try to detect the antenna setup
too early in the node boot up process.