### PR TITLE
Force a GC before the lua manager sleeps

### DIFF
--- a/files/usr/local/bin/manager.lua
+++ b/files/usr/local/bin/manager.lua
@@ -102,6 +102,10 @@ do
 	table.sort(tasks, function(a,b) return a.time < b.time end)
 	local delay = tasks[1].time - os.time()
 	if delay > 0 then
-		nixio.nanosleep(delay, 0)
+		collectgarbage("collect")
+		delay = tasks[1].time - os.time()
+		if delay > 0 then
+			nixio.nanosleep(delay, 0)
+		end
 	end
 end


### PR DESCRIPTION
Garbage collect before we sleep to keep the memory footprint down. We're about to wait anyway, so now is a good time to do this.