### PR TITLE
Support changing the VLAN tag on WAN

### DIFF
--- a/files/usr/local/bin/aredn_postupgrade
+++ b/files/usr/local/bin/aredn_postupgrade
@@ -107,7 +107,7 @@ do
 end
 
 -- specific settings for variables that are not in the default config but are added by the system
-for _, key in ipairs({ 'dmz_dhcp_end', 'dmz_dhcp_limit', 'dmz_dhcp_start', 'dmz_lan_ip', 'dmz_lan_mask', 'wifi_rxant', 'wifi_txant', 'wan_gw', 'wan_ip', 'wan_mask' })
+for _, key in ipairs({ 'dmz_dhcp_end', 'dmz_dhcp_limit', 'dmz_dhcp_start', 'dmz_lan_ip', 'dmz_lan_mask', 'wifi_rxant', 'wifi_txant', 'wan_gw', 'wan_ip', 'wan_mask', 'wan_intf' })
 do
     local v = cfg[key]
     if v then

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -90,7 +90,7 @@ local dtdmac = mac_to_ip(aredn.hardware.get_interface_mac(lanintf:match("^(%S+)"
 local deleteme = {}
 local cfg = {
     lan_intf = lanintf,
-    wan_intf = "dummy",
+    wan_intf = aredn.hardware.get_board().network.wan.ifname,
     dtdlink_intf = aredn.hardware.get_bridge_iface_names('dtdlink')
 }
 

--- a/files/usr/local/bin/wifi-setup
+++ b/files/usr/local/bin/wifi-setup
@@ -55,14 +55,6 @@ done < $configfile
 meshif="$(uci -q get network.wifi.ifname)"
 meshphy="phy${meshif#wlan}"
 
-# set physical wan interface in network
-
-wan_intf=`cat /etc/board.json|jsonfilter -e '@.network.wan.ifname'`
-uci -c ${dropdir} -q batch > /dev/null <<-EOF
-set network.wan.ifname="$wan_intf"
-EOF
-uci -c ${dropdir} -q commit network
-
 rm -f "${dropdir}/wireless" 
 touch "${dropdir}/wireless"
 

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -212,12 +212,13 @@ local settings = {
         default = "1000"
     },
     {
-        key = "network.wan.ifname",
+        key = "aredn.wan.vlanid",
         type = "string",
-        desc = "Specify WAN interface VLAN #. MUST be entered as ethX.YY where X is the interface (usually '0') and YY is the VLAN # to use.",
+        desc = "Specify WAN VLAN #",
         default = "",
         condition = "supportsVLANChange()",
-        postcallback = "postChangeWANVLAN()",
+        current = "currentWANVLAN()",
+        postcallback = "changeWANVLAN()",
         needreboot = true
     },
     {
@@ -463,7 +464,22 @@ function adjustTunnelInterfaceCount()
     end
 end
 
-function postChangeWANVLAN()
+function currentWANVLAN()
+    for line in io.lines("/etc/config.mesh/_setup")
+    do
+        local vlan = line:match("^wan_intf = %w+%d+%.(%d+)")
+        if vlan then
+            return vlan
+        end
+    end
+    local vlan = aredn.hardware.get_board().network.wan.ifname:match("^%w+%.(%d+)")
+    if vlan then
+        return vlan
+    end
+    return ""
+end
+
+function changeWANVLAN()
     local lines = {}
     for line in io.lines("/etc/config.mesh/_setup")
     do
@@ -472,7 +488,14 @@ function postChangeWANVLAN()
         end
     end
     if newval ~= "" then
-        lines[#lines + 1] = "wan_intf = " .. newval
+        local wan_intf = ""
+        for dev in aredn.hardware.get_board().network.wan.ifname:gmatch("%S+")
+        do
+            wan_intf = wan_intf .. " " .. dev:match("^([^%.]+)") .. "." .. newval
+        end
+        if wan_intf ~= "" then
+            lines[#lines + 1] = "wan_intf =" .. wan_intf
+        end
     end
     local f = io.open("/etc/config.mesh/_setup", "w")
     if f then
@@ -674,8 +697,13 @@ html.print([[
 for i, setting in ipairs(settings)
 do
     if not setting.condition or loadstring("return " .. setting.condition)() then
-        local a, b, c = setting.key:match("(.+)%.(.+)%.(.*)")
-        local sval = cursor_get(a, b, c)
+        local sval
+        if setting.current then
+            sval = loadstring("return " .. setting.current)()
+        else
+            local a, b, c = setting.key:match("(.+)%.(.+)%.(.*)")
+            sval = cursor_get(a, b, c)
+        end
         sval = sval and tostring(sval) or ""
         html.print([[<tr><td align="center"><span title="]] .. setting.desc .. [["><img src="/qmark.png" /></span></td><td>]] .. setting.key .. [[</td><td>]])
         if setting.type == "string" then

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -196,7 +196,8 @@ local settings = {
         key = "aredn.@tunnel[0].wanonly",
         type = "boolean",
         desc = "Prevents tunnel traffic from being routed over the mesh network itself.",
-        default = "1"
+        default = "1",
+        needreboot= true
     },
     {
         key = "aredn.@meshstatus[0].lowmem",
@@ -209,6 +210,14 @@ local settings = {
         type = "string",
         desc = "When low memory is detected, limit the number of routes shown on the mesh status page",
         default = "1000"
+    },
+    {
+        key = "network.wan.ifname",
+        type = "string",
+        desc = "Specify WAN interface VLAN #. MUST be entered as ethX.YY where X is the interface (usually '0') and YY is the VLAN # to use.",
+        default = "",
+        postcallback = "postChangeWANVLAN()",
+        needreboot = true
     },
     {
         key = "aredn.olsr.restart",
@@ -234,7 +243,8 @@ local settings = {
         key = "aredn.@alerts[0].pollrate",
         type = "string",
         desc = "Specifies how many hours to wait between polling for new AREDN Alerts.",
-        default = "12"
+        default = "12",
+        needreboot = true
     },
     {
         key = "aredn.aam.purge",
@@ -446,6 +456,28 @@ function adjustTunnelInterfaceCount()
     end
 end
 
+function postChangeWANVLAN()
+    local lines = {}
+    for line in io.lines("/etc/config.mesh/_setup")
+    do
+        if not line:match("^wan_intf = ") then
+            lines[#lines + 1] = line
+        end
+    end
+    if newval ~= "" then
+        lines[#lines + 1] = "wan_intf = " .. newval
+    end
+    local f = io.open("/etc/config.mesh/_setup", "w")
+    if f then
+        for _, line in ipairs(lines)
+        do
+            f:write(line .. "\n")
+        end
+        f:close()
+    end
+    os.execute("/usr/local/bin/node-setup -a mesh")
+end
+
 -- read_postdata
 local parms = {}
 if os.getenv("REQUEST_METHOD") == "POST" then
@@ -495,6 +527,9 @@ do
         msg("Changed " .. key)
         if setting.postcallback then
             loadstring(setting.postcallback)()
+        end
+        if setting.needreboot then
+            io.open("/tmp/reboot-required", "w"):close()
         end
         break
     end
@@ -604,6 +639,10 @@ html.print("</tr></table><hr>")
 html.print("</td></tr>")
 
 html.print("<tr><td align=center><a href='/help.html#advancedconfig' target='_blank'>Help</a>&nbsp;&nbsp;<input type=submit name=button_reboot value=Reboot style='font-weight:bold' title='Immediately reboot this node'>&nbsp;&nbsp;<input type=submit name=button_firstboot value='Reset to Firstboot' onclick=\"return confirm('All config settings and add-on packages will be lost back to first boot state. Continue?')\"  title='Reset this node to the initial/firstboot status and reboot.'></td></tr>")
+
+if nixio.fs.stat("/tmp/reboot-required") then
+    html.print("<tr><td align=center><h3>Reboot is required for changes to take effect</h3></td></tr>")
+end
 
 for _, m in ipairs(msgs)
 do

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -216,6 +216,7 @@ local settings = {
         type = "string",
         desc = "Specify WAN interface VLAN #. MUST be entered as ethX.YY where X is the interface (usually '0') and YY is the VLAN # to use.",
         default = "",
+        condition = "supportsVLANChange()",
         postcallback = "postChangeWANVLAN()",
         needreboot = true
     },
@@ -358,6 +359,12 @@ end
 
 function hasUSB()
     return aredn.hardware.has_usb()
+end
+
+function supportsVLANChange()
+    -- We dont currently support VLAN changes on devices with switch chips
+    local stat = nixio.fs.stat("/etc/aredn_include/swconfig")
+    return not (stat and stat.size > 0)
 end
 
 -- callbacks

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -1310,6 +1310,7 @@ html.print("</select></td><td align=left>NTP Server</td><td><input type=text nam
 
 hidden[#hidden + 1] = "<input type=hidden name=reload value=1>"
 hidden[#hidden + 1] = "<input type=hidden name=dtdlink_ip value='" .. dtdlink_ip .. "'>"
+hidden[#hidden + 1] = "<input type=hidden name=wan_intf value='" .. (wan_intf or "") .. "'>"
 
 for _,hid in ipairs(hidden)
 do


### PR DESCRIPTION
Support changing the default VLAN tag for the WAN interface.
This comes up a bunch for people running complex networks (I had to buy a switch I use to specifically rewrite the VLAN tag of WANs) and providing this as an advance feature seems useful.
Also, added in a 'reboot' message for changing advance config options which need a reboot.