### PR TITLE
Missing cursor during reboot

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -158,7 +158,7 @@ function reboot()
             local cursor = uci:cursor()
             local cfgip = cursor:get("network", "lan", "ipaddr")
             local cfgmask = ip_to_decimal(cursor:get("network", "lan", "netmask"))
-            if lanmask ~= cfgmask or decimal_to_ip(nixio.bit.band(ip_to_decimal(ip), lanmask)) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
+            if lanmask ~= cfgmask or decimal_to_ip(nixio.bit.band(ip_to_decimal(lanip), lanmask)) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
                 subnet_change = true
             end
         end

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -155,6 +155,7 @@ function reboot()
         fromlan = validate_same_subnet(browser, lanip, lanmask)
         if fromlan then
             lanmask = ip_to_decimal(lanmask)
+            local cursor = uci:cursor()
             local cfgip = cursor:get("network", "lan", "ipaddr")
             local cfgmask = ip_to_decimal(cursor:get("network", "lan", "netmask"))
             if lanmask ~= cfgmask or decimal_to_ip(nixio.bit.band(ip_to_decimal(ip), lanmask)) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then


### PR DESCRIPTION
One path through the reboot process requires a cursor we didn't have.
Also, incorrect name for IP address.
https://github.com/aredn/aredn/issues/231
https://github.com/aredn/aredn/issues/223