### PR TITLE
allow long filename display

### DIFF
--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -764,7 +764,7 @@ html.print([[
             searchstring= ".*cpe" + hwtype + ".*-sysupgrade.bin$\";
             efn = "aredn-" .. fw_version .. "-" .. mfgprefix .. hardwaretypev .. ".*-sysupgrade.bin";
         }
-        var re = new RegExp(searchstring,"g");   
+        var re = new RegExp(searchstring,"g");
         if(elem.value.match(re)){
             return true;
         }else{
@@ -818,7 +818,7 @@ html.print("<tr><td align=center colspan=3>Keep Existing Configuration Settings 
 
 html.print("<tr>")
 html.print("<td>Upload Firmware</td>")
-html.print("<td><input type=file name=firmfile title='choose the firmware file to install from your hard drive' accept='.bin' onchange='validateFirmwareFilename(this)'></td>")
+html.print("<td><input style='width:100%' type=file name=firmfile title='choose the firmware file to install from your hard drive' accept='.bin' onchange='validateFirmwareFilename(this)'></td>")
 html.print("<td align=center><input type=submit name=button_ul_fw value=Upload title='install the firmware'></td>")
 html.print("</tr>")
 
@@ -864,7 +864,7 @@ end
 
 html.print("<tr>")
 html.print("<td>Upload Package</td>")
-html.print("<td><input type=file name=ul_pkg title='choose the .ipk file to install from your hard drive'> </td>")
+html.print("<td><input style='width:100%' type=file name=ul_pkg title='choose the .ipk file to install from your hard drive'> </td>")
 html.print("<td align=center><input type=submit name=button_ul_pkg value=Upload title='install the package'>")
 html.print("</td>")
 html.print("</tr>")
@@ -911,7 +911,7 @@ end
 
 html.print("<tr>")
 html.print("<td>Upload Key</td>")
-html.print("<td><input type=file name=sshkey title='choose the id_rsa.pub file to install from your hard drive'></td>")
+html.print("<td><input style='width:100%' type=file name=sshkey title='choose the id_rsa.pub file to install from your hard drive'></td>")
 html.print("<td align=center><input type=submit name=button_ul_key value=Upload title='install the key'")
 html.print("></td>")
 html.print("</tr>")


### PR DESCRIPTION
Allow longer filenames to be displayed after `Choose File` input.  Fixes #434 