### PR TITLE
Improve xlink integration

### DIFF
--- a/files/etc/local/mesh-firewall/05-xlink
+++ b/files/etc/local/mesh-firewall/05-xlink
@@ -42,29 +42,23 @@ if nixio.fs.stat("/etc/config.mesh/xlink") then
     uci.cursor("/etc/config.mesh"):foreach("xlink", "interface",
         function(section)
             local ifname = section.ifname
-            os.execute("/usr/sbin/iptables -D FORWARD -i " .. ifname .. " -j zone_vpn_forward 2>/dev/null")
-            os.execute("/usr/sbin/iptables -D INPUT -i " .. ifname .. " -j zone_vpn_input 2>/dev/null")
-            os.execute("/usr/sbin/iptables -D OUTPUT -o " .. ifname .. " -j zone_vpn_ACCEPT 2>/dev/null")
-            os.execute("/usr/sbin/iptables -D zone_vpn_ACCEPT -o " .. ifname .. " -j ACCEPT")
-            os.execute("/usr/sbin/iptables -D zone_vpn_ACCEPT -i " .. ifname .. " -j ACCEPT")
-            os.execute("/usr/sbin/iptables -D zone_vpn_REJECT -o " .. ifname .. " -j reject")
-            os.execute("/usr/sbin/iptables -D zone_vpn_REJECT -i " .. ifname .. " -j reject")
-            os.execute("/usr/sbin/iptables -D zone_vpn_dest_ACCEPT -o " .. ifname .. " -j ACCEPT")
-            os.execute("/usr/sbin/iptables -D zone_vpn_dest_REJECT -o " .. ifname .. " -j reject")
+            os.execute("/usr/sbin/iptables -D FORWARD -i " .. ifname .. " -j zone_dtdlink_forward")
+            os.execute("/usr/sbin/iptables -D INPUT -i " .. ifname .. " -j zone_dtdlink_input")
+            os.execute("/usr/sbin/iptables -D OUTPUT -o " .. ifname .. " -j zone_dtdlink_output")
+            os.execute("/usr/sbin/iptables -D zone_dtdlink_dest_ACCEPT -o " .. ifname .. " -j ACCEPT")
+            os.execute("/usr/sbin/iptables -D zone_dtdlink_dest_REJECT -o " .. ifname .. " -j reject")
+            os.execute("/usr/sbin/iptables -D zone_dtdlink_src_REJECT -i " .. ifname .. " -j reject")
         end
     )
     uci.cursor("/etc/config.mesh"):foreach("xlink", "interface",
         function(section)
             local ifname = section.ifname
-            os.execute("/usr/sbin/iptables -I FORWARD -i " .. ifname .. " -j zone_vpn_forward")
-            os.execute("/usr/sbin/iptables -I INPUT -i " .. ifname .. " -j zone_vpn_input")
-            os.execute("/usr/sbin/iptables -I OUTPUT -o " .. ifname .. " -j zone_vpn_ACCEPT")
-            os.execute("/usr/sbin/iptables -A zone_vpn_ACCEPT -o " .. ifname .. " -j ACCEPT")
-            os.execute("/usr/sbin/iptables -A zone_vpn_ACCEPT -i " .. ifname .. " -j ACCEPT")
-            os.execute("/usr/sbin/iptables -A zone_vpn_REJECT -o " .. ifname .. " -j reject")
-            os.execute("/usr/sbin/iptables -A zone_vpn_REJECT -i " .. ifname .. " -j reject")
-            os.execute("/usr/sbin/iptables -A zone_vpn_dest_ACCEPT -o " .. ifname .. " -j ACCEPT")
-            os.execute("/usr/sbin/iptables -A zone_vpn_dest_REJECT -o " .. ifname .. " -j reject")
+            os.execute("/usr/sbin/iptables -I FORWARD -i " .. ifname .. " -j zone_dtdlink_forward")
+            os.execute("/usr/sbin/iptables -A INPUT -i " .. ifname .. " -j zone_dtdlink_input")
+            os.execute("/usr/sbin/iptables -A OUTPUT -o " .. ifname .. " -j zone_dtdlink_output")
+            os.execute("/usr/sbin/iptables -A zone_dtdlink_dest_ACCEPT -o " .. ifname .. " -j ACCEPT")
+            os.execute("/usr/sbin/iptables -A zone_dtdlink_dest_REJECT -o " .. ifname .. " -j reject")
+            os.execute("/usr/sbin/iptables -A zone_dtdlink_src_REJECT -i " .. ifname .. " -j reject")
         end
     )
 end

--- a/files/etc/local/mesh-firewall/05-xlink
+++ b/files/etc/local/mesh-firewall/05-xlink
@@ -1,4 +1,4 @@
-O--[[
+--[[
 
 	Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
 	Copyright (C) 2022 Tim Wilkinson

--- a/files/etc/local/mesh-firewall/05-xlink
+++ b/files/etc/local/mesh-firewall/05-xlink
@@ -1,5 +1,4 @@
-#! /usr/bin/lua
---[[
+O--[[
 
 	Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
 	Copyright (C) 2022 Tim Wilkinson
@@ -50,6 +49,8 @@ if nixio.fs.stat("/etc/config.mesh/xlink") then
             os.execute("/usr/sbin/iptables -D zone_dtdlink_src_REJECT -i " .. ifname .. " -j reject")
         end
     )
+	os.execute("/usr/sbin/iptables -D zone_dtdlink_forward -j zone_dtdlink_dest_ACCEPT")
+	local addrule = false
     uci.cursor("/etc/config.mesh"):foreach("xlink", "interface",
         function(section)
             local ifname = section.ifname
@@ -59,6 +60,10 @@ if nixio.fs.stat("/etc/config.mesh/xlink") then
             os.execute("/usr/sbin/iptables -A zone_dtdlink_dest_ACCEPT -o " .. ifname .. " -j ACCEPT")
             os.execute("/usr/sbin/iptables -A zone_dtdlink_dest_REJECT -o " .. ifname .. " -j reject")
             os.execute("/usr/sbin/iptables -A zone_dtdlink_src_REJECT -i " .. ifname .. " -j reject")
+			addrule = true
         end
     )
+	if addrule then
+		os.execute("/usr/sbin/iptables -I zone_dtdlink_forward -j zone_dtdlink_dest_ACCEPT")
+	end
 end

--- a/files/etc/local/mesh-firewall/05-xlink
+++ b/files/etc/local/mesh-firewall/05-xlink
@@ -1,3 +1,4 @@
+#! /usr/bin/lua
 --[[
 
 	Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -327,6 +327,36 @@ function lqm()
             end
         end
 
+        -- Xlink
+        if nixio.fs.stat("/etc/config.mesh/xlink") then
+            uci.cursor("/etc/config.mesh"):foreach("xlink", "interface",
+                function(section)
+                    if section.peer and section.ifname then
+                        local foundmac
+                        for mac, entry in pairs(arps)
+                        do
+                            if entry["IP address"] == section.peer then
+                                foundmac = mac
+                                break
+                            end
+                        end
+                        if foundmac then
+                            stations[#stations + 1] = {
+                                type = "Xlink",
+                                device = section.ifname,
+                                signal = nil,
+                                ip = section.peer,
+                                mac = foundmac,
+                                tx_packets = 0,
+                                tx_fail = 0,
+                                tx_retries = 0
+                            }
+                        end
+                    end
+                end
+            )
+        end
+
         for _, station in ipairs(stations)
         do
             if station.signal ~= 0 and not our_macs[station.mac] then
@@ -373,7 +403,7 @@ function lqm()
                 if not track.hostname and track.ip then
                     local hostname = nixio.getnameinfo(track.ip)
                     if hostname then
-                        track.hostname = hostname:lower():gsub("^dtdlink%.",""):gsub("^mid%d+%.",""):gsub("%.local%.mesh$", "")
+                        track.hostname = hostname:lower():gsub("^dtdlink%.",""):gsub("^mid%d+%.",""):gsub("^xlink%d+%.",""):gsub("%.local%.mesh$", "")
                     end
                 end
 

--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -134,10 +134,21 @@ if dmz_mode ~= "0" then
     end
 end
 
--- add a name for the dtdlink interface
+-- add a name for the dtdlink and xlink interfaces
 if name then
     local dtdip = aredn.hardware.get_interface_ip4(aredn.hardware.get_iface_name("dtdlink"))
     hosts[#hosts + 1] = { ip = dtdip, host = "dtdlink." .. name .. ".local.mesh" }
+    if nixio.fs.stat("/etc/config.mesh/xlink") then
+        local count = 0
+        uci.cursor("/etc/config.mesh"):foreach("xlink", "interface",
+            function(section)
+                if section.ipaddr then
+                    hosts[#hosts + 1] = { ip = section.ipaddr, host = "xlink" .. count .. "." .. name .. ".local.mesh" }
+                    count = count + 1
+                end
+            end
+        )
+    end
 end
 
 -- load the services

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -345,6 +345,11 @@ if nixio.fs.stat("/var/run/hosts_olsr.stable") then
                 if links[ip] then
                     links[ip].dtd = true
                 end
+            elseif name:match("^xlink%d+%.") then
+                dtd[originator] = true
+                if links[ip] then
+                    links[ip].xlink = true
+                end
             elseif name:match("^mid%d+%.") then
                 if not midcount[originator] then
                     midcount[originator] = 1
@@ -663,6 +668,8 @@ do
     if ipmain ~= ip then
         if links[ip].dtd then
             nodeiface = "dtd"
+        elseif links[ip].xlink then
+            nodeiface = "xlink"
         elseif links[ip].tun then
             nodeiface = "tun"
         else


### PR DESCRIPTION
Improve integration of external links (xlinks).
These are the extra vlan links, often to non-aredn radios. These changes better integrate the links into the other
subsystems, including how they look on the Mesh page, and allows LQM to monitor them.