### PR TITLE
Single quote can kill the uci format if they make it into values. Switch them.

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -873,8 +873,9 @@ function calcDistance(x) {
 
 function doSubmit() {
     var desc_text = document.mainForm.description_node.value;
-    var singleLine = desc_text.replace(new RegExp( "\\n", "g" ), " ");
+    var singleLine = desc_text.replace(new RegExp( "\\n", "g" ), " ").replace(new RegExp( "'", "g" ), "");
     document.mainForm.description_node.value = singleLine;
+    document.mainForm.nodetac.value = document.mainForm.nodetac.value.replace(new RegExp( "'", "g" ), "");
     return true;
 }
 

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -873,9 +873,9 @@ function calcDistance(x) {
 
 function doSubmit() {
     var desc_text = document.mainForm.description_node.value;
-    var singleLine = desc_text.replace(new RegExp( "\\n", "g" ), " ").replace(new RegExp( "'", "g" ), "");
+    var singleLine = desc_text.replace(new RegExp( "\\n", "g" ), " ").replace(new RegExp( "'", "g" ), "`");
     document.mainForm.description_node.value = singleLine;
-    document.mainForm.nodetac.value = document.mainForm.nodetac.value.replace(new RegExp( "'", "g" ), "");
+    document.mainForm.nodetac.value = document.mainForm.nodetac.value.replace(new RegExp( "'", "g" ), "`");
     return true;
 }
 


### PR DESCRIPTION
Strings in UCI file are single quoted. If we add strings to these files which also contains extra single quotes then things break as the files become unreadable.

Ideally the Lua UCI library would escape this sort of thing or at least tolerate it, but that does not appear to be the case so the simplest thing is to switch them to a different character (a back quote). It's not an ideal fix so I'm going to leave myself a note to go through all the code later to sanity check where this might become an issue. For now, this fixes the use-case which has been flagged to me. An alternative (my first thought) was to simply remove them. This is probably a better visual fix.

Interesting the command line tools (which the perl code uses) has no problems with this - just the lua uci library.