### PR TITLE
Remove potentially problematic copying of /etc/config.mesh/aredn

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -50,6 +50,9 @@ local errors = {}
 local output = {}
 local hidden = {}
 
+-- uci cursor
+local cursor = uci.cursor()
+
 -- helpers start
 
 local rf_channel_map = {
@@ -155,7 +158,6 @@ function reboot()
         fromlan = validate_same_subnet(browser, lanip, lanmask)
         if fromlan then
             lanmask = ip_to_decimal(lanmask)
-            local cursor = uci:cursor()
             local cfgip = cursor:get("network", "lan", "ipaddr")
             local cfgmask = ip_to_decimal(cursor:get("network", "lan", "netmask"))
             if lanmask ~= cfgmask or decimal_to_ip(nixio.bit.band(ip_to_decimal(lanip), lanmask)) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
@@ -246,14 +248,6 @@ local cfive = { 36,40,44,48,149,153,157,161,165 }
 local wifiintf = aredn.hardware.get_iface_name("wifi")
 local phy = iwinfo.nl80211.phyname(wifiintf)
 local phycount = tonumber(capture("ls -1d /sys/class/ieee80211/* | wc -l"):chomp())
-
--- uci cursor
-local cursor = uci:cursor()
-
-function aredn_clone()
-    cursor:commit("aredn")
-    filecopy("/etc/config/aredn", "/etc/config.mesh/aredn")
-end
 
 -- post_data
 local parms = {}
@@ -454,15 +448,19 @@ end
 
 if parms.button_updatelocation then
     -- process gridsquare
+    local cursora = uci.cursor();
+    local cursorb = uci.cursor("/etc/config.mesh")
     if parms.gridsquare ~= "" then
         if parms.gridsquare:match("^[A-Z][A-Z]%d%d[a-z][a-z]$") then
-            cursor:set("aredn", "@location[0]", "gridsquare", parms.gridsquare)
+            cursora:set("aredn", "@location[0]", "gridsquare", parms.gridsquare)
+            cursorb:set("aredn", "@location[0]", "gridsquare", parms.gridsquare)
             out("Gridsquare updated.")
         else
             err("ERROR: Gridsquare format is: 2-uppercase letters, 2-digits, 2-lowercase letters. (AB12cd)")
         end
     else
-        cursor:set("aredn", "@location[0]", "gridsquare", "")
+        cursora:set("aredn", "@location[0]", "gridsquare", "")
+        cursorb:set("aredn", "@location[0]", "gridsquare", "")
         out("Gridsquare purged.")
     end
 
@@ -470,8 +468,10 @@ if parms.button_updatelocation then
     if parms.latitude ~= "" and parms.longitude ~= "" then
         if parms.latitude:match("^[-+]?%d%d?%.%d+$") and parms.longitude:match("^[-+]?%d%d?%d?%.%d+$") then
             if tonumber(parms.latitude) >= -90 and tonumber(parms.latitude) <= 90 and tonumber(parms.longitude) >= -180 and tonumber(parms.longitude) <= 180 then
-                cursor:set("aredn", "@location[0]", "lat", parms.latitude)
-                cursor:set("aredn", "@location[0]", "lon", parms.longitude)
+                cursora:set("aredn", "@location[0]", "lat", parms.latitude)
+                cursorb:set("aredn", "@location[0]", "lat", parms.latitude)
+                cursora:set("aredn", "@location[0]", "lon", parms.longitude)
+                cursorb:set("aredn", "@location[0]", "lon", parms.longitude)
                 out("Lat/lon updated.")
             else
                 err("ERROR: Lat/lon values must be between -90/90 and -180/180, respectively.")
@@ -480,11 +480,14 @@ if parms.button_updatelocation then
             err("ERROR: Lat/lon format is decimal: (ex. 30.121456 or -95.911154).")
         end
     else
-        cursor:set("aredn", "@location[0]", "lat", "")
-        cursor:set("aredn", "@location[0]", "lon", "")
+        cursora:set("aredn", "@location[0]", "lat", "")
+        cursorb:set("aredn", "@location[0]", "lat", "")
+        cursora:set("aredn", "@location[0]", "lon", "")
+        cursorb:set("aredn", "@location[0]", "lon", "")
         out("Lat/lon purged.")
     end
-    aredn_clone()
+    cursora:commit("aredn")
+    cursorb:commit("aredn")
 end
 
 -- retrieve location data


### PR DESCRIPTION
Remove the potentially problematic 'filecopy("/etc/config/aredn", "/etc/config.mesh/aredn")'

/etc/config.mesh/aredn sometimes gets truncated, although reproducing it is difficult. This
is one of the few (only?) places this file is mindlessly written to, so instead use cursors to update it.

https://github.com/aredn/aredn/issues/253