### PR TITLE
Allow LQM auto-distance to be overridden

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -61,6 +61,7 @@ function get_config()
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
+        auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),
         min_quality = tonumber(c:get("aredn", "@lqm[0]", "min_quality")),
         margin_quality = tonumber(c:get("aredn", "@lqm[0]", "margin_quality")),
         ping_penalty = tonumber(c:get("aredn", "@lqm[0]", "ping_penalty")),
@@ -740,6 +741,8 @@ function lqm()
         elseif alt_distance > 1 then
             coverage = math.min(255, math.floor((alt_distance * 2 * 0.0033) / 3))
             os.execute(IW .. " " .. phy .. " set coverage " .. coverage)
+        elseif config.auto_distance > 0 then
+            os.execute(IW .. " " .. phy .. " set distance " .. config.auto_distance)
         else
             os.execute(IW .. " " .. phy .. " set distance auto")
         end

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -314,6 +314,14 @@ local settings = {
     },
     {
         category = "Link Quality",
+        key = "aredn.@lqm[0].auto_distance",
+        type = "string",
+        desc = "Distance to use when actual distance cannot be calculated. 0 for auto",
+        default = "0",
+        condition = "lqm_enabled()"
+    },
+    {
+        category = "Link Quality",
         key = "aredn.@lqm[0].margin_quality",
         type = "string",
         desc = "Quality increase before neighbor can be re-accepted",
@@ -497,6 +505,7 @@ function lqm_defaults()
     cursor_set("aredn", "@lqm[0]", "min_snr", "15")
     cursor_set("aredn", "@lqm[0]", "margin_snr", "1")
     cursor_set("aredn", "@lqm[0]", "min_distance", "0")
+    cursor_set("aredn", "@lqm[0]", "auto_distance", "0")
     cursor_set("aredn", "@lqm[0]", "max_distance", "80467")
     cursor_set("aredn", "@lqm[0]", "min_quality", "50")
     cursor_set("aredn", "@lqm[0]", "ping_penalty", "5")

--- a/files/www/cgi-bin/sysinfo.json
+++ b/files/www/cgi-bin/sysinfo.json
@@ -174,6 +174,7 @@ if string.find(nixio.getenv("QUERY_STRING"):lower(),"lqm=1") then
 			margin_snr = tonumber(ctx:get("aredn", "@lqm[0]", "margin_snr")),
 			min_distance = tonumber(ctx:get("aredn", "@lqm[0]", "min_distance")),
 			max_distance = tonumber(ctx:get("aredn", "@lqm[0]", "max_distance")),
+			auto_distance = tonumber(ctx:get("aredn", "@lqm[0]", "auto_distance") or "0"),
 			min_quality = tonumber(ctx:get("aredn", "@lqm[0]", "min_quality")),
 			margin_quality = tonumber(ctx:get("aredn", "@lqm[0]", "margin_quality")),
 			ping_penalty = tonumber(ctx:get("aredn", "@lqm[0]", "ping_penalty")),


### PR DESCRIPTION
Allow auto-distance to be overridden when LQM cannot determine the distance to other nodes

https://github.com/aredn/aredn/issues/415