### PR TITLE
Automatically update package dependencies if package install fails

### DIFF
--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -567,11 +567,20 @@ if nixio.fs.stat("/etc/permpkg") then
     end
 end
 
+local meshpkgs = capture("grep -q \".local.mesh\" /etc/opkg/distfeeds.conf"):chomp()
+
 -- upload package
 if parms.button_ul_pkg and nixio.fs.stat("/tmp/web/upload/file") then
     os.execute("mv -f /tmp/web/upload/file /tmp/web/upload/newpkg.ipk")
     os.execute("/usr/local/bin/uploadctlservices opkginstall > /dev/null 2>&1")
-    pkgout(capture("opkg -force-overwrite install /tmp/web/upload/newpkg.ipk 2>&1"))
+    local result = capture("opkg -force-overwrite install /tmp/web/upload/newpkg.ipk 2>&1")
+    if result:match("satisfy_dependencies_for:") then
+        -- dependency failure - silently update dependencies and try again
+        os.execute("opkg update > /dev/null 2>&1")
+        os.execute("opkg list | grep -v '^ ' | cut -f1,3 -d' ' | gzip -c > /etc/opkg.list.gz")
+        result = capture("opkg -force-overwrite install /tmp/web/upload/newpkg.ipk 2>&1")
+    end
+    pkgout(result)
     os.execute("rm -rf /tmp/opkg-*")
     nixio.fs.remove("/tmp/web/upload/newpkg.ipk")
     if os.execute("/usr/local/bin/uploadctlservices restore > /dev/null 2>&1") ~= 0 then
@@ -580,7 +589,6 @@ if parms.button_ul_pkg and nixio.fs.stat("/tmp/web/upload/file") then
 end
 
 -- download package
-local meshpkgs = capture("grep -q \".local.mesh\" /etc/opkg/distfeeds.conf"):chomp()
 if parms.button_dl_pkg and parms.dl_pkg ~= "default" then
     if get_default_gw() ~= "none" or meshpkgs ~= "" then
         os.execute("/usr/local/bin/uploadctlservices opkginstall > /dev/null 2>&1")


### PR DESCRIPTION
When uploading a package by hand which depends on an uninstalled system package, unless the packages have been updated since boot, the install will fail. This can be particularly confusing because we persist the downloadable package list across reboots but opkg itself does not keep its internal dependency list. Instead detect the dependency failure, update the package list, and try again.