### PR TITLE
Add WAN VLAN support to the Mikrotik hAP

### DIFF
--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -465,8 +465,9 @@ function supportsVLANChange()
     if not (stat and stat.size > 0) then
         return true
     end
-    -- We also support VLAN changing on hAPs as WAN is on it's own ethernet port
-    if aredn.hardware.get_type() == "rb-952ui-5ac2nd" then
+    -- We also support VLAN changing on hAP, A750 and AR150 as WAN is on it's own ethernet port
+    local type = aredn.hardware.get_type()
+    if type == "rb-952ui-5ac2nd" or type == "gl-ar750" then
         return true
     end
     -- Otherwise

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -460,9 +460,17 @@ function hasUSB()
 end
 
 function supportsVLANChange()
-    -- We dont currently support VLAN changes on devices with switch chips
     local stat = nixio.fs.stat("/etc/aredn_include/swconfig")
-    return not (stat and stat.size > 0)
+    -- We always support VLAN changing on devices without switches
+    if not (stat and stat.size > 0) then
+        return true
+    end
+    -- We also support VLAN changing on hAPs as WAN is on it's own ethernet port
+    if aredn.hardware.get_type() == "rb-952ui-5ac2nd" then
+        return true
+    end
+    -- Otherwise
+    return false
 end
 
 -- callbacks


### PR DESCRIPTION
The hAP is the first device to support which also contains a switch chip. In this case it's easy to do as the WAN port is separate from the switched port.