### PR TITLE
Add /var/run/services_olsr to support tool data

### DIFF
--- a/files/www/cgi-bin/supporttool
+++ b/files/www/cgi-bin/supporttool
@@ -53,6 +53,7 @@ local files = {
     "/etc/mesh-release",
     "/tmp/etc/",
     "/var/run/hosts_olsr",
+    "/var/run/services_olsr",
     "/tmp/rssi.dat",
     "/tmp/rssi.log",
     "/tmp/zombie.log",


### PR DESCRIPTION
Had to request this file by-hand during the debugging process for some nodes, so add it by default.

This file wasn't included in the old perl version.