### PR TITLE
LQM improvements

### DIFF
--- a/files/etc/config.mesh/aredn
+++ b/files/etc/config.mesh/aredn
@@ -30,5 +30,5 @@ config lqm
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'
-        option ping_penalty '10'
+        option ping_penalty '5'
         option margin_quality '1'

--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -10,7 +10,7 @@ do
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'
-        option ping_penalty '10'
+        option ping_penalty '5'
         option margin_quality '1'
 __EOF__
         /sbin/uci -c $c commit aredn

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -366,8 +366,7 @@ function lqm()
             end
 
             -- Ping addresses and penalize quality for excessively slow links
-            -- Dont ping if the snr is too low to avoid penalizing node which are rebooting
-            if track.ip and not track.blocked and track.snr >= config.low then
+            if track.ip and not track.blocked then
                 local sigsock = nixio.socket("inet", "dgram")
                 sigsock:setopt("socket", "bindtodevice", wlan)
                 sigsock:setopt("socket", "dontroute", 1)

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -367,7 +367,7 @@ function lqm()
 
             -- Ping addresses and penalize quality for excessively slow links
             -- Dont ping if the snr is too low to avoid penalizing node which are rebooting
-            if track.ip and (not track.blocked or only_quality_block(track)) and track.snr > config.low then
+            if track.ip and not track.blocked and track.snr >= config.low then
                 local sigsock = nixio.socket("inet", "dgram")
                 sigsock:setopt("socket", "bindtodevice", wlan)
                 sigsock:setopt("socket", "dontroute", 1)

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -366,7 +366,8 @@ function lqm()
             end
 
             -- Ping addresses and penalize quality for excessively slow links
-            if track.ip and (not track.blocked or only_quality_block(track)) then
+            -- Dont ping if the snr is too low to avoid penalizing node which are rebooting
+            if track.ip and (not track.blocked or only_quality_block(track)) and track.snr > config.low then
                 local sigsock = nixio.socket("inet", "dgram")
                 sigsock:setopt("socket", "bindtodevice", wlan)
                 sigsock:setopt("socket", "dontroute", 1)

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -325,7 +325,7 @@ local settings = {
         key = "aredn.@lqm[0].ping_penalty",
         type = "string",
         desc = "Quality penalty when neighbor cannot be pinged",
-        default = "10",
+        default = "5",
         condition = "lqm_enabled()"
     },
     {
@@ -491,7 +491,7 @@ function lqm_defaults()
     cursor_set("aredn", "@lqm[0]", "min_distance", "0")
     cursor_set("aredn", "@lqm[0]", "max_distance", "80467")
     cursor_set("aredn", "@lqm[0]", "min_quality", "50")
-    cursor_set("aredn", "@lqm[0]", "ping_penalty", "10")
+    cursor_set("aredn", "@lqm[0]", "ping_penalty", "5")
     cursor_set("aredn", "@lqm[0]", "margin_quality", "1")
 end
 

--- a/files/www/cgi-bin/lqm
+++ b/files/www/cgi-bin/lqm
@@ -105,7 +105,7 @@ html.print([[<hr>
         </td></tr>
         <tr><td>
             <div class="lt">
-                <span class="m">Neighbor</span><span class="s">SNR</span><span class="p">Distance</span><span class="s">Quality</span><span class="p">TX Estimate</span><span class="p">Status</span>
+                <span class="m">RF Neighbor</span><span class="s">SNR</span><span class="p">Distance</span><span class="s">Quality</span><span class="p">TX Estimate</span><span class="p">Status</span>
             </div>
             <div id="links"></div>
             </td></tr>

--- a/files/www/cgi-bin/lqm
+++ b/files/www/cgi-bin/lqm
@@ -183,7 +183,12 @@ html.print([[<hr>
                 }
                 links += `<div><span class="m">${name(track)}</span><span class="s">${track.snr}${"rev_snr" in track ? "/" + track.rev_snr : ""}</span><span class="p">${distance}</span><span class="s">${txquality}</span><span class="p">${txspeed}</span><span class="p">${status}</span></div>`;
             }
-            document.getElementById("links").innerHTML = links;
+            if (links.length) {
+                document.getElementById("links").innerHTML = links;
+            }
+            else {
+                document.getElementById("links").innerHTML = `<div><span>Currently no RF neighbor data available</span></div>`
+            }
         }
         const fetchAndUpdate = () => {
             fetch("/cgi-bin/sysinfo.json?lqm=1").then(r => r.json()).then(data => {


### PR DESCRIPTION
Improve Neighbor messaging
Decrease default ping penalty
Only apply ping penalty if we have a good SNR to the other end - avoids problem when nodes are rebooted/upgraded and go away briefly.