### PR TITLE
Make sure we copy /etc/config/vtun to /etc/config.mesh/vtun when installing tunnels

### DIFF
--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -183,6 +183,7 @@ function install_vtun()
     cursor:add("vtun", "options")
     cursor:add("vtun", "network")
     cursor:commit("vtun")
+    write_all("/etc/config.mesh/vtun", read_all("/etc/config/vtun"))
 
     http_header()
     html.header("TUNNEL INSTALLATION IN PROGRESS", true)

--- a/files/www/cgi-bin/vpnc
+++ b/files/www/cgi-bin/vpnc
@@ -168,6 +168,7 @@ function install_vtun()
     cursor:add("vtun", "options")
     cursor:add("vtun", "network")
     cursor:commit("vtun")
+    write_all("/etc/config.mesh/vtun", read_all("/etc/config/vtun"))
 
     http_header()
     html.header("TUNNEL INSTALLATION IN PROGRESS", true)


### PR DESCRIPTION
Make sure we copy /etc/config/vtun to /etc/config.mesh/vtun when installing tunnels.

While this copy process happens when tunnels are edited, if we install tunnels and then
leave the page and do something on the setup page, /etc/config/vtun will be lost because
/etc/config.mesh/vtun was never created for 'node-setup' to find and copy.