### PR TITLE
Network fixes for older nodes using bridges

### DIFF
--- a/files/usr/lib/lua/aredn/hardware.lua
+++ b/files/usr/lib/lua/aredn/hardware.lua
@@ -128,7 +128,7 @@ function hardware.get_iface_name(name)
     end
     local intfname = cursor:get("network", name, "ifname")
     if intfname then
-        return intfname
+        return intfname:match("^(%S+)")
     end
     -- Now we guess
     if name == "lan" then
@@ -145,6 +145,30 @@ function hardware.get_iface_name(name)
     end
     -- Maybe the board knows
     return hardware.get_board().network[name].ifname:match("^(%S+)")
+end
+
+function hardware.get_bridge_iface_names(name)
+    local cursor = uci.cursor()
+    local btype = cursor:get("network", name, "type")
+    local intfnames = cursor:get("network", name, "ifname")
+    if intfnames then
+        return intfnames
+    end
+    -- Now we guess
+    if name == "lan" then
+        return "eth0"
+    end
+    if name == "wan" then
+        return "eth0.1"
+    end
+    if name == "wifi" then
+        return "wlan0"
+    end
+    if name == "dtdlink" then
+        return "eth0.2"
+    end
+    -- Maybe the board knows
+    return hardware.get_board().network[name].ifname
 end
 
 function hardware.get_link_led()
@@ -235,7 +259,7 @@ end
 function hardware.get_interface_mac(intf)
     local mac = ""
     if intf then
-        local f = io.popen("ifconfig " .. intf)
+        local f = io.popen("ifconfig " .. intf .. " 2>/dev/null")
         for line in f:lines()
         do
             local m = line:match("HWaddr ([%w:]+)")

--- a/files/usr/lib/lua/aredn/hardware.lua
+++ b/files/usr/lib/lua/aredn/hardware.lua
@@ -149,7 +149,6 @@ end
 
 function hardware.get_bridge_iface_names(name)
     local cursor = uci.cursor()
-    local btype = cursor:get("network", name, "type")
     local intfnames = cursor:get("network", name, "ifname")
     if intfnames then
         return intfnames

--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -452,6 +452,9 @@ end
 
 function mac_to_ip(mac, shift)
     local a, b, c = mac:match("%w%w:%w%w:%w%w:(%w%w):(%w%w):(%w%w)")
+	if not a then
+		return "0.0.0"
+	end
     return string.format("%d.%d.%d", tonumber(a, 16), tonumber(b, 16), tonumber(c, 16))
 end
 

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -81,11 +81,11 @@ if not (config == "mesh" and nixio.fs.access("/etc/config.mesh/_setup", "r")) th
     return -1
 end
 
-local lanintf = aredn.hardware.get_board().network.lan.ifname:match("^(%S+)")
+local lanintf = aredn.hardware.get_board().network.lan.ifname
 local node = aredn_info.get_nvram("node")
 local tactical = aredn_info.get_nvram("tactical")
 local mac2 = mac_to_ip(aredn.hardware.get_interface_mac(aredn.hardware.get_iface_name("wifi")), 0)
-local dtdmac = mac_to_ip(aredn.hardware.get_interface_mac(lanintf), 0) -- *not* based of dtdlink
+local dtdmac = mac_to_ip(aredn.hardware.get_interface_mac(lanintf:match("^(%S+)")), 0) -- *not* based of dtdlink
 
 local deleteme = {}
 local cfg = {
@@ -112,7 +112,7 @@ do
 end
 
 if cfg.wifi_enable == "1" then
-    cfg.wifi_intf = aredn.hardware.get_board().network.wifi.ifname
+    cfg.wifi_intf = aredn.hardware.get_board().network.wifi.ifname:match("^(%S+)")
 else
     cfg.wifi_intf = cfg.dtdlink_intf:match("([%w]*)") .. ".3975"
 end

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -91,7 +91,7 @@ local deleteme = {}
 local cfg = {
     lan_intf = lanintf,
     wan_intf = "dummy",
-    dtdlink_intf = aredn.hardware.get_iface_name('dtdlink')
+    dtdlink_intf = aredn.hardware.get_bridge_iface_names('dtdlink')
 }
 
 if not auto then
@@ -114,7 +114,7 @@ end
 if cfg.wifi_enable == "1" then
     cfg.wifi_intf = aredn.hardware.get_board().network.wifi.ifname:match("^(%S+)")
 else
-    cfg.wifi_intf = cfg.dtdlink_intf:match("([%w]*)") .. ".3975"
+    cfg.wifi_intf = lanintf:match("^([^%.%s]+).*$") .. ".3975"
 end
 
 -- delete some config lines if necessary


### PR DESCRIPTION
Well ... Joe @ae6xe  did warn me this was more complicated than I through ... so here we are.

Some nodes assign multiple ethernet devices to each "virtual" device (e.g. lan, wan, etc.) are much of this code didn't understand this. A earlier fix solved some of these issue, but didn't add all the ethernet to bridges correctly.

Also broken was the creation of the dtdlink which can also be a bridge, even if only one device is attached to it.

I suspect more subtleties will be discovered here, but for now this solves known problems with older NSM2/5 devices.