### PR TITLE
Switch to more active wifi reset

### DIFF
--- a/files/usr/local/bin/mgr/rssi_monitor.lua
+++ b/files/usr/local/bin/mgr/rssi_monitor.lua
@@ -99,7 +99,7 @@ function run_monitor()
     -- avoid node going deaf while trying to obtain 'normal' statistics of neighbor strength
     -- in first few minutes after boot
     if now > 119 and now < 750 then
-        os.execute("/usr/sbin/iw " .. wifiiface .. " scan freq " .. aredn_info.getFreq() .. " passive")
+        os.execute("/usr/sbin/iw " .. wifiiface .. " scan")
     end
 
     local station_count = 0
@@ -157,7 +157,7 @@ function run_monitor()
 
     if amac then
         -- reset
-        os.execute("/usr/sbin/iw " .. wifiiface .. " scan freq " .. aredn_info.getFreq() .. " passive")
+        os.execute("/usr/sbin/iw " .. wifiiface .. " scan")
         wait_for_ticks(5)
         -- update time
         now = nixio.sysinfo().uptime
@@ -193,7 +193,7 @@ function run_monitor()
         end
     elseif station_count == 0 and last_station_count ~= 0 then
          -- reset
-         os.execute("/usr/sbin/iw " .. wifiiface .. " scan freq " .. aredn_info.getFreq() .. " passive")
+         os.execute("/usr/sbin/iw " .. wifiiface .. " scan")
          wait_for_ticks(5)
          log:write("No stations detected")
     end


### PR DESCRIPTION
The new code was detecting the wifi deadness, but not fixing it. The support tool code did fix the isse. So, let's try using the wifi scan used in the tool (which is active rather than passive).