### PR TITLE
Fix tunnel display order

### DIFF
--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -210,23 +210,19 @@ end
 local gci_vars = { "enabled", "name", "passwd", "netip", "contact" }
 function get_client_info()
     local c = 0
-    local all = cursor:get_all("vtun")
-    if all then
-        for _, myclient in pairs(all)
-        do
-            if myclient[".type"] == "client" then
-                for _, var in ipairs(gci_vars)
-                do
-                    local key = "client" .. c .. "_" .. var
-                    parms[key] = myclient[var]
-                    if not parms[key] then
-                        parms[key] = ""
-                    end
+    cursor:foreach("vtun", "client",
+        function(section)
+            for _, var in ipairs(gci_vars)
+            do
+                local key = "client" .. c .. "_" .. var
+                parms[key] = section[var]
+                if not parms[key] then
+                    parms[key] = ""
                 end
-                c = c + 1
             end
+            c = c + 1
         end
-    end
+    )
     parms.client_num = c
 end
 

--- a/files/www/cgi-bin/vpnc
+++ b/files/www/cgi-bin/vpnc
@@ -194,23 +194,19 @@ end
 local gci_vars = { "enabled", "host", "passwd", "netip", "contact" }
 function get_connection_info()
     local c = 0
-    local conns = cursor:get_all("vtun")
-    if conns then
-        for _, myconn in pairs(conns)
-        do
-            if myconn[".type"] == "server" then
-                for _, var in ipairs(gci_vars)
-                do
-                    local key = "conn" .. c .. "_" .. var
-                    parms[key] = myconn[var]
-                    if not parms[key] then
-                        parms[key] = ""
-                    end
+    cursor:foreach("vtun", "server",
+        function(section)
+            for _, var in ipairs(gci_vars)
+            do
+                local key = "conn" .. c .. "_" .. var
+                parms[key] = section[var]
+                if not parms[key] then
+                    parms[key] = ""
                 end
-                c = c + 1
             end
+            c = c + 1
         end
-    end
+    )
     parms.conn_num = c
 end
 


### PR DESCRIPTION
Previous way of retrieving tunnels produced a non-deterministic order. Switch to version with is ordered.
https://github.com/aredn/aredn/issues/283