### PR TITLE
Really old sysinfo.json dont have link_info

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -355,7 +355,7 @@ function lqm()
                                 track.links[link.hostname:lower()] = { type = "DTD" }
                             end
                         end
-                    else
+                    elseif info.link_info then
                         -- If there's no LQM information we fallback on using link information.
                         for ip, link in pairs(info.link_info)
                         do


### PR DESCRIPTION
Very old APIs don't return link_info, and the code failed to handle this.