### PR TITLE
Fix typo in iperf fw restart patch.

### DIFF
--- a/patches/709-iperf-fw-restart.patch
+++ b/patches/709-iperf-fw-restart.patch
@@ -19,7 +19,7 @@ Index: openwrt/package/network/utils/iperf3/Makefile
 +	$(INSTALL_BIN) ./files/iperf.firewall $(1)/etc/local/mesh-firewall/20-iperf3
 +endef
 +
-+define Package/iperf/postinst
++define Package/iperf3/postinst
 +#!/bin/sh
 +# check if we are on real system
 +if [ -z "$${IPKG_INSTROOT}" ]; then


### PR DESCRIPTION
The iperf3 package installs a firewall rule, but the script to restart
the firewall on install had a typo meaning it wasn't called. Instead the
new firewall setup required and otherwise unnecessary reboot.