### PR TITLE
LQM fixes 6

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -110,15 +110,14 @@ end
 
 function update_block(track)
     if should_block(track) then
-        if not track.blocked then
-            track.blocked = true
-            os.execute("/usr/sbin/iptables -D input_lqm -p udp --destination-port 698 -m mac --mac-source " .. track.mac .. " -j DROP 2> /dev/null")
+        track.blocked = true
+        if os.execute("/usr/sbin/iptables -C input_lqm -p udp --destination-port 698 -m mac --mac-source " .. track.mac .. " -j DROP 2> /dev/null") ~= 0 then
             os.execute("/usr/sbin/iptables -I input_lqm -p udp --destination-port 698 -m mac --mac-source " .. track.mac .. " -j DROP 2> /dev/null")
             return "blocked"
         end
     else
-        if track.blocked then
-            track.blocked = false
+        track.blocked = false
+        if os.execute("/usr/sbin/iptables -C input_lqm -p udp --destination-port 698 -m mac --mac-source " .. track.mac .. " -j DROP 2> /dev/null") == 0 then
             os.execute("/usr/sbin/iptables -D input_lqm -p udp --destination-port 698 -m mac --mac-source " .. track.mac .. " -j DROP 2> /dev/null")
             return "unblocked"
         end

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -839,9 +839,6 @@ if parms.button_save and not (#port_err > 0 or #dhcp_err > 0 or #dmz_err > 0 or 
     if not luci.sys.init.reload("firewall") then
         err("problem with port setup")
     end
-    if os.execute("/etc/init.d/manager restart") ~= 0 then
-        err("problem with manager")
-    end
     -- This "luci.sys.init.restart("olsrd")" doesnt do the same thing so we have to call restart directly
     if os.execute("/etc/init.d/olsrd restart") ~= 0 then
         err("problem with olsr setup")


### PR DESCRIPTION
1. Make user mac filter more tolerant of mac list format
2. Track block state based on actual firewall rules - External actions can change the firewall table (usually clearing and rebuilding it) leaving LQM's idea of what is blocked different from the actual firewall rules. Now use firewall as the LQM state.