### PR TITLE
Tiny iperf3 UI [also for discussion]

### DIFF
--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -254,6 +254,12 @@ local settings = {
         desc = "Immediately purge/delete all AREDN (and local) Alerts from this node.",
         default = "",
         postcallback = "alert_purge()"
+    },
+    {
+        key = "aredn.@iperf[0].enable",
+        type = "boolean",
+        desc = "Enable the included iperf3 client/server support",
+        default = "1"
     }
 }
 

--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -39,17 +39,19 @@ require("aredn.http")
 require("luci.sys")
 require("aredn.html")
 
-local server = (os.getenv("QUERY_STRING") or ""):match("server=(.*)")
+local q = os.getenv("QUERY_STRING") or ""
+local server = q:match("server=([^&]*)")
+local protocol = q:match("protocol=([^&]*)") or "tcp"
 http_header()
 if uci.cursor():get("aredn", "@iperf[0]", "enable") == "0" then
     aredn.html.print("<html><head></head><body><pre>iperf is disabled</pre></body></html>")
 elseif not server then
-    aredn.html.print("<html><head></head><body><pre>Provide a server name to run a test between this client and a server [/cgi-bin/iperf?server=&lt;ServerName&gt;]</pre></body></html>")
+    aredn.html.print("<html><head></head><body><pre>Provide a server name to run a test between this client and a server [/cgi-bin/iperf?server=&lt;ServerName&gt;&amp;protocol=&lt;udp|tcp&gt;]</pre></body></html>")
 elseif server == "" then
     os.execute("killall iperf3; iperf3 -s -D -1")
     aredn.html.print("<html><head></head><body><pre>iperf server running (one time)</pre></body></html>")
 else
     luci.sys.httpget("http://" .. server .. ":8080/cgi-bin/iperf?server=")
-    aredn.html.print("<html><head><title>iperf</title></head><body><body><pre>" .. io.popen("/usr/bin/iperf3 -c " .. server .. " 2>&1"):read("*a") .. "</pre></body></html>")
+    aredn.html.print("<html><head><title>iperf</title></head><body><body><pre>" .. io.popen("/usr/bin/iperf3 -b 0 -c " .. server .. (protocol == "udp" and " -u" or "") .. " 2>&1"):read("*a") .. "</pre></body></html>")
 end
 http_footer()

--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -42,7 +42,7 @@ require("aredn.html")
 local q = os.getenv("QUERY_STRING") or ""
 local server = q:match("server=([^&]*)")
 local protocol = q:match("protocol=([^&]*)") or "tcp"
-http_header()
+http_header(true)
 if uci.cursor():get("aredn", "@iperf[0]", "enable") == "0" then
     aredn.html.print("<html><head></head><body><pre>iperf is disabled</pre></body></html>")
 elseif not server then
@@ -50,7 +50,12 @@ elseif not server then
 elseif server == "" then
     os.execute("killall iperf3; iperf3 -s -D -1")
     aredn.html.print("<html><head></head><body><pre>iperf server running (one time)</pre></body></html>")
+elseif server:match("[^%w-%.]") then
+    aredn.html.print("<html><head></head><body><pre>Illegal server name</pre></body></html>")
 else
+    if not server:match("%.") then
+      server = server .. ".local.mesh"
+    end
     luci.sys.httpget("http://" .. server .. ":8080/cgi-bin/iperf?server=")
     aredn.html.print("<html><head><title>iperf</title></head><body><body><pre>" .. io.popen("/usr/bin/iperf3 -b 0 -c " .. server .. (protocol == "udp" and " -u" or "") .. " 2>&1"):read("*a") .. "</pre></body></html>")
 end

--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -1,0 +1,60 @@
+#!/usr/bin/lua
+--[[
+
+	Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+	Copyright (C) 2022 Tim Wilkinson
+	See Contributors file for additional contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+	Additional Terms:
+
+	Additional use restrictions exist on the AREDN(TM) trademark and logo.
+		See AREDNLicense.txt for more info.
+
+	Attributions to the AREDN Project must be retained in the source code.
+	If importing this code into a new or existing project attribution
+	to the AREDN project must be added to the source code.
+
+	You must not misrepresent the origin of the material contained within.
+
+	Modified versions must be modified to attribute to the original source
+	and be marked in reasonable ways as differentiate it from the original
+	version
+
+--]]
+
+require("aredn.http")
+require("luci.sys")
+local html = require("aredn.html")
+
+local target = (os.getenv("QUERY_STRING") or ""):match("target=(.*)")
+if not target then
+    http_header()
+    html.print("<html><head></head><body>Error</body></html>")
+    http_footer()
+elseif target == "" then
+    os.execute("killall iperf3; iperf3 -s -D -1")
+    http_header()
+    html.print("<html><head></head><body>OK</body></html>")
+    http_footer()
+else
+    luci.sys.httpget("http://" .. target .. ":8080/cgi-bin/iperf?target=")
+    http_header()
+    html.header("iperf")
+    html.print("<body><pre>")
+    html.print(io.popen("/usr/bin/iperf3 -c " .. target .. " 2>&1"):read("*a"))
+    html.print("</pre>")
+    html.print("</body></html>")
+    http_footer()
+end

--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -34,27 +34,22 @@
 
 --]]
 
+require("uci")
 require("aredn.http")
 require("luci.sys")
-local html = require("aredn.html")
+require("aredn.html")
 
-local target = (os.getenv("QUERY_STRING") or ""):match("target=(.*)")
-if not target then
-    http_header()
-    html.print("<html><head></head><body>Error</body></html>")
-    http_footer()
-elseif target == "" then
+local server = (os.getenv("QUERY_STRING") or ""):match("server=(.*)")
+http_header()
+if uci.cursor():get("aredn", "@iperf[0]", "enable") == "0" then
+    aredn.html.print("<html><head></head><body><pre>iperf is disabled</pre></body></html>")
+elseif not server then
+    aredn.html.print("<html><head></head><body><pre>Provide a server name to run a test between this client and a server [/cgi-bin/iperf?server=&lt;ServerName&gt;]</pre></body></html>")
+elseif server == "" then
     os.execute("killall iperf3; iperf3 -s -D -1")
-    http_header()
-    html.print("<html><head></head><body>OK</body></html>")
-    http_footer()
+    aredn.html.print("<html><head></head><body><pre>iperf server running (one time)</pre></body></html>")
 else
-    luci.sys.httpget("http://" .. target .. ":8080/cgi-bin/iperf?target=")
-    http_header()
-    html.header("iperf")
-    html.print("<body><pre>")
-    html.print(io.popen("/usr/bin/iperf3 -c " .. target .. " 2>&1"):read("*a"))
-    html.print("</pre>")
-    html.print("</body></html>")
-    http_footer()
+    luci.sys.httpget("http://" .. server .. ":8080/cgi-bin/iperf?server=")
+    aredn.html.print("<html><head><title>iperf</title></head><body><body><pre>" .. io.popen("/usr/bin/iperf3 -c " .. server .. " 2>&1"):read("*a") .. "</pre></body></html>")
 end
+http_footer()


### PR DESCRIPTION
(see https://github.com/aredn/aredn/pull/337 for the main discussion)

A super lightweight and simple iperf testing page.

Proposing this as an alternative (and probably better) approach to running an iperf3 server by default. In this case the server is launched on demand when the client needs it. This is similar to iperfspeed but without the sophistication; but still makes a useful testing tool without the constant memory footprint.

```
curl http://<client-node>:8080/cgi-bin/iperf?target=<server-node>
```