### PR TITLE
Fixes for "Prevent LAN devices from accessing WAN"

### DIFF
--- a/files/etc/config.mesh/_setup
+++ b/files/etc/config.mesh/_setup
@@ -33,7 +33,6 @@ dhcp_end = 25
 dhcp_limit = 20
 
 olsrd_bridge = 0
-olsrd_gw = 0
 
 wan_proto = dhcp
 wan_dns1 = 8.8.8.8

--- a/files/etc/config.mesh/_setup.default
+++ b/files/etc/config.mesh/_setup.default
@@ -27,14 +27,12 @@ lan_proto = static
 lan_ip = 172.27.0.1
 lan_mask = 255.255.255.0
 lan_dhcp = 1
-lan_dhcp_noroute = 0
 
 dhcp_start = 5
 dhcp_end = 25
 dhcp_limit = 20
 
 olsrd_bridge = 0
-olsrd_gw = 0
 
 wan_proto = dhcp
 wan_dns1 = 8.8.8.8

--- a/files/etc/hotplug.d/iface/11-meshrouting
+++ b/files/etc/hotplug.d/iface/11-meshrouting
@@ -42,7 +42,7 @@ fi
 
 if [ "$ACTION" = "ifup" ] ; then
 
-  is_olsrgw=$(cat /etc/config.mesh/_setup|grep -i olsrd_gw|cut -d ' ' -f 3)
+  is_olsrgw=$(/sbin/uci -q get aredn.@wan[0].olsrd_gw)
 
   # Set routes for wifi or device to device linking
   # unreachable rule is needed  to ensure packets do not traverse a rule later that considers routing to another network.

--- a/files/etc/local/mesh-firewall/10-lan-to-wan
+++ b/files/etc/local/mesh-firewall/10-lan-to-wan
@@ -33,14 +33,11 @@
 
 LICENSE
 
-noroute=$(grep "lan_dhcp_noroute" /etc/config.mesh/_setup | sed s/^lan_dhcp_noroute\ =\ //)
+lan_dhcp_route=$(/sbin/uci -q get aredn.@wan[0].lan_dhcp_route)
 wan=$(grep "wan_intf" /etc/config.mesh/_setup | sed s/^wan_intf\ =\ //)
 
-case "${noroute}" in
-0)
-    # LAN to WAN okay
-    ;;
-*)
+case "${lan_dhcp_route}" in
+  0)
     # LAN to WAN forwarding is disabled
     # Inserted in reverse order
     # Block traffic forwarding between LAN and local WAN (need this rule if WAN happens to be 10.X or 172.16.X)
@@ -50,5 +47,8 @@ case "${noroute}" in
     iptables -I zone_lan_forward -d 172.16.0.0/12 -j ACCEPT
     iptables -I zone_lan_forward -d 10.0.0.0/8 -j ACCEPT
     iptables -I zone_lan_forward -o ${wan} -j REJECT
+    ;;
+  *)
+    # LAN to WAN okay
     ;;
 esac

--- a/files/etc/local/mesh-firewall/10-lan-to-wan
+++ b/files/etc/local/mesh-firewall/10-lan-to-wan
@@ -42,6 +42,13 @@ case "${noroute}" in
     ;;
 *)
     # LAN to WAN forwarding is disabled
+    # Inserted in reverse order
+    # Block traffic forwarding between LAN and local WAN (need this rule if WAN happens to be 10.X or 172.16.X)
+    # Allow traffic for mesh-IPs and tun-IPs
+    # Block traffic to all other IPs
+    iptables -I zone_lan_forward -j REJECT
+    iptables -I zone_lan_forward -d 172.16.0.0/12 -j ACCEPT
+    iptables -I zone_lan_forward -d 10.0.0.0/8 -j ACCEPT
     iptables -I zone_lan_forward -o ${wan} -j REJECT
     ;;
 esac

--- a/files/etc/local/mesh-firewall/10-lan-to-wan
+++ b/files/etc/local/mesh-firewall/10-lan-to-wan
@@ -1,0 +1,47 @@
+#!/bin/sh
+<<'LICENSE'
+  Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+  Copyright (C) 2022 Tim Wilkinson
+   See Contributors file for additional contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional Terms:
+
+  Additional use restrictions exist on the AREDN(TM) trademark and logo.
+    See AREDNLicense.txt for more info.
+
+  Attributions to the AREDN Project must be retained in the source code.
+  If importing this code into a new or existing project attribution
+  to the AREDN project must be added to the source code.
+
+  You must not misrepresent the origin of the material contained within.
+
+  Modified versions must be modified to attribute to the original source
+  and be marked in reasonable ways as differentiate it from the original
+  version.
+
+LICENSE
+
+noroute=$(grep "lan_dhcp_noroute" /etc/config.mesh/_setup | sed s/^lan_dhcp_noroute\ =\ //)
+wan=$(grep "wan_intf" /etc/config.mesh/_setup | sed s/^wan_intf\ =\ //)
+
+case "${noroute}" in
+0)
+    # LAN to WAN okay
+    ;;
+*)
+    # LAN to WAN forwarding is disabled
+    iptables -I zone_lan_forward -o ${wan} -j REJECT
+    ;;
+esac

--- a/files/etc/uci-defaults/81_aredn_migrate_wansettings
+++ b/files/etc/uci-defaults/81_aredn_migrate_wansettings
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+noroute=$(grep "lan_dhcp_noroute" /etc/config.mesh/_setup | sed s/^lan_dhcp_noroute\ =\ //)
+olsrd_gw=$(grep "olsrd_gw" /etc/config.mesh/_setup | sed s/^olsrd_gw\ =\ //)
+
+if [ "$(/sbin/uci -c /etc/config.mesh -q get aredn.@wan[0])" != "wan" ]; then
+    /sbin/uci -c /etc/config.mesh -q add aredn wan
+fi
+
+if [ "${noroute}" != "" ]; then
+    if [ "${noroute}" = "0" ]; then
+        /sbin/uci -c /etc/config.mesh set aredn.@wan[0].lan_dhcp_route=1
+    else
+        /sbin/uci -c /etc/config.mesh set aredn.@wan[0].lan_dhcp_route=0
+    fi
+    /sbin/uci -c /etc/config.mesh set aredn.@wan[0].lan_dhcp_defaultroute=0
+    /sbin/uci -c /etc/config.mesh commit aredn
+    sed -i /^lan_dhcp_noroute\ =/d /etc/config.mesh/_setup
+fi
+
+if [ "${olsrd_gw}" != "" ]; then
+    /sbin/uci -c /etc/config.mesh set aredn.@wan[0].olsrd_gw=${olsrd_gw}
+    /sbin/uci -c /etc/config.mesh commit aredn
+    sed -i /^olsrd_gw\ =/d /etc/config.mesh/_setup
+fi

--- a/files/usr/lib/lua/aredn/controller/setup_basic.lua
+++ b/files/usr/lib/lua/aredn/controller/setup_basic.lua
@@ -105,7 +105,6 @@ function module:GET()
   -- WAN Advanced
   data.wanadv = {}
   data.wanadv.meshgw = aredn_info.isMeshGatewayEnabled()
-  -- lan_no_wan (lan_dhcp_noroute)
 
   -- WAN Wifi Client
   data.wanclient = {}

--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -597,9 +597,7 @@ end
 -- Returns Mesh gateway setting
 -------------------------------------
 function model.getMeshGatewaySetting()
-	gw=os.capture("cat /etc/config.mesh/_setup|grep olsrd_gw|cut -d'=' -f2|tr -d ' ' ")
-	gw=gw:chomp()
-	return gw
+	return uci.cursor():get("aredn", "@wan[0]", "olsrd_gw") or ""
 end
 
 -------------------------------------
@@ -628,8 +626,7 @@ end
 -- is Mesh olsr gateway enabled
 -------------------------------------
 function model.isMeshGatewayEnabled()
-	r=os.capture("cat /etc/config.mesh/_setup|grep olsrd_gw|cut -d'=' -f2|tr -d ' ' ")
-	r=r:chomp()
+	local r = model.getMeshGatewaySetting()
 	if r=="0" then
 		return false
 	else

--- a/files/usr/local/bin/aredn_postupgrade
+++ b/files/usr/local/bin/aredn_postupgrade
@@ -38,6 +38,7 @@ require("aredn.utils")
 local aredn_info = require("aredn.info")
 require("aredn.hardware")
 require("luci.sys")
+require("uci")
 
 local needsrun = aredn_info.get_nvram("nodeupgraded")
 if needsrun == "" or needsrun == "0" then
@@ -86,7 +87,9 @@ end
 
 -- set variables in special conditions
 if cfg.dmz_mode == "0" or cfg.wan_proto == "disabled" then
-    cfg.olsrd_gw = "0"
+    local c = uci.cursor("/etc/config.mesh")
+    c:set("aredn", "@wan[0]", "olsrd_gw", "0")
+    c:commit("aredn")
 end
 -- end special condition overrides
 

--- a/files/usr/local/bin/mesh-firewall
+++ b/files/usr/local/bin/mesh-firewall
@@ -46,7 +46,7 @@ fi
 
 #Is this node a meshgw
 export MESHFW_MESHGW
-MESHFW_MESHGW=$(grep -i olsrd_gw /etc/config.mesh/_setup|cut -d ' ' -f 3)
+MESHFW_MESHGW=$(/sbin/uci -q get aredn.@wan[0].olsrd_gw)
 
 # Are tunnels 'enabled'
 if [ -x "/usr/sbin/vtund" ]

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -366,7 +366,7 @@ if fw then
         fw:write("\nconfig 'include'\n        option 'path' '/etc/firewall.natmode'\n        option 'reload' '1'\n")
     end
 
-    if not is_null(cfg.olsrd_gw) then
+    if c:get("aredn", "@wan[0]", "olsrd_gw") == "1" then
         fw:write("\nconfig forwarding\n        option src    wifi\n        option dest   wan\n")
         fw:write("\nconfig forwarding\n        option src    dtdlink\n        option dest   wan\n")
     end
@@ -504,7 +504,7 @@ if nixio.fs.access("/etc/config.mesh/olsrd", "r") then
                 end
             end
         
-            if not is_null(cfg.olsrd_gw) then
+            if c:get("aredn", "@wan[0]", "olsrd_gw") == "1" then
                 of:write("config LoadPlugin\n\toption library 'olsrd_dyn_gw.so.0.5'\n\toption Interval '60'\n\tlist Ping '8.8.8.8'\n\tlist Ping '8.8.4.4'\n\n\n")
             end
         end
@@ -520,16 +520,19 @@ c:commit("aredn")
 
 -- setup node lan dhcp
 
-if not is_null(cfg.lan_dhcp_noroute) then
+if c:get("aredn", "@wan[0]", "lan_dhcp_route") == "1" or c:get("aredn", "@wan[0]", "lan_dhcp_defaultroute") == "1" then
+    -- Provide stateless routes and default route
+    c:set("dhcp", "@dhcp[0]", "dhcp_option", {
+        "121,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip,
+        "249,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip
+    })
+else
+    -- Provide stateless routes to the mesh, and a blank default route (option 3 has no values) to
+    -- surpress default route being sent
     c:set("dhcp", "@dhcp[0]", "dhcp_option", {
         "121,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip,
         "249,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip,
         "3"
-    })
-else
-    c:set("dhcp", "@dhcp[0]", "dhcp_option", {
-        "121,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip,
-        "249,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip
     })
 end
 c:commit("dhcp")

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -523,15 +523,15 @@ c:commit("aredn")
 if c:get("aredn", "@wan[0]", "lan_dhcp_route") == "1" or c:get("aredn", "@wan[0]", "lan_dhcp_defaultroute") == "1" then
     -- Provide stateless routes and default route
     c:set("dhcp", "@dhcp[0]", "dhcp_option", {
-        "121,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip,
-        "249,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip
+        "121,10.0.0.0/8," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip,
+        "249,10.0.0.0/8," .. cfg.lan_ip .. ",0.0.0.0/0," .. cfg.lan_ip
     })
 else
     -- Provide stateless routes to the mesh, and a blank default route (option 3 has no values) to
     -- surpress default route being sent
     c:set("dhcp", "@dhcp[0]", "dhcp_option", {
-        "121,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip,
-        "249,10.0.0.0/8," .. cfg.lan_ip .. ",172.16.0.0/12," .. cfg.lan_ip,
+        "121,10.0.0.0/8," .. cfg.lan_ip,
+        "249,10.0.0.0/8," .. cfg.lan_ip,
         "3"
     })
 end

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -147,8 +147,8 @@ local settings = {
     {
         category = "WAN Settings",
         key = "aredn.@wan[0].olsrd_gw",
-        type = "string",
-        desc = "Allow others to use my WAN",
+        type = "boolean",
+        desc = "Allow other MESH nodes to use my WAN - not recommended and OFF by default",
         default = "0",
         postcallback = "changeWANGW()",
         needreboot = true
@@ -156,16 +156,16 @@ local settings = {
     {
         category = "WAN Settings",
         key = "aredn.@wan[0].lan_dhcp_route",
-        type = "string",
-        desc = "Allow LAN devices to accessing WAN",
+        type = "boolean",
+        desc = "Allow my LAN devices to access my WAN - ON by default",
         default = "1",
         needreboot = true
     },
     {
         category = "WAN Settings",
         key = "aredn.@wan[0].lan_dhcp_defaultroute",
-        type = "string",
-        desc = "Provide default route to LAN devices when WAN access is disabled",
+        type = "boolean",
+        desc = "Provide default route to LAN devices even when WAN access is disabled",
         default = "0",
         needreboot = true
     },

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -146,6 +146,31 @@ local settings = {
     },
     {
         category = "WAN Settings",
+        key = "aredn.@wan[0].olsrd_gw",
+        type = "string",
+        desc = "Allow others to use my WAN",
+        default = "0",
+        postcallback = "changeWANGW()",
+        needreboot = true
+    },
+    {
+        category = "WAN Settings",
+        key = "aredn.@wan[0].lan_dhcp_route",
+        type = "string",
+        desc = "Allow LAN devices to accessing WAN",
+        default = "1",
+        needreboot = true
+    },
+    {
+        category = "WAN Settings",
+        key = "aredn.@wan[0].lan_dhcp_defaultroute",
+        type = "string",
+        desc = "Provide default route to LAN devices when WAN access is disabled",
+        default = "0",
+        needreboot = true
+    },
+    {
+        category = "WAN Settings",
         key = "aredn.wan.vlanid",
         type = "string",
         desc = "Specify WAN VLAN #",
@@ -625,6 +650,10 @@ function changeWANVLAN()
         end
         f:close()
     end
+    os.execute("/usr/local/bin/node-setup -a mesh")
+end
+
+function changeWANGW()
     os.execute("/usr/local/bin/node-setup -a mesh")
 end
 

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -159,6 +159,7 @@ local settings = {
         type = "boolean",
         desc = "Allow my LAN devices to access my WAN - ON by default",
         default = "1",
+        postcallback = "changeWANGW()",
         needreboot = true
     },
     {
@@ -167,6 +168,7 @@ local settings = {
         type = "boolean",
         desc = "Provide default route to LAN devices even when WAN access is disabled",
         default = "0",
+        postcallback = "changeWANGW()",
         needreboot = true
     },
     {

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -357,7 +357,7 @@ else
 end
 
 -- make sure everything we need is initialized
-local d0 = { "lan_dhcp", "olsrd_bridge", "olsrd_gw", "wifi2_enable", "lan_dhcp_noroute", "wifi_enable", "wifi3_enable", "dhcp_start", "dhcp_end" }
+local d0 = { "lan_dhcp", "olsrd_bridge", "wifi2_enable", "wifi_enable", "wifi3_enable", "dhcp_start", "dhcp_end" }
 for _, k in ipairs(d0)
 do
     if not parms[k] then
@@ -1303,13 +1303,7 @@ end
 html.print("<tr><td><nobr>DNS 1</nobr></td><td><input type=text size=15 name=wan_dns1 value='" .. wan_dns1 .. "'></td></tr>")
 html.print("<tr><td><nobr>DNS 2</nobr></td><td><input type=text size=15 name=wan_dns2 value='" .. wan_dns2 .. "'></td></tr>")
 
-html.print("<tr><th colspan=2><hr></td></tr><tr><th colspan=2><small>Advanced WAN Access</small></th></tr>")
-if wan_proto ~= "disabled" then
-    html.print("<tr><td><nobr>Allow others to<br>use my WAN</td><td><input type=checkbox name=olsrd_gw value=1 title='Allow this node to provide internet access to other mesh users'" .. (olsrd_gw ~= "0" and " checked" or "") .. ">&nbsp;&nbsp;<a href='/help.html#allowwan' target='_blank'><img src='/qmark.png'></a></td></tr>")
-else
-    hidden[#hidden + 1] = "<input type=hidden name=olsrd_gw value='0'>"
-end
-html.print("<tr><td><nobr>Prevent LAN devices<br>from accessing WAN</td><td><input type=checkbox name=lan_dhcp_noroute value=1 title='Disable LAN devices to access the internet'" .. (lan_dhcp_noroute ~= "0" and " checked" or "") .. ">&nbsp;&nbsp;<a href='/help.html#preventwan' target='_blank'><img src='/qmark.png'></a></td></tr>")
+html.print("<tr><th colspan=2><hr></td></tr>")
 
 -- wan wifi client
 if (phycount > 1 and (wifi_enable ~= "1" or wifi2_enable ~= "1")) or (phycount == 1 and wifi_enable ~= "1" and wifi2_enable ~= "1") and not M39model then
@@ -1351,7 +1345,7 @@ if (phycount > 1 and (wifi_enable ~= "1" or wifi2_enable ~= "1")) or (phycount =
         end
     end
 
-    html.print("<tr><td colspan=2><hr></td></tr><tr><th colspan=2><small>WAN Wifi Client&nbsp;<img style='vertical-align:text-bottom' src='" .. connected .. "' title='" .. cmessage .. "'></small></th></tr>")
+    html.print("<tr><th colspan=2><small>WAN Wifi Client&nbsp;<img style='vertical-align:text-bottom' src='" .. connected .. "' title='" .. cmessage .. "'></small></th></tr>")
     html.print("<tr><td>Enable</td><td><input type=checkbox name=wifi3_enable value=1" .. (wifi3_enable == "1" and " checked" or "") .. ">&nbsp;&nbsp;<a href='/help.html#wanclient' target='_blank'><img src='/qmark.png'></a></td></tr>")
 
     if wifi_enable ~= "1" and wifi2_enable ~= "1" and phycount > 1 then


### PR DESCRIPTION
Part 1 - when "Prevent LAN devices from accessing WAN" is enabled, use a firewall rule to prevent traffic from LAN going to the WAN.

Part 2 - we need to change the dialog and the DHCP offerings to allow three cases:
a) LAN can access WAN
b) LAN cannot access WAN (LAN devices get a default route)
c) LAN cannot access WAN (LAN devices dont get a default route)

Option (b) is necessary for devices which dont support DHCP option 121 and 249 .. such as many IP cameras.
Option (c) is what you probably think you have now, you don't because traffic isn't blocked.

Just need some good UX/UI suggestions to finish this up.

Related to:
https://github.com/aredn/aredn/issues/475
https://github.com/aredn/aredn/issues/474
https://github.com/aredn/aredn/issues/26
https://github.com/aredn/aredn/issues/42