### PR TITLE
If redirect ends at an https link assume it is valid

### DIFF
--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -179,9 +179,15 @@ if validate then
                 valid_services[#valid_services + 1] = service
             elseif proto == "http" then
                 -- http so looks like a link. http check it
-                local status = io.popen("/usr/bin/curl --retry 0 --connect-timeout 2 --speed-time 5 --speed-limit 1000 --silent --output /dev/null --location --write-out '%{http_code}' " .. "http://" .. hostname .. ":" .. port .. path):read("*a")
+                local status, effective_url = io.popen("/usr/bin/curl --retry 0 --connect-timeout 2 --speed-time 5 --speed-limit 1000 --silent --output /dev/null --location --write-out '%{http_code} %{url_effective}' " .. "http://" .. hostname .. ":" .. port .. path):read("*a"):match("^(%d+) (.*)")
                 if status == "200" then
                     valid_services[#valid_services + 1] = service
+                elseif status == "301" or status == "302" or status == "308" then
+		    -- Ended at a redirect rather than an actual page.
+                    if effective_url:match("^https:") then
+                        -- We cannot validate https: links so we just assume they're okay
+                        valid_services[#valid_services + 1] = service
+                    end
                 end
             else
                 -- valid port, but we dont know the protocol (we cannot trust the one defined in the services file because the UI wont set


### PR DESCRIPTION
We cannot check https links as we dont have ssl installed, so we just assume any redirect which ends in https://... is valid