### PR TITLE
Reduce footprint of WAN when attached to 10-net network [Investigation]

### DIFF
--- a/files/etc/udhcpc.user
+++ b/files/etc/udhcpc.user
@@ -1,0 +1,49 @@
+#!/bin/sh
+<<'LICENSE'
+  Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+  Copyright (C) 2022 Tim Wilkinson
+   See Contributors file for additional contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional Terms:
+
+  Additional use restrictions exist on the AREDN(TM) trademark and logo.
+    See AREDNLicense.txt for more info.
+
+  Attributions to the AREDN Project must be retained in the source code.
+  If importing this code into a new or existing project attribution
+  to the AREDN project must be added to the source code.
+
+  You must not misrepresent the origin of the material contained within.
+
+  Modified versions must be modified to attribute to the original source
+  and be marked in reasonable ways as differentiate it from the original
+  version.
+
+LICENSE
+
+case "${INTERFACE}@$1@${router}" in
+    #
+    # If the WAN is a 10-net address, we remove the network route and leave just
+    # the default route to the specific gateway in place. This reduces the likelyhood
+    # of an IP class to a single address - no worse than your average new node on the
+    # network.
+    #
+    wan@bound@10\.*)
+        eval "$(/bin/ipcalc.sh ${ip}/${mask})"
+        /sbin/ip route del ${NETWORK}/${mask}
+        ;;
+    *)
+        ;;
+esac

--- a/files/etc/udhcpc.user
+++ b/files/etc/udhcpc.user
@@ -35,14 +35,16 @@ LICENSE
 
 case "${INTERFACE}@$1@${router}" in
     #
-    # If the WAN is a 10-net address, we remove the network route and leave just
-    # the default route to the specific gateway in place. This reduces the likelyhood
-    # of an IP class to a single address - no worse than your average new node on the
-    # network.
+    # If the WAN is a 10-net address, we remove the 10-network routes and leave just
+    # the default route to the specific gateway in place.
     #
     wan@bound@10\.*)
+        sleep 10 # Need to wait a moment for the wifi to we can remove its route
         eval "$(/bin/ipcalc.sh ${ip}/${mask})"
         /sbin/ip route del ${NETWORK}/${mask}
+        /sbin/ip route del 10.0.0.0/8 dev $(uci get network.wifi.ifname)
+        /sbin/ip route del 10.0.0.0/8 dev eth1.2
+        /sbin/ip route add default via ${route} dev ${interface}
         ;;
     *)
         ;;


### PR DESCRIPTION
When the WAN interface is connected to a 10-net network, things will often break because the mesh is a 10.0.0.0/8 network. When this happens, this fix reduces the WAN network to a single gateway address, reducing the change of an address conflict and letting the WAN work correctly.

A WAN address conflict will then only happen if the WAN gateway IP or the WAN IP of this device are also on mesh IPs; but this is much more unlikely than an entire subnet, and similar to the chance of a new node address conflicting with one already present.