### PR TITLE
Dont truncate /etc/config/vtun on tunnel install

### DIFF
--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -179,7 +179,7 @@ function install_vtun()
     os.execute("cat /etc/config.mesh/network_tun >> /etc/config.mesh/network")
     os.execute("cat /etc/config.mesh/network_tun >> /etc/config/network")
 
-    io.open("/etc/config/vtun", "w"):close()
+    io.open("/etc/config/vtun", "a"):close()
     cursor:add("vtun", "options")
     cursor:add("vtun", "network")
     cursor:commit("vtun")

--- a/files/www/cgi-bin/vpnc
+++ b/files/www/cgi-bin/vpnc
@@ -164,7 +164,7 @@ function install_vtun()
     os.execute("cat /etc/config.mesh/network_tun >> /etc/config.mesh/network")
     os.execute("cat /etc/config.mesh/network_tun >> /etc/config/network")
 
-    io.open("/etc/config/vtun", "w"):close()
+    io.open("/etc/config/vtun", "a"):close()
     cursor:add("vtun", "options")
     cursor:add("vtun", "network")
     cursor:commit("vtun")


### PR DESCRIPTION
Create /etc/config/vtun if it doesn't exist, but don't truncate it if it does.