### PR TITLE
Add cross origin access to remove remote access limitation 04/27/2022

### DIFF
--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -35,28 +35,29 @@
 --]]
 
 require("uci")
-require("aredn.http")
 require("luci.sys")
-require("aredn.html")
 
 local q = os.getenv("QUERY_STRING") or ""
 local server = q:match("server=([^&]*)")
 local protocol = q:match("protocol=([^&]*)") or "tcp"
-http_header(true)
+
+print "Content-type: text/html\r"
+print "Cache-Control: no-store\r"
+print("Access-Control-Allow-Origin: *\r")
+print("\r")
 if uci.cursor():get("aredn", "@iperf[0]", "enable") == "0" then
-    aredn.html.print("<html><head></head><body><pre>iperf is disabled</pre></body></html>")
+    print("<html><head></head><body><pre>iperf is disabled</pre></body></html>")
 elseif not server then
-    aredn.html.print("<html><head></head><body><pre>Provide a server name to run a test between this client and a server [/cgi-bin/iperf?server=&lt;ServerName&gt;&amp;protocol=&lt;udp|tcp&gt;]</pre></body></html>")
+    print("<html><head></head><body><pre>Provide a server name to run a test between this client and a server [/cgi-bin/iperf?server=&lt;ServerName&gt;&amp;protocol=&lt;udp|tcp&gt;]</pre></body></html>")
 elseif server == "" then
     os.execute("killall iperf3; iperf3 -s -D -1")
-    aredn.html.print("<html><head></head><body><pre>iperf server running (one time)</pre></body></html>")
+    print("<html><head></head><body><pre>iperf server running (one time)</pre></body></html>")
 elseif server:match("[^%w-%.]") then
-    aredn.html.print("<html><head></head><body><pre>Illegal server name</pre></body></html>")
+    print("<html><head></head><body><pre>Illegal server name</pre></body></html>")
 else
     if not server:match("%.") then
       server = server .. ".local.mesh"
     end
     luci.sys.httpget("http://" .. server .. ":8080/cgi-bin/iperf?server=")
-    aredn.html.print("<html><head><title>iperf</title></head><body><body><pre>" .. io.popen("/usr/bin/iperf3 -b 0 -c " .. server .. (protocol == "udp" and " -u" or "") .. " 2>&1"):read("*a") .. "</pre></body></html>")
+    print("<html><head><title>iperf</title></head><body><body><pre>" .. io.popen("/usr/bin/iperf3 -b 0 -c " .. server .. (protocol == "udp" and " -u" or "") .. " 2>&1"):read("*a") .. "</pre></body></html>")
 end
-http_footer()


### PR DESCRIPTION
I was modifying the old iperfspeed tool to use this service instead and realized
this was missing for it to work correctly. Command line use (as originally
envisaged) is fine - this is just extra.

I also removed the aredn.html and aredn.http libraries which,
at this point, weren't doing anything (compression was disabled).