### PR TITLE
Improvement to service checking

### DIFF
--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -152,6 +152,7 @@ end
 
 -- validation
 if validate then
+    local laniface = aredn.hardware.get_iface_name("lan")
     local valid_hosts = {}
     -- Add in local names so services checks pass
     for _, name in ipairs(names)
@@ -162,6 +163,8 @@ if validate then
     for _, host in ipairs(hosts)
     do
         if os.execute("/bin/ping -q -c 1 -W 1 " .. host.ip .. " > /dev/null 2>&1") == 0 then
+            valid_hosts[host.host:lower()] = host
+        elseif os.execute("/usr/sbin/arping -q -f -c 1 -w 1 -I " .. laniface .. " " .. host.ip .. " > /dev/null 2>&1") == 0 then
             valid_hosts[host.host:lower()] = host
         end
     end

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -567,6 +567,14 @@ end
 
 local meshpkgs = capture("grep -q \".local.mesh\" /etc/opkg/distfeeds.conf"):chomp()
 
+function update_advertised_services()
+    local script = "/etc/cron.hourly/check-services"
+    local stat = nixio.fs.stat(script)
+    if stat.type == "reg" and nixio.bit.band(tonumber(stat.modedec, 8), tonumber(111, 8)) ~= 0 then
+        os.execute("(cd /tmp;" .. script .. " 2>&1 | logger -p daemon.debug -t " .. script .. ")&")
+    end
+end
+
 -- upload package
 if parms.button_ul_pkg and nixio.fs.stat("/tmp/web/upload/file") then
     os.execute("mv -f /tmp/web/upload/file /tmp/web/upload/newpkg.ipk")
@@ -583,6 +591,8 @@ if parms.button_ul_pkg and nixio.fs.stat("/tmp/web/upload/file") then
     nixio.fs.remove("/tmp/web/upload/newpkg.ipk")
     if os.execute("/usr/local/bin/uploadctlservices restore > /dev/null 2>&1") ~= 0 then
         pkgout("Failed to restart all services, please reboot this node.")
+    else
+        update_advertised_services()
     end
 end
 
@@ -600,6 +610,8 @@ if parms.button_dl_pkg and parms.dl_pkg ~= "default" then
         pkgout(result)
         if os.execute("/usr/local/bin/uploadctlservices restore > /dev/null 2>&1") ~= 0 then
             pkgout("Failed to restart all services, please reboot this node.")
+        else
+            update_advertised_services()
         end
     else
         pkgout("Error: no route to Host")
@@ -622,6 +634,7 @@ if parms.button_rm_pkg and parms.rm_pkg ~= "default" and not permpkg[parms.rm_pk
     pkgout(output)
     if not output:match("No packages removed") then
         pkgout("Package removed successfully")
+        update_advertised_services()
     end
 end
 


### PR DESCRIPTION
1. Add an 'arping' check for an address is a normal ping fails. This uses arp to find an address on the network, and will find devices which are live but have pings blocked. Only works for local lan devices.
2. Feedback from users - After an upgrade, services are left registered even though the packages are not yet reinstalled. We hide these service entries and restore them when the package is installed again - but there was a delay because we only run the check once per hour. It wasn't obvious what was happening, so now we immediately run the check after a package install.