### PR TITLE
Wait for iperf3 daemon to startup before returning.

### DIFF
--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -36,6 +36,7 @@
 
 require("uci")
 require("luci.sys")
+require("nixio")
 
 local q = os.getenv("QUERY_STRING") or ""
 local server = q:match("server=([^&]*)")
@@ -51,6 +52,13 @@ elseif not server then
     print("<html><head></head><body><pre>Provide a server name to run a test between this client and a server [/cgi-bin/iperf?server=&lt;ServerName&gt;&amp;protocol=&lt;udp|tcp&gt;]</pre></body></html>")
 elseif server == "" then
     os.execute("killall iperf3; iperf3 -s -D -1")
+	for _ = 1,5
+	do
+		if io.popen("netstat -ln | grep 0.0.0.0:5201"):read("*a") ~= "" then
+			break
+		end
+		nixio.nanosleep(1, 0)
+	end
     print("<html><head></head><body><pre>iperf server running (one time)</pre></body></html>")
 elseif server:match("[^%w-%.]") then
     print("<html><head></head><body><pre>Illegal server name</pre></body></html>")


### PR DESCRIPTION
On slower nodes, iperf will not always startup quickly enough and
then the other end's connection fails. Wait until it's available
before returning (limited to 5 seconds)