### PR TITLE
Fix url format for no-link service names

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -434,7 +434,7 @@ if sf then
                     if proto == "" then
                         proto = "http"
                     end
-                    if link == "" then
+                    if link == "0" then
                         port = "0"
                     end
                     sf:write(string.format("%s://%s:%s/%s|tcp|%s\n", proto, host, port, sffx, name))


### PR DESCRIPTION
Service names, which were not links, were being saved with a missing port number - breaks advertising them