### PR TITLE
fixes for NAT Mode DHCP address range

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -395,7 +395,7 @@ if dmz_mode ~= 0 then
 end
 
 parms.dhcp_limit = dhcp_end - dhcp_start + 1
-parms.dmz_dhcp_limit = dmz_dhcp_end - dmz_dhcp_start + 1
+parms.dmz_dhcp_limit = tonumber(dmz_dhcp_end) - dmz_dhcp_start + 1
 
 -- get the active wifi settings on a fresh page load
 if not parms.reload then


### PR DESCRIPTION
Prevent `setup:398: attempt to perform arithmetic on global 'dmz_dhcp_end' (a string value)` message.
Reported in this forum post: https://www.arednmesh.org/content/navigating-cgi-binsetup-gives-502-bad-gateway-status-code