### PR TITLE
add kernel MemAvailable to Status page

### DIFF
--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -103,15 +103,16 @@ end
 function get_memavail()
     local f = io.open("/proc/meminfo", "r")
     if f then
-      for line in f:lines()
-      do
-        local memavail = line:match("^MemAvailable:%s+(%d+)%s+kB")
-        if memavail then
-          f:close()
-          return tonumber(memavail)
+        for line in f:lines()
+        do
+            local memavail = line:match("^MemAvailable:%s+(%d+)%s+kB")
+            if memavail then
+                f:close()
+                return memavail
+            end
         end
-      end
     end
+    f:close()
 end
 
 function get_wifi_signal(wifiif)
@@ -413,10 +414,14 @@ else
     rspace = rspace .. " KB"
 end
 local mavail = get_memavail()
-if mavail < 500 then
-    mavail = "<blink><b>" .. mavail .. " KB</b></blink>"
+if mavail then
+    if tonumber(mavail) < 500 then
+        mavail = "<blink><b>" .. mavail .. " KB</b></blink>"
+    else
+        mavail = mavail .. " KB"
+    end
 else
-    mavail = mavail .. " KB"
+    mavail = "unknown"
 end
 
 col2[#col2 + 1] = "<th align=right valign=top><nobr>load average</nobr><br><nobr>available space</nobr></th><td>" .. string.format("%.2f, %.2f, %.2f", sysinfo.loads[1], sysinfo.loads[2], sysinfo.loads[3]) .. "<br><nobr>flash = " .. fspace .. "</nobr><br><nobr>/tmp = " .. tspace .. "</nobr><br><nobr>memory = " .. rspace .. "</nobr><br><nobr>kmemavail = " .. mavail .. "</nobr></td>";

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -100,6 +100,20 @@ function get_default_gw()
     return "none"
 end
 
+function get_memavail()
+    local f = io.open("/proc/meminfo", "r")
+    if f then
+      for line in f:lines()
+      do
+        local memavail = line:match("^MemAvailable:%s+(%d+)%s+kB")
+        if memavail then
+          f:close()
+          return tonumber(memavail)
+        end
+      end
+    end
+end
+
 function get_wifi_signal(wifiif)
     local signal = -1000
     local noise = -1000
@@ -392,15 +406,21 @@ if tspace < 3000 then
 else
     tspace = tspace .. " KB"
 end
-local rspace = (sysinfo.freeram + sysinfo.bufferram) / 1024
+local rspace = sysinfo.freeram / 1024
 if rspace < 500 then
     rspace = "<blink><b>" .. rspace .. " KB</b></blink>"
 else
     rspace = rspace .. " KB"
 end
+local mavail = get_memavail()
+if mavail < 500 then
+    mavail = "<blink><b>" .. mavail .. " KB</b></blink>"
+else
+    mavail = mavail .. " KB"
+end
 
-col2[#col2 + 1] = "<th align=right valign=top><nobr>load average</nobr><br><nobr>free space</nobr></th><td>" .. string.format("%.2f, %.2f, %.2f", sysinfo.loads[1], sysinfo.loads[2], sysinfo.loads[3]) .. "<br><nobr>flash = " .. fspace .. "</nobr><br><nobr>/tmp = " .. tspace .. "</nobr><br><nobr>memory = " .. rspace .. "</nobr></td>";
-col2[#col2 + 1] = "<th align=right valign=top>Host Entries</th><td><nobr>Total = " .. host_total .. "<nobr><br><nobr>Nodes = " .. host_nodes .. "<nobr></td>"
+col2[#col2 + 1] = "<th align=right valign=top><nobr>load average</nobr><br><nobr>available space</nobr></th><td>" .. string.format("%.2f, %.2f, %.2f", sysinfo.loads[1], sysinfo.loads[2], sysinfo.loads[3]) .. "<br><nobr>flash = " .. fspace .. "</nobr><br><nobr>/tmp = " .. tspace .. "</nobr><br><nobr>memory = " .. rspace .. "</nobr><br><nobr>kmemavail = " .. mavail .. "</nobr></td>";
+col2[#col2 + 1] = "<th align=right valign=top>Host Entries</th><td><nobr>Total = " .. host_total .. "</nobr><br><nobr>Nodes = " .. host_nodes .. "<nobr></td>"
 
 -- now print the tables
 

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -108,11 +108,12 @@ function get_memavail()
             local memavail = line:match("^MemAvailable:%s+(%d+)%s+kB")
             if memavail then
                 f:close()
-                return memavail
+                return tonumber(memavail)
             end
         end
         f:close()
     end
+    return 0
 end
 
 function get_wifi_signal(wifiif)
@@ -400,24 +401,20 @@ if fspace < 100 then
 else
     fspace = fspace .. " KB"
 end
+
 local rspace = sysinfo.freeram / 1024
+local mavail = get_memavail()
+if rspace < mavail then
+    rspace = mavail
+end
+
 if rspace < 500 then
     rspace = "<blink><b>" .. rspace .. " KB</b></blink>"
 else
     rspace = rspace .. " KB"
 end
-local mavail = get_memavail()
-if mavail then
-    if tonumber(mavail) < 500 then
-        mavail = "<blink><b>" .. mavail .. " KB</b></blink>"
-    else
-        mavail = mavail .. " KB"
-    end
-else
-    mavail = "unknown"
-end
 
-col2[#col2 + 1] = "<th align=right valign=top><nobr>load average</nobr><br><nobr>available space</nobr></th><td>" .. string.format("%.2f, %.2f, %.2f", sysinfo.loads[1], sysinfo.loads[2], sysinfo.loads[3]) .. "<br><nobr>flash = " .. fspace .. "</nobr><br><nobr>memory = " .. rspace .. "</nobr><br><nobr>kmemavail = " .. mavail .. "</nobr></td>";
+col2[#col2 + 1] = "<th align=right valign=top><nobr>load average</nobr><br><nobr>available space</nobr></th><td>" .. string.format("%.2f, %.2f, %.2f", sysinfo.loads[1], sysinfo.loads[2], sysinfo.loads[3]) .. "<br><nobr>flash = " .. fspace .. "</nobr><br><nobr>memory = " .. rspace .. "</nobr></td>";
 col2[#col2 + 1] = "<th align=right valign=top>Host Entries</th><td><nobr>Total = " .. host_total .. "</nobr><br><nobr>Nodes = " .. host_nodes .. "<nobr></td>"
 
 -- now print the tables

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -111,8 +111,8 @@ function get_memavail()
                 return memavail
             end
         end
+        f:close()
     end
-    f:close()
 end
 
 function get_wifi_signal(wifiif)

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -400,13 +400,6 @@ if fspace < 100 then
 else
     fspace = fspace .. " KB"
 end
-vfs = nixio.fs.statvfs("/tmp")
-local tspace = vfs.bfree * vfs.bsize / 1024
-if tspace < 3000 then
-    tspace = "<blink><b>" .. tspace .. " KB</b></blink>"
-else
-    tspace = tspace .. " KB"
-end
 local rspace = sysinfo.freeram / 1024
 if rspace < 500 then
     rspace = "<blink><b>" .. rspace .. " KB</b></blink>"
@@ -424,7 +417,7 @@ else
     mavail = "unknown"
 end
 
-col2[#col2 + 1] = "<th align=right valign=top><nobr>load average</nobr><br><nobr>available space</nobr></th><td>" .. string.format("%.2f, %.2f, %.2f", sysinfo.loads[1], sysinfo.loads[2], sysinfo.loads[3]) .. "<br><nobr>flash = " .. fspace .. "</nobr><br><nobr>/tmp = " .. tspace .. "</nobr><br><nobr>memory = " .. rspace .. "</nobr><br><nobr>kmemavail = " .. mavail .. "</nobr></td>";
+col2[#col2 + 1] = "<th align=right valign=top><nobr>load average</nobr><br><nobr>available space</nobr></th><td>" .. string.format("%.2f, %.2f, %.2f", sysinfo.loads[1], sysinfo.loads[2], sysinfo.loads[3]) .. "<br><nobr>flash = " .. fspace .. "</nobr><br><nobr>memory = " .. rspace .. "</nobr><br><nobr>kmemavail = " .. mavail .. "</nobr></td>";
 col2[#col2 + 1] = "<th align=right valign=top>Host Entries</th><td><nobr>Total = " .. host_total .. "</nobr><br><nobr>Nodes = " .. host_nodes .. "<nobr></td>"
 
 -- now print the tables


### PR DESCRIPTION
Add the _MemAvailable_ value from `/proc/meminfo` to the **Status** page.  This value is an estimate of how much memory is available for starting new applications. The linux kernel calculates this value from MemFree, SReclaimable, the size of the file LRU lists, and the low watermarks in each zone.  [See this link for more information on MemAvailable](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773).

This PR also removes the buffer cache value from the free memory calculation, which inflates the free memory value (per Joe AE6XE).  It continues to display the sysinfo value for comparison purposes.  It also removes the confusing /tmp free value, since it is not separate storage space but is already included in the available memory figure.

