### PR TITLE
Only one device name per interface name (some devices have 2)

### DIFF
--- a/files/usr/lib/lua/aredn/hardware.lua
+++ b/files/usr/lib/lua/aredn/hardware.lua
@@ -144,7 +144,7 @@ function hardware.get_iface_name(name)
         return "eth0.2"
     end
     -- Maybe the board knows
-    return hardware.get_board().network[name].ifname
+    return hardware.get_board().network[name].ifname:match("^(%S+)")
 end
 
 function hardware.get_link_led()

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -81,7 +81,7 @@ if not (config == "mesh" and nixio.fs.access("/etc/config.mesh/_setup", "r")) th
     return -1
 end
 
-local lanintf = aredn.hardware.get_board().network.lan.ifname
+local lanintf = aredn.hardware.get_board().network.lan.ifname:match("^(%S+)")
 local node = aredn_info.get_nvram("node")
 local tactical = aredn_info.get_nvram("tactical")
 local mac2 = mac_to_ip(aredn.hardware.get_interface_mac(aredn.hardware.get_iface_name("wifi")), 0)


### PR DESCRIPTION
Apparently some devices have multiple device assigned to each interface ... so only return the first one.