### PR TITLE
Fix displaying "Previous neighbors" with empty hostnames

### DIFF
--- a/files/usr/local/bin/mgr/namechange.lua
+++ b/files/usr/local/bin/mgr/namechange.lua
@@ -93,15 +93,9 @@ function do_namechange()
     if nixio.fs.stat("/tmp/node.history") then
         for line in io.lines("/tmp/node.history")
         do
-            local v = line:splitWhiteSpace()
-            local ip = v[1]
-            local age = 0
-            if v[2] then
-                age = math.floor(v[2])
-            end
-            local name = v[3]
-            if age and not history[ip] and uptime - age < 86400 then
-                history[ip] = { age = age, name = name or "" }
+            local ip, age, name = line:match("^(%S*) (%d+) +(.*)$")
+            if ip and age and not history[ip] and uptime - tonumber(age) < 86400 then
+                history[ip] = { age = age, name = name }
             end
         end
     end
@@ -111,7 +105,7 @@ function do_namechange()
     if f then
         for k,v in pairs(history)
         do
-            f:write(string.format("%s %d %s\n", k, v.age, v.name))
+            f:write(k .. " " .. v.age .. " " .. v.name .. "\n")
         end
         f:close()
     end

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -729,7 +729,7 @@ do
     if not (links[ip] or links[ipalias[ip]]) then
         local age = uptime - tonumber(node.age)
         local host = node.host
-        if not host then
+        if host == "" then
             host = ip
         else
             host = host:gsub("^mid%d+%.", ""):gsub("^dtdlink%.", "")

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -399,7 +399,7 @@ end
 if nixio.fs.stat("/tmp/node.history") then
     for line in io.lines("/tmp/node.history")
     do
-        local ip, age, host = line:match("^(.+) (%d+) (.*)")
+        local ip, age, host = line:match("^(%S+) (%d+) (%S+)")
         if ip and age and host then
             history[ip] = { age = age, host = host:gsub("/", " / ") }
         end


### PR DESCRIPTION
Neighbors names can be missing and we were just displaying blanks when this happened. Instead we now display IP addresses (as we should have originally).
Also fixed a few other bugs related to the upkeep of this information.