### PR TITLE
A simple way to keep a user swconfig override across upgrades

### DIFF
--- a/files/etc/arednsysupgrade.conf
+++ b/files/etc/arednsysupgrade.conf
@@ -12,6 +12,7 @@
 /etc/config.mesh/vtun
 /etc/config.mesh/network_tun
 /etc/config.mesh/aredn
+/etc/aredn_include/swconfig.user
 /etc/dropbear/dropbear_dss_host_key
 /etc/dropbear/dropbear_rsa_host_key
 /etc/dropbear/authorized_keys

--- a/files/etc/uci-defaults/99_setup_aredn_include
+++ b/files/etc/uci-defaults/99_setup_aredn_include
@@ -1,6 +1,10 @@
 #!/bin/sh
 # extract auto-generated first boot switch config settings
-# and store them for future use
+# and store them for future use. Support advanced user overrides.
+if [ -f /etc/aredn_include/swconfig.user ]
+then
+	cp /etc/aredn_include/swconfig.user /etc/aredn_include/swconfig
+fi
 if [ ! -f /etc/aredn_include/swconfig ]
 then
   mkdir -p /etc/aredn_include


### PR DESCRIPTION
Proposal for a simple way to allow a user to override the default swconfig and keep it across upgrades.
This seems sufficiently specialized that even an advance config is not the way to go; but as you can already
override swconfig if you want, this just provides a mechanism to keep those changes across upgrades.