### PR TITLE
Add port dump to supporttool data

### DIFF
--- a/files/www/cgi-bin/supporttool
+++ b/files/www/cgi-bin/supporttool
@@ -86,6 +86,7 @@ local cmds = {
     "ip route list table main",
     "ip route list table default",
     "ip rule list",
+    "netstat -aln",
     "iwinfo",
     "iwinfo " .. wifiif .. " assoclist",
     phy and "iw phy " .. phy .. " info" or "",


### PR DESCRIPTION
It's seems that OLSRD doesn't always open all the appropriate ports, so it would be good to see when this happens. Not a fix, but helpful.