### PR TITLE
Snapshot hostnames after updates so we have a consistent copy to display

### DIFF
--- a/files/etc/dnsmasq.conf
+++ b/files/etc/dnsmasq.conf
@@ -12,7 +12,7 @@ no-negcache
 resolv-file=/tmp/resolv.conf.auto
 
 # include olsr nameservice
-addn-hosts=/var/run/hosts_olsr
+addn-hosts=/var/run/hosts_olsr.stable
 
 dhcp-authoritative
 dhcp-leasefile=/tmp/dhcp.leases

--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -355,7 +355,7 @@ function model.all_hosts()
 	local hosts={}
 	local lines={}
 	local pos, val
-	local hfile=io.open("/var/run/hosts_olsr","r")
+	local hfile=io.open("/var/run/hosts_olsr.stable","r")
 	if hfile~=nil then
 		for line in hfile:lines() do
 			table.insert(lines,line)
@@ -571,7 +571,7 @@ end
 -------------------------------------
 function model.getLocalHosts()
   local localhosts = {}
-  myhosts=os.capture('/bin/grep "# myself" /var/run/hosts_olsr|grep -v dtdlink')
+  myhosts=os.capture('/bin/grep "# myself" /var/run/hosts_olsr.stable|grep -v dtdlink')
   local lines = myhosts:splitNewLine()
   data = {}
   for k,v in pairs(lines) do

--- a/files/usr/local/bin/mgr/namechange.lua
+++ b/files/usr/local/bin/mgr/namechange.lua
@@ -63,7 +63,7 @@ function do_namechange()
     local history = {}
 
     -- Load the hosts file
-    for line in io.lines("/var/run/hosts_olsr")
+    for line in io.lines("/var/run/hosts_olsr.stable")
     do
         local v = line:splitWhiteSpace()
         local ip = v[1]

--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -262,7 +262,7 @@ print([[{]])
 print([[    PlParam "sighup-pid-file" "/var/run/dnsmasq/dnsmasq.pid"]])
 print([[    PlParam "interval" "30"]])
 print([[    PlParam "timeout" "300"]])
-print([[    PlParam "name-change-script" "touch /tmp/namechange"]])
+print([[    PlParam "name-change-script" "touch /tmp/namechange; cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot"]])
 for _, name in ipairs(names)
 do
     print([[    PlParam "name" "]] .. name .. [["]])

--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -262,7 +262,7 @@ print([[{]])
 print([[    PlParam "sighup-pid-file" "/var/run/dnsmasq/dnsmasq.pid"]])
 print([[    PlParam "interval" "30"]])
 print([[    PlParam "timeout" "300"]])
-print([[    PlParam "name-change-script" "touch /tmp/namechange; cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot; mv -f /var/run/hosts_olsr.snapshop /var/run/hosts_olsr.stable"]])
+print([[    PlParam "name-change-script" "touch /tmp/namechange; cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot; mv -f /var/run/hosts_olsr.snapshot /var/run/hosts_olsr.stable"]])
 for _, name in ipairs(names)
 do
     print([[    PlParam "name" "]] .. name .. [["]])

--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -262,7 +262,7 @@ print([[{]])
 print([[    PlParam "sighup-pid-file" "/var/run/dnsmasq/dnsmasq.pid"]])
 print([[    PlParam "interval" "30"]])
 print([[    PlParam "timeout" "300"]])
-print([[    PlParam "name-change-script" "touch /tmp/namechange; cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot"]])
+print([[    PlParam "name-change-script" "touch /tmp/namechange; cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot; mv -f /var/run/hosts_olsr.snapshop /var/run/hosts_olsr.stable"]])
 for _, name in ipairs(names)
 do
     print([[    PlParam "name" "]] .. name .. [["]])

--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -145,7 +145,7 @@ function getRemoteNodes()
 	do
 		routeetx[v.destination] = string.format("%.2f", v.etx)
 	end
-	for line in io.lines("/var/run/hosts_olsr")
+	for line in io.lines("/var/run/hosts_olsr.stable")
 	do
 		local ip, hostname = line:match("^(%d+%.%d+%.%d+%.%d+)%s+(%S+)%s+#.*$")
 		if ip and not neighbors[ip] and not (hostname:match("^dtdlink%.") or hostname:match("^mid%d+%.")) then

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -317,55 +317,63 @@ do
 end
 
 -- load the olsr hosts file
-for line in io.lines("/var/run/hosts_olsr")
+local hosts_lines = {}
+for _, hosts_olsr in ipairs({ "/var/run/hosts_olsr.snapshot", "/var/run/hosts_olsr" })
 do
-    local ip, name, originator = line:match("^([%d%.]+)%s+(%S+)%s+%S+%s+(%S+)")
-    if ip and originator and originator ~= "myself" and (routes[ip] or routes[originator]) then
-        local etx = routes[ip]
-        if not etx then
-            etx = routes[originator]
-        end
-        etx = etx.etx
-        if not name:match("%.") or name:match("^mid%.[^%.]*$") then
-            name = name .. ".local.mesh"
-        end
-        if ip == originator then
-            if not hosts[originator] then
-                hosts[originator] = { hosts = {} }
+    for line in io.lines(hosts_olsr)
+    do
+        if not hosts_lines[line] then
+            hosts_lines[line] = true
+            local ip, name, originator = line:match("^([%d%.]+)%s+(%S+)%s+%S+%s+(%S+)")
+            if ip and originator and originator ~= "myself" and (routes[ip] or routes[originator]) then
+                local etx = routes[ip]
+                if not etx then
+                    etx = routes[originator]
+                end
+                etx = etx.etx
+                if not name:match("%.") or name:match("^mid%.[^%.]*$") then
+                    name = name .. ".local.mesh"
+                end
+                if ip == originator then
+                    if not hosts[originator] then
+                        hosts[originator] = { hosts = {} }
+                    end
+                    local host = hosts[originator]
+                    if host.name then
+                        host.tactical = name
+                    else
+                        host.name = name
+                        host.etx = etx
+                    end
+                elseif name:match("^dtdlink%.") then
+                    dtd[originator] = true
+                    if links[ip] then
+                        links[ip].dtd = true
+                    end
+                elseif name:match("^mid%d+%.") then
+                    if not midcount[originator] then
+                        midcount[originator] = 1
+                    else
+                        midcount[originator] = midcount[originator] + 1
+                    end
+                    if links[ip] then
+                        links[ip].tun = true
+                    end
+                else
+                    if not hosts[originator] then
+                        hosts[originator] = { hosts = {} }
+                    end
+                    local host = hosts[originator]
+                    host.hosts[#host.hosts + 1] = name
+                end
             end
-            local host = hosts[originator]
-            if host.name then
-                host.tactical = name
-            else
-                host.name = name
-                host.etx = etx
-            end
-        elseif name:match("^dtdlink%.") then
-            dtd[originator] = true
-            if links[ip] then
-                links[ip].dtd = true
-            end
-        elseif name:match("^mid%d+%.") then
-            if not midcount[originator] then
-                midcount[originator] = 1
-            else
-                midcount[originator] = midcount[originator] + 1
-            end
-            if links[ip] then
-                links[ip].tun = true
-            end
-        else
-            if not hosts[originator] then
-                hosts[originator] = { hosts = {} }
-            end
-            local host = hosts[originator]
-            host.hosts[#host.hosts + 1] = name
         end
     end
 end
 
 -- discard
 routes = nil
+hosts_lines = nil
 
 for line in io.lines("/var/run/services_olsr")
 do

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -317,63 +317,55 @@ do
 end
 
 -- load the olsr hosts file
-local hosts_lines = {}
-for _, hosts_olsr in ipairs({ "/var/run/hosts_olsr.snapshot", "/var/run/hosts_olsr" })
+for line in io.lines("/var/run/hosts_olsr.stable")
 do
-    for line in io.lines(hosts_olsr)
-    do
-        if not hosts_lines[line] then
-            hosts_lines[line] = true
-            local ip, name, originator = line:match("^([%d%.]+)%s+(%S+)%s+%S+%s+(%S+)")
-            if ip and originator and originator ~= "myself" and (routes[ip] or routes[originator]) then
-                local etx = routes[ip]
-                if not etx then
-                    etx = routes[originator]
-                end
-                etx = etx.etx
-                if not name:match("%.") or name:match("^mid%.[^%.]*$") then
-                    name = name .. ".local.mesh"
-                end
-                if ip == originator then
-                    if not hosts[originator] then
-                        hosts[originator] = { hosts = {} }
-                    end
-                    local host = hosts[originator]
-                    if host.name then
-                        host.tactical = name
-                    else
-                        host.name = name
-                        host.etx = etx
-                    end
-                elseif name:match("^dtdlink%.") then
-                    dtd[originator] = true
-                    if links[ip] then
-                        links[ip].dtd = true
-                    end
-                elseif name:match("^mid%d+%.") then
-                    if not midcount[originator] then
-                        midcount[originator] = 1
-                    else
-                        midcount[originator] = midcount[originator] + 1
-                    end
-                    if links[ip] then
-                        links[ip].tun = true
-                    end
-                else
-                    if not hosts[originator] then
-                        hosts[originator] = { hosts = {} }
-                    end
-                    local host = hosts[originator]
-                    host.hosts[#host.hosts + 1] = name
-                end
+    local ip, name, originator = line:match("^([%d%.]+)%s+(%S+)%s+%S+%s+(%S+)")
+    if ip and originator and originator ~= "myself" and (routes[ip] or routes[originator]) then
+        local etx = routes[ip]
+        if not etx then
+            etx = routes[originator]
+        end
+        etx = etx.etx
+        if not name:match("%.") or name:match("^mid%.[^%.]*$") then
+            name = name .. ".local.mesh"
+        end
+        if ip == originator then
+            if not hosts[originator] then
+                hosts[originator] = { hosts = {} }
             end
+            local host = hosts[originator]
+            if host.name then
+                host.tactical = name
+            else
+                host.name = name
+                host.etx = etx
+            end
+        elseif name:match("^dtdlink%.") then
+            dtd[originator] = true
+            if links[ip] then
+                links[ip].dtd = true
+            end
+        elseif name:match("^mid%d+%.") then
+            if not midcount[originator] then
+                midcount[originator] = 1
+            else
+                midcount[originator] = midcount[originator] + 1
+            end
+            if links[ip] then
+                links[ip].tun = true
+            end
+        else
+            if not hosts[originator] then
+                hosts[originator] = { hosts = {} }
+            end
+            local host = hosts[originator]
+            host.hosts[#host.hosts + 1] = name
         end
     end
 end
 
 -- discard
 routes = nil
-hosts_lines = nil
 
 for line in io.lines("/var/run/services_olsr")
 do

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -453,8 +453,8 @@ do
         if val == "_add" then
             if host ~= "" then
                 local pattern = "%s" .. host .. "%s"
-                if nixio.fs.stat("/var/run/hosts_olsr") then
-                    for line in io.lines("/var/run/hosts_olsr")
+                if nixio.fs.stat("/var/run/hosts_olsr.stable") then
+                    for line in io.lines("/var/run/hosts_olsr.stable")
                     do
                         if line:lower():match(pattern) then
                             foundhost = true
@@ -649,8 +649,8 @@ do
         if val == "_add" then
             if host ~= "" then
                 local pattern = "%s" .. host .. "%s"
-                if nixio.fs.stat("/var/run/hosts_olsr") then
-                    for line in io.lines("/var/run/hosts_olsr")
+                if nixio.fs.stat("/var/run/hosts_olsr.stable") then
+                    for line in io.lines("/var/run/hosts_olsr.stable")
                     do
                         if line:lower():match(pattern) then
                             foundhost = true

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -59,7 +59,7 @@ function mesh_ip_to_hostnames(ip)
         end
     end
     local hosts = ""
-    for line in io.lines("/var/run/hosts_olsr")
+    for line in io.lines("/var/run/hosts_olsr.stable")
     do
         local host = line:match(pattern)
         if host then

--- a/files/www/cgi-bin/supporttool
+++ b/files/www/cgi-bin/supporttool
@@ -53,6 +53,7 @@ local files = {
     "/etc/mesh-release",
     "/tmp/etc/",
     "/var/run/hosts_olsr",
+    "/var/run/hosts_olsr.stable",
     "/var/run/services_olsr",
     "/tmp/rssi.dat",
     "/tmp/rssi.log",


### PR DESCRIPTION
When the olsr hosts are updated, the file gets truncated which can cause problems for the mesh display.

Here we use the olsrd update notification mechanism to first make a copy of the current hosts_olsr and then atomically move them to the new host_olsr.stable file. This guarantees that the rest of the system never sees a truncated set of hostnames.