### PR TITLE
Keep 100mb as the only speed, but let the port autonegotiate with the switch

### DIFF
--- a/patches/716-ubnt-pbe-100mb-port.patch
+++ b/patches/716-ubnt-pbe-100mb-port.patch
@@ -10,7 +10,7 @@ Index: openwrt/package/base-files/files/etc/rc.local
 +BOARDID=$(/usr/local/bin/get_boardid)                                 
 +case "$BOARDID" in                                                         
 +        0xe885|0xe4e5|0xe6e5)                                                            
-+		/usr/sbin/ethtool -s eth0 speed 100 duplex full autoneg off
++		/usr/sbin/ethtool -s eth0 speed 100 duplex full autoneg on
 +                ;;
 +esac
 +


### PR DESCRIPTION
Force device speed to be 100Mbps, but allows it to actively negotiate with the switch. This avoid any extra switch configuration, and is invaluable when the switch is dumb (like the popular outdoor nanoswitches) and cannot be reconfigured.

