### PR TITLE
stop dnsmasq from filling the log 11/01/2022

### DIFF
--- a/files/etc/dnsmasq.conf
+++ b/files/etc/dnsmasq.conf
@@ -26,3 +26,4 @@ read-ethers
 #    dns server(s): dhcp-option=6,192.168.1.1,192.168.1.2
 
 strict-order
+log-facility=/dev/null


### PR DESCRIPTION
The node's limited log buffer is being filled quickly by dnsmasq which is very chatty.  Once the log buffer fills, then older messages are lost when they may be needed.  There seems to be no way to _reduce_ the chattiness of dnsmasq, but there is a way to keep it from logging altogether.  This allows other important messages to be retained for a longer period of time in the log.