### PR TITLE
Fix broken auto-reboot on initial setup

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -671,7 +671,7 @@ if parms.button_save then
         parms.node = node
         parms.tactical = tactical
         if nixio.fs.stat("/etc/config/unconfigured") then
-            os.remove("/etc/config/unconfigured")
+            io.open("/tmp/unconfigured", "w"):close()
         end
         local function s2h(str)
             local h = ""


### PR DESCRIPTION
During initial node setup, the node should auto reboot on the first-save, but this was broken.