### PR TITLE
Add periodic tasks in the style of cron hourly, daily and weekly scripts

### DIFF
--- a/files/usr/local/bin/manager.lua
+++ b/files/usr/local/bin/manager.lua
@@ -68,7 +68,8 @@ local tasks = {
 	{ app = require("mgr.watchdog") },
 	{ app = require("mgr.fccid") },
 	{ app = require("mgr.snrlog") },
-	{ app = require("mgr.aredn_message") }
+	{ app = require("mgr.aredn_message") },
+	{ app = require("mgr.periodic") }
 }
 
 local log = aredn.log.open("/tmp/manager.log", 8000)

--- a/files/usr/local/bin/manager.lua
+++ b/files/usr/local/bin/manager.lua
@@ -60,17 +60,15 @@ function exit_app()
 	coroutine.yield('exit')
 end
 
--- Define the list of management task
-local tasks = {
-	{ app = require("mgr.rssi_monitor") },
-	{ app = require("mgr.linkled") },
-	{ app = require("mgr.namechange") },
-	{ app = require("mgr.watchdog") },
-	{ app = require("mgr.fccid") },
-	{ app = require("mgr.snrlog") },
-	{ app = require("mgr.aredn_message") },
-	{ app = require("mgr.periodic") }
-}
+-- Load management tasks
+local tasks = {}
+for name in nixio.fs.dir("/usr/local/bin/mgr")
+do
+	local task = name:match("^(.+)%.lua$")
+	if task then
+		tasks[#tasks + 1] = { app = require("mgr." .. task) }
+	end
+end
 
 local log = aredn.log.open("/tmp/manager.log", 8000)
 

--- a/files/usr/local/bin/mgr/periodic.lua
+++ b/files/usr/local/bin/mgr/periodic.lua
@@ -1,0 +1,70 @@
+--[[
+
+	Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+	Copyright (C) 2021 Tim Wilkinson
+	Original Shell Copyright (C) 2015 Conrad Lara
+	See Contributors file for additional contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+	Additional Terms:
+
+	Additional use restrictions exist on the AREDN(TM) trademark and logo.
+		See AREDNLicense.txt for more info.
+
+	Attributions to the AREDN Project must be retained in the source code.
+	If importing this code into a new or existing project attribution
+	to the AREDN project must be added to the source code.
+
+	You must not misrepresent the origin of the material contained within.
+
+	Modified versions must be modified to attribute to the original source
+	and be marked in reasonable ways as differentiate it from the original
+	version
+
+--]]
+
+function run_scripts(dir)
+    if nixio.fs.stat(dir, "type") == "dir" then
+        for script in nixio.fs.dir(dir)
+        do
+            local stat = nixio.fs.stat(dir .. "/" .. script)
+            if script:match("^[a-zA-Z0-9_%-]+$") and stat.type == "reg" and nixio.bit.band(tonumber(stat.modedec, 8), tonumber(111, 8)) ~= 0 then
+                os.execute("(cd /tmp;" .. dir .. "/" .. script .. " 2>&1 | logger -p daemon.debug -t " .. script .. ")&")
+            end
+        end
+    end
+end
+
+function periodic()
+    wait_for_ticks(120) -- Initial wait before starting up period tasks
+    local hours = 0
+    local days = 0
+    while true
+    do
+        run_scripts("/etc/cron.hourly")
+        hours = hours - 1
+        if hours <= 0 then
+            run_scripts("/etc/cron.daily")
+            hours = 24
+            days = days - 1
+            if days <= 0 then
+                run_scripts("/etc/cron.weekly")
+                days = 7
+            end
+        end
+        wait_for_ticks(60 * 60)
+    end
+end
+
+return periodic


### PR DESCRIPTION
Allows user and/or packages to install cron scripts which will be run approximately every hour, day, or week.

A use for something like this came up while I was looking at the mesh ntpd stuff and I really wanted to a way to
refresh the peer list every now and again. Obviously having a daemon hanging around just to do this is very wasteful.
This is a simple alternative which is already familiar to Debian developers. Script are installed in the relevant /etc/cron.X directory and run on the appropriate schedule.