### PR TITLE
Remove #NOPROP from /etc/ethers where it was being incorrectly parsed.

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -303,7 +303,7 @@ if h and e then
                     ip = decimal_to_ip(netaddr + ip)
                     if validate_same_subnet(ip, cfg.lan_ip, cfg.lan_mask) and validate_ip_netmask(ip, cfg.lan_mask) then
                         h:write(ip .. "\t" .. host .. " " .. noprop .. "\n")
-                        e:write(mac .. "\t" .. ip .. " " .. noprop .. "\n")
+                        e:write(mac .. "\t" .. ip .. "\n")
                     end
                 end
             end

--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -105,16 +105,23 @@ if dmz_mode ~= "0" then
         end
     end
     if nixio.fs.stat("/etc/ethers") then
+        local noprop_ip = {}
+        if nixio.fs.stat("/etc/hosts") then
+            for line in io.lines("/etc/hosts")
+            do
+                local ip = line:match("^(%S+)%s.*#NOPROP$")
+                if ip then
+                    noprop_ip[ip] = true
+                end
+            end
+        end
         for line in io.lines("/etc/ethers")
         do
-            local noprop = line:match(".*%s+.*%s+#NOPROP")
-            if not noprop then
-                local ip = line:match("[0-9a-fA-F:]+%s+([%d%.]+)")
-                if ip then
-                    local host = ip_to_hostname(ip)
-                    if host then
-                        hosts[#hosts + 1] = { ip = ip, host = host }
-                    end
+            local ip = line:match("[0-9a-fA-F:]+%s+([%d%.]+)")
+            if ip and not noprop_ip[ip] then
+                local host = ip_to_hostname(ip)
+                if host then
+                    hosts[#hosts + 1] = { ip = ip, host = host }
                 end
             end
         end


### PR DESCRIPTION
The AREDN code now cross references entries in /etc/ethers with those in
/etc/hosts to determine if an IP is #NOPROP. The dnsmasq code could not handle
the #NOPROP flag at the end of /etc/ether entries.
