### PR TITLE
Quote escapes (take 2)

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -681,6 +681,9 @@ if parms.button_save then
         parms.wifi3_key = s2h(wifi3_key)
         parms.wifi3_ssid = s2h(wifi3_ssid)
 
+        -- escape and limit description
+        parms.description_node = parms.description_node:sub(1,210):gsub('"',"&quot;"):gsub("'","&apos;"):gsub("<","&lt;"):gsub(">","&gt;")
+
         -- save_setup
         local f = io.open("/etc/config.mesh/_setup", "w")
         if f then

--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -242,7 +242,7 @@ if config == "" or nixio.fs.stat("/tmp/reboot-required") then
     html.alert_banner()
     html.print("<table width=790><tr><td>")
     navbar();
-    hrml.print("</td></tr><tr><td align=center><br>")
+    html.print("</td></tr><tr><td align=center><br>")
     if config == "" then
         html.print("<b>This page is not available until the configuration has been set.</b>")
     else
@@ -330,6 +330,8 @@ do
                 parms[varname] = "0"
             elseif not parms[varname] then
                 parms[varname] = ""
+            elseif varname == "contact" then
+                parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", ""):sub(1,210):gsub('"',"&quot;"):gsub("'","&apos;"):gsub("<","&lt;"):gsub(">","&gt;")
             else
                 parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", "")
             end

--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -330,7 +330,7 @@ do
                 parms[varname] = "0"
             elseif not parms[varname] then
                 parms[varname] = ""
-            elseif varname == "contact" then
+            elseif var == "contact" then
                 parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", ""):sub(1,210):gsub('"',"&quot;"):gsub("'","&apos;"):gsub("<","&lt;"):gsub(">","&gt;")
             else
                 parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", "")

--- a/files/www/cgi-bin/vpnc
+++ b/files/www/cgi-bin/vpnc
@@ -226,7 +226,7 @@ if config == "" or nixio.fs.stat("/tmp/reboot-required") then
     html.alert_banner()
     html.print("<table width=790>")
     navbar();
-    hrml.print("</td></tr><tr><td align=center><br>")
+    html.print("</td></tr><tr><td align=center><br>")
     if config == "" then
         html.print("<b>This page is not available until the configuration has been set.</b>")
     else
@@ -325,6 +325,8 @@ do
                 parms[varname] = "0"
             elseif not parms[varname] then
                 parms[varname] = ""
+            elseif varname == "contact" then
+                parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", ""):sub(1,210):gsub('"',"&quot;"):gsub("'","&apos;"):gsub("<","&lt;"):gsub(">","&gt;")
             else
                 parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", "")
             end

--- a/files/www/cgi-bin/vpnc
+++ b/files/www/cgi-bin/vpnc
@@ -325,7 +325,7 @@ do
                 parms[varname] = "0"
             elseif not parms[varname] then
                 parms[varname] = ""
-            elseif varname == "contact" then
+            elseif var == "contact" then
                 parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", ""):sub(1,210):gsub('"',"&quot;"):gsub("'","&apos;"):gsub("<","&lt;"):gsub(">","&gt;")
             else
                 parms[varname] = parms[varname]:gsub("^%s+", ""):gsub("%s+$", "")


### PR DESCRIPTION
Copy over the perl escapes for the node descriptions and contact information.
The perl code explicitly escapes certain fields and this was not reflected in the lua code - now it is.

Also, fixed a couple of typos.