### PR TITLE
Make ntp update script protocol agnostic

### DIFF
--- a/files/etc/cron.daily/update-clock
+++ b/files/etc/cron.daily/update-clock
@@ -49,7 +49,7 @@ fi
 
 # NTP servers tend to be poorly advertised, so we have to use a bit of
 # heuristics to find them
-for candidate in $(grep -i ntp /var/run/services_olsr | sed "s/^http:\/\/\(.*\):.*$/\1/")
+for candidate in $(grep -i ntp /var/run/services_olsr | sed "s/^.*:\/\/\(.*\):.*$/\1/")
 do
     if $(ntpd -n -q -p ${candidate}); then
         logger -p notice -t update-time "Update clock from ${candidate}"


### PR DESCRIPTION
Some people define their ntp clocks using the pseudo protocol ntp:// which which we should allow