### PR TITLE
Run the iperf3 server by default [For discussion]

### DIFF
--- a/files/etc/init.d/iperf3
+++ b/files/etc/init.d/iperf3
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=91
+
+start_service() {
+    procd_open_instance iperf3
+    procd_set_param command /usr/bin/iperf3 -s -D
+    procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param pidfile /var/run/iperf3.pid
+    procd_set_param user root
+    procd_close_instance
+}

--- a/files/usr/local/bin/upgrade_prepare.sh
+++ b/files/usr/local/bin/upgrade_prepare.sh
@@ -37,7 +37,7 @@ LICENSE
 # ServiceName[:ServiceDaemon] pairs.
 # If ServiceDaemon is omitted, we wont first kill the daemon
 #
-SERVICES="dnsmasq:dnsmasq dropbear:dropbear urngd:urngd rpcd:rpcd telnet:telnetd manager:manager.lua log:logd"
+SERVICES="dnsmasq:dnsmasq dropbear:dropbear urngd:urngd rpcd:rpcd telnet:telnetd manager:manager.lua log:logd iperf3:iperf4"
 
 #
 # We unceremoniously kill services, and then stop them to prevent


### PR DESCRIPTION
Putting this up here for discussion. This change starts the iperf3 server on every node by default (rather than it just being installed).

Positive:
Having the running on every node makes it much easier to debug problematic network links and flakey nodes. Few people have iperfspeed installed (a UI for iperf3) making testing and finding bottlenecks on the network nearly impossible.

Negative:
Will people find it objectionable to have this running by default?

From personal experience, not having tools like this widely available on a network makes it very difficult to generate good data for fixing things. The SF mesh regularly goes through an identity crisis where people get frustrated with performance, threaten to burn everything down, but ultimately have no tools to make informed and useful choices. Things like this would help.