### PR TITLE
Modify the style sheet URL to let the browser cache

### DIFF
--- a/files/usr/lib/lua/aredn/html.lua
+++ b/files/usr/lib/lua/aredn/html.lua
@@ -48,13 +48,15 @@ function html.header(title, close)
     html.print("<meta name='robots' content='noindex'>")
 
     -- set up the style sheet
-    if not nixio.fs.stat("/tmp/web") then
-        nixio.fs.mkdir("/tmp/web")
+    local link = nixio.fs.readlink("/tmp/web/style.css")
+    if not link then
+        if not nixio.fs.stat("/tmp/web") then
+            nixio.fs.mkdir("/tmp/web")
+        end
+        link = "/www/aredn.css"
+        nixio.fs.symlink(link, "/tmp/web/style.css")
     end
-    if not nixio.fs.readlink("/tmp/web/style.css") then
-        nixio.fs.symlink("/www/aredn.css", "/tmp/web/style.css")
-    end
-    html.print("<link id='stylesheet_css' rel=StyleSheet href='/style.css?" .. os.time() .. "' type='text/css'>")
+    html.print("<link id='stylesheet_css' rel=StyleSheet href='/style.css?_=" .. link .. "' type='text/css'>")
     if close then
         html.print("</head>")
     end


### PR DESCRIPTION
Modify the style sheet URL to let the browser cache while still supporting switching the style.
He old code appended the time which made it simple to switch styles on the node, but forced everyone to reload the stylesheet every time. Now append the actual style after the ? in the url, so we cache the style and let it be switched.