### PR TITLE
Fix random iperf failures

### DIFF
--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -37,6 +37,9 @@
 require("uci")
 require("luci.sys")
 require("nixio")
+local info = require("aredn.info")
+
+local node = info.get_nvram("node")
 
 local q = os.getenv("QUERY_STRING") or ""
 local server = q:match("server=([^&]*)")
@@ -51,7 +54,7 @@ if uci.cursor():get("aredn", "@iperf[0]", "enable") == "0" then
 elseif not server then
     print("<html><head></head><body><pre>Provide a server name to run a test between this client and a server [/cgi-bin/iperf?server=&lt;ServerName&gt;&amp;protocol=&lt;udp|tcp&gt;]</pre></body></html>")
 elseif server == "" then
-    os.execute("killall iperf3; iperf3 -s -D -1")
+    os.execute("killall iperf3; iperf3 -s -D -1 -B " .. node)
 	for _ = 1,5
 	do
 		if io.popen("netstat -ln | grep 0.0.0.0:5201"):read("*a") ~= "" then


### PR DESCRIPTION
Sometimes, when an iperf3 server is started for a test, it will bind to an address which isn't the main mesh address. For tcp this isn't a problem as the test is connection based, but for UDP this can cause issues by sending UDP from an unexpected address. By always binding the server to the primary node address we avoid this problem.

I've been chasing this for a while as it's been making automated UDP based testing unreliable.