### PR TITLE
restrict msg banner to nonprotected pages

### DIFF
--- a/files/usr/lib/lua/aredn/html.lua
+++ b/files/usr/lib/lua/aredn/html.lua
@@ -67,12 +67,8 @@ function html.footer()
 end
 
 function html.alert_banner()
-    local aredn_message = read_all("/tmp/aredn_message")
-    local local_message = read_all("/tmp/local_message")
-
     html.print("<div class=\"TopBanner\">")
     html.print("<div class=\"LogoDiv\"><a href=\"http://localnode.local.mesh:8080\" title=\"Go to localnode\"><img src=\"/AREDN.png\" class=\"AREDNLogo\"></img></a></div>")
-
     local supported = aredn.hardware.supported()
     if supported == 0 then
         html.print("<div style=\"padding:5px;background-color:#FF4719;color:black;border:1px solid #ccc;width:600px;\"><a href=\"/cgi-bin/sysinfo\">!!!! UNSUPPORTED DEVICE !!!!</a></div>")
@@ -81,14 +77,19 @@ function html.alert_banner()
     elseif supported ~= 1 then
         html.print("<div style=\"padding:5px;background-color:yellow;color:black;border:1px solid #ccc;width:600px;\"><a href=\"/cgi-bin/sysinfo\">!!!! UNTESTED HARDWARE !!!!</a></div>")
     end
+    html.print("</div>")
+end
 
+function html.msg_banner()
+    html.print("<div class=\"TopBanner\">")
+    local aredn_message = read_all("/tmp/aredn_message")
+    local local_message = read_all("/tmp/local_message")
     if aredn_message and #aredn_message > 0 then
-        html.print("<div style=\"padding:5px;background-color:#fff380;color:black;border:1px solid #ccc;width:600px;\"><strong>AREDN Alert(s):</strong><br /><div style=\"text-align:left;\">" .. aredn_message .. "</div></div>")
+        html.print("<div style=\"padding:5px;background-color:#fff380;color:black;border:1px solid #ccc;width:600px;\"><strong>AREDN Messages:</strong><br /><div style=\"text-align:left;\">" .. aredn_message .. "</div></div>")
     end
     if local_message and #local_message > 0 then
-        html.print("<div style=\"padding:5px;background-color:#fff380;color:black;border:1px solid #ccc;width:600px;\"><strong>Local Alert(s):</strong><br /><div style=\"text-align:left;\">" .. local_message .. "</div></div>")
+        html.print("<div style=\"padding:5px;background-color:#fff380;color:black;border:1px solid #ccc;width:600px;\"><strong>Local Messages:</strong><br /><div style=\"text-align:left;\">" .. local_message .. "</div></div>")
     end
-
     html.print("</div>")
 end
 

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -419,6 +419,7 @@ html.print("<input type=hidden name=reload value=1>")
 html.print("<center>")
 
 html.alert_banner()
+html.msg_banner()
 
 html.print("<h1>" .. node .. " mesh status</h1>")
 

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -221,6 +221,7 @@ html.print("<body><form method='post' action='/cgi-bin/status' enctype='multipar
 html.print("<center>")
 
 html.alert_banner()
+html.msg_banner()
 
 -- page header
 html.print("<h1><big>" .. node)
@@ -359,7 +360,7 @@ if config == "mesh" and not wifi_disabled then
     col2[#col2] = col2[#col2] .. "&nbsp;&nbsp;&nbsp;<button type=button onClick='window.location=\"signal?realtime=1\"' title='Display continuous or archived signal strength on a chart'>Charts</button></nobr></td>"
 end
 
-col2[#col2 + 1] = "<th align=right><nobr>firmware version</nobr><br><nobr>hardware type</nobr></th><td>" .. read_all("/etc/mesh-release") .. "<br>" .. aredn.hardware.get_type() .. "</td>";
+col2[#col2 + 1] = "<th align=right><nobr>firmware version</nobr><br><nobr>hardware type</nobr></th><td>" .. read_all("/etc/mesh-release") .. "<br>" .. aredn.hardware.get_radio().name .. "</td>";
 
 local sysinfo = nixio.sysinfo()
 local uptime = string.format("%d:%02d", math.floor(sysinfo.uptime / 3600) % 24, math.floor(sysinfo.uptime / 60) % 60)

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -360,7 +360,7 @@ if config == "mesh" and not wifi_disabled then
     col2[#col2] = col2[#col2] .. "&nbsp;&nbsp;&nbsp;<button type=button onClick='window.location=\"signal?realtime=1\"' title='Display continuous or archived signal strength on a chart'>Charts</button></nobr></td>"
 end
 
-col2[#col2 + 1] = "<th align=right><nobr>firmware version</nobr><br><nobr>hardware type</nobr></th><td>" .. read_all("/etc/mesh-release") .. "<br>" .. aredn.hardware.get_radio().name .. "</td>";
+col2[#col2 + 1] = "<th align=right><nobr>firmware version</nobr><br><nobr>hardware type</nobr></th><td>" .. read_all("/etc/mesh-release") .. "<br>" .. aredn.hardware.get_type() .. "</td>";
 
 local sysinfo = nixio.sysinfo()
 local uptime = string.format("%d:%02d", math.floor(sysinfo.uptime / 3600) % 24, math.floor(sysinfo.uptime / 60) % 60)


### PR DESCRIPTION
This PR separates the normal alert banner for unsupported hardware (which will appear on every page), so that the AREDN Alert Messages will only appear on the non-protected pages (Status and Mesh).