### PR TITLE
add warning message to package display

### DIFF
--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -702,14 +702,14 @@ function isFreeMemoryLow()
     -- get low memory threshold
     local u=uci.cursor()
     local lowmemory = u:get("aredn", "@meshstatus[0]", "lowmem")
-    if not lowmemory then 
-        lowmemory = 10000 
+    if not lowmemory then
+        lowmemory = 10000
     end
     lowmemory = 1024 * tonumber(lowmemory)   -- convert to bytes
-    if nixio.sysinfo().freeram < lowmemory then 
-        return true 
-    else 
-        return false 
+    if (nixio.sysinfo().freeram + nixio.sysinfo().bufferram) < lowmemory then 
+        return true
+    else
+        return false
     end
 end
 

--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -697,6 +697,22 @@ function validate_port_range(range)
 	return true
 end
 
+-- test whether free memory is low
+function isFreeMemoryLow()
+    -- get low memory threshold
+    local u=uci.cursor()
+    local lowmemory = u:get("aredn", "@meshstatus[0]", "lowmem")
+    if not lowmemory then 
+        lowmemory = 10000 
+    end
+    lowmemory = 1024 * tonumber(lowmemory)   -- convert to bytes
+    if nixio.sysinfo().freeram < lowmemory then 
+        return true 
+    else 
+        return false 
+    end
+end
+
 --[[
 LuCI - System library
 

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -555,13 +555,7 @@ function pkgout(msg)
     pkg_output[#pkg_output + 1] = msg
 end
 
--- get low memory threshold
-local lowmemory = cursor:get("aredn", "@meshstatus[0]", "lowmem")
-if not lowmemory then
-    lowmemory = 10000
-end
-lowmemory = 1024 * tonumber(lowmemory)   -- convert to bytes
-if nixio.sysinfo().freeram < lowmemory then
+if isFreeMemoryLow() then
     pkgout("WARNING: this node has low free memory and may not be stable with extra packages installed!")
 end
 

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -555,6 +555,16 @@ function pkgout(msg)
     pkg_output[#pkg_output + 1] = msg
 end
 
+-- get low memory threshold
+local lowmemory = cursor:get("aredn", "@meshstatus[0]", "lowmem")
+if not lowmemory then
+    lowmemory = 10000
+end
+lowmemory = 1024 * tonumber(lowmemory)   -- convert to bytes
+if nixio.sysinfo().freeram < lowmemory then
+    pkgout("WARNING: this node has low free memory and may not be stable with extra packages installed!")
+end
+
 local permpkg = {}
 if nixio.fs.stat("/etc/permpkg") then
     for line in io.lines("/etc/permpkg")


### PR DESCRIPTION
If a node has low free memory then display a warning message that installing extra packages may not be a good idea.