### PR TITLE
Migrate LeafletJS to new URL

### DIFF
--- a/files/etc/config.mesh/aredn
+++ b/files/etc/config.mesh/aredn
@@ -8,8 +8,8 @@ config usb
 		option passthrough '1'
 
 config map
-        option leafletjs 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js'
-        option leafletcss 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css'
+        option leafletjs 'http://unpkg.com/leaflet@0.7.7/dist/leaflet.js'
+        option leafletcss 'http://unpkg.com/leaflet@0.7.7/dist/leaflet.css'
         option maptiles 'http://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg'
 
 config meshstatus

--- a/files/etc/config/system
+++ b/files/etc/config/system
@@ -21,6 +21,6 @@ config button
         option max '20'
 
 config map
-        option leafletjs 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js'
-        option leafletcss 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css'
+        option leafletjs 'http://unpkg.com/leaflet@0.7.7/dist/leaflet.js'
+        option leafletcss 'http://unpkg.com/leaflet@0.7.7/dist/leaflet.css'
         option maptiles 'http://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg'

--- a/files/etc/uci-defaults/95_aredn_migrate_leafletjs
+++ b/files/etc/uci-defaults/95_aredn_migrate_leafletjs
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ "$(/sbin/uci -c /etc/config.mesh -q get aredn.@map[0].leafletjs)" = "http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js" ]; then
+    /sbin/uci -c /etc/config.mesh -q set aredn.@map[0].leafletjs="http://unpkg.com/leaflet@0.7.7/dist/leaflet.js"
+    /sbin/uci -c /etc/config.mesh -q set aredn.@map[0].leafletcss="http://unpkg.com/leaflet@0.7.7/dist/leaflet.css"
+    /sbin/uci -c /etc/config.mesh -q commit aredn
+fi

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -89,13 +89,13 @@ local settings = {
         key = "aredn.@map[0].leafletcss",
         type = "string",
         desc = "Specifies the URL of the leaflet.css file",
-        default = "http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css"
+        default = "http://unpkg.com/leaflet@0.7.7/dist/leaflet.css"
     },
     {
         key = "aredn.@map[0].leafletjs",
         type = "string",
         desc = "Specifies the URL of the leaflet.js file",
-        default = "http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"
+        default = "http://unpkg.com/leaflet@0.7.7/dist/leaflet.js"
     },
     {
         key = "aredn.@downloads[0].firmwarepath",


### PR DESCRIPTION
The old LeafletJS CDN is dead. Migrate to the new approved URL.
Note. I don't know what the old URL did, but the new one, while specified as http:, will direct to https: when
used. Something to be aware of.