### PR TITLE
Remove an old "Lua version" display tag

### DIFF
--- a/files/www/cgi-bin/signal
+++ b/files/www/cgi-bin/signal
@@ -254,7 +254,6 @@ local prelude = [[
     </div>
     <center>
         <div class="TopBanner">
-        <div style="float: right;font-size: 8px;color: grey;">Lua version</div>
         <div class="LogoDiv"><img src="/AREDN.png" class="AREDNLogo"></img></div>
         </div>
         <h1><big>$node</big></h1><hr>


### PR DESCRIPTION
Missed this old "lua version" tag when the others were removed.