### PR TITLE
Fix spectral info arrays

### DIFF
--- a/files/www/cgi-bin/scan
+++ b/files/www/cgi-bin/scan
@@ -370,8 +370,8 @@ html.write("const p=[")
 for _, b in ipairs(fbuckets)
 do
     if #b > 0 then
-        local l = b[math.floor(#b * 0.50)]
-        local m = b[math.floor(#b * 0.95)]
+        local l = b[1 + math.floor(#b * 0.50)]
+        local m = b[1 + math.floor(#b * 0.95)]
         local h = b[#b]
         html.write(l .. "," .. (m-l) .. "," .. (h-m) .. ",")
     end


### PR DESCRIPTION
If buckets only have a few samples, it could end up trying to read the 0'th one, not the 1'th. Lua has 1-indexed arrays.