### PR TITLE
Reduce colors and improve scan information

### DIFF
--- a/files/www/cgi-bin/scan
+++ b/files/www/cgi-bin/scan
@@ -261,8 +261,15 @@ local cheight = 400;
 html.print([[
     <center style="font-family: Arial">
     <div style="padding:8px">Spectral View</div>
-    <div style="position:relative;display:inline-block"><div style="position:absolute;left:-30px;top:-200px;transform:rotate(-90deg)">SNR</div></div>
-    <canvas id="spectral" width="]] .. cwidth .. [[" height="]] .. cheight .. [[" style="border:1px solid grey;background-color:white"></canvas>
+    <div style="position:relative;display:inline-block">
+      <div style="position:absolute;top:200px;left:-35px;transform:rotate(-90deg)">SNR</div>
+      <canvas id="spectral" width="]] .. cwidth .. [[" height="]] .. cheight .. [[" style="border:1px solid grey;background-color:white"></canvas>
+      <div style="position:absolute;display:inline-block;vertical-align:top;text-align:left;top:6px;left:35px;background-color:white;border:solid 1px grey;padding:10px;font-size:12px;line-height:16px">
+        <div><span style="background-color:mediumpurple">&nbsp;&nbsp;&nbsp;</span> 5% of traffic</div>
+        <div><span style="background-color:yellow">&nbsp;&nbsp;&nbsp;</span> 95% of traffic</div>
+        <div><span style="background-color:red">&nbsp;&nbsp;&nbsp;</span> Noise</div>
+      </div>
+    </div>
     <div style="padding:4px">Channel</div>
     </center>
     <script>
@@ -275,6 +282,11 @@ function u8tos8(b)
 end
 
 local cnf = nf - 17.5 -- sub-carrier noise floor
+if bw == 10 then
+    cnf = cnf - 3
+elseif bw == 5 then
+    cnf = cnf - 6
+end
 local start_freq
 local end_freq
 if rfband == "900" then
@@ -295,20 +307,7 @@ else
     end_freq = 5920
     html.print("const freq2chan = (f) => (f - 5000) / 5;");
 end
-local bw
-for line in io.lines("/etc/config.mesh/_setup")
-do
-    bw = line:match("^wifi_chanbw%s=%s(%d+)")
-    if bw then
-        break
-    end
-end
-bw = tonumber(bw) or 10
-if bw == 10 then
-    cnf = cnf - 3
-elseif bw == 5 then
-    cnf = cnf - 6
-end
+local bw = 10
 
 local fbuckets = {}
 for freq = 1, (end_freq - start_freq + bw) * 56 / bw
@@ -350,7 +349,9 @@ do
                         end
                         local bidx = math.floor((freq - start_freq) / bw * 56 + dptr - 28)
                         local bucket = fbuckets[bidx]
-                        bucket[#bucket + 1] = math.floor((sig - min_sig) * 4)
+                        if bucket then
+                            bucket[#bucket + 1] = math.floor((sig - min_sig) * 4)
+                        end
                     end
                 end
             end
@@ -359,39 +360,28 @@ do
     i = i + 3 + l
 end
 
-local max_fsize = 0
 for _, b in ipairs(fbuckets)
 do
     table.sort(b)
-    if #b > max_fsize then
-        max_fsize = #b
-    end
 end
+
 html.print("const n = null;")
 html.write("const p=[")
-local sizes = { 0.20, 0.30, 0.40, 0.50, 0.60 }
 for _, b in ipairs(fbuckets)
 do
-    local len = #b
-    local last = 0
-    for _, size in ipairs(sizes)
-    do
-        local max = math.floor(size * max_fsize)
-        if len >= max then
-            html.write((b[max] - last) .. ",")
-            last = b[max]
-        end
-    end
-    if len > 0 and b[#b] ~= last then
-        html.write((b[#b] - last) .. ",")
+    if #b > 0 then
+        local l = b[math.floor(#b * 0.50)]
+        local m = b[math.floor(#b * 0.95)]
+        local h = b[#b]
+        html.write(l .. "," .. (m-l) .. "," .. (h-m) .. ",")
     end
     html.write("n,")
 end
-html.print("-1];")
+html.print("n];")
 
 html.print("const yscale = " .. (-cheight / (max_sig - min_sig) / 4) .. ";")
 html.print([[
-    const bcolors = [ "red", "yellow", "green", "cyan", "blue", "purple" ];
+    const bcolors = [ "red", "yellow", "mediumpurple" ];
     let xcursor = 0;
     let ycursor = 0;
     let ccursor = 0;
@@ -406,7 +396,8 @@ html.print([[
             v *= yscale;
             ycursor += v;
             ctx.fillStyle = bcolors[ccursor];
-            ctx.fillRect(xcursor, ]] .. cheight .. [[ + ycursor, ]] .. (xscale * bw / 56) .. [[, -v);
+            // ctx.fillRect(xcursor, ]] .. cheight .. [[ + ycursor, ]] .. (xscale * bw / 56) .. [[, -v);
+            ctx.fillRect(xcursor, ]] .. cheight .. [[ + ycursor, 1, -v);
             ccursor++;
         }
     }

--- a/files/www/cgi-bin/scan
+++ b/files/www/cgi-bin/scan
@@ -267,7 +267,7 @@ html.print([[
       <div style="position:absolute;display:inline-block;vertical-align:top;text-align:left;top:6px;left:35px;background-color:white;border:solid 1px grey;padding:10px;font-size:12px;line-height:16px">
         <div><span style="background-color:mediumpurple">&nbsp;&nbsp;&nbsp;</span> 5% of traffic</div>
         <div><span style="background-color:yellow">&nbsp;&nbsp;&nbsp;</span> 95% of traffic</div>
-        <div><span style="background-color:red">&nbsp;&nbsp;&nbsp;</span> Noise</div>
+        <div><span style="background-color:red">&nbsp;&nbsp;&nbsp;</span> Ambient noise</div>
       </div>
     </div>
     <div style="padding:4px">Channel</div>


### PR DESCRIPTION
Reduce the graph colors and add a key to improve the the information being conveyed by the spectral scan. Now we display 3 bands - noise, 95% of traffic, and 5% of traffic. The goal is to convey both where the spectrum is in use, and how much it is in use. Hopefully this does a better job of that.

![reduce-colors](https://user-images.githubusercontent.com/751258/178491944-9340674c-d20c-4cb5-ae26-c7451203d82c.png)

