### PR TITLE
Fix broken cursor use.

### DIFF
--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -245,8 +245,8 @@ function msg(m)
 end
 
 -- uci cursor
-local cursora = uci:cursor()
-local cursorb = uci:cursor("/etc/config.mesh")
+local cursora = uci.cursor()
+local cursorb = uci.cursor("/etc/config.mesh")
 function cursor_set(a, b, c, d)
     if not cursora:get(a, b) and b:match("@(.+)%[0%]") then
         cursora:add(a, b:match("@(.+)%[0%]"))


### PR DESCRIPTION
Was using 'uci:cursor' and not 'uci.cursor' which appears to work but
actually breaks config files causing them to be truncated.
https://github.com/aredn/aredn/issues/253