### PR TITLE
build: github no longer supports the git protocol - use https

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,1 +1,1 @@
-src-git arednpackages git://github.com/aredn/aredn_packages;develop
+src-git arednpackages https://github.com/aredn/aredn_packages;develop


### PR DESCRIPTION
received "The unauthenticated git protocol on port 9418 is no longer supported" error.
Changed to https in feeds.conf