### PR TITLE
remove reference to nodes reducing power

### DIFF
--- a/files/www/help.html
+++ b/files/www/help.html
@@ -255,7 +255,7 @@ interfaces are set.</p>
 <ul>
 <li><a name=channel></a>The <strong>Channel</strong> and <strong>Channel Width</strong> selection determines the center frequency and signal bandwidth.  AREDN&#174; reminds operators that they must select frequencies, bandwidths, and power levels which comply with their country's amateur radio license requirements.<br><br></li>
 
-<li><a name=power></a>The <strong>Power</strong> setting controls the maximum power the unit may transmit. Some devices may have max power levels that change based on which channel/frequency the hardware is operating on, and in this case the max level will change when you save settings and will be capped at the max level supported by the hardware for that frequency.</li>
+<li><a name=power></a>The <strong>Power</strong> selector specifies the maximum power the unit may transmit.</li>
 </ul></p>
 
 <p>The final section of the <strong>Mesh RF</strong> column will show <strong>Power &amp; Distance</strong> settings if you have the <strong>Link Quality Manager</strong> <em>disabled</em>.</p>

--- a/files/www/help.html
+++ b/files/www/help.html
@@ -255,7 +255,7 @@ interfaces are set.</p>
 <ul>
 <li><a name=channel></a>The <strong>Channel</strong> and <strong>Channel Width</strong> selection determines the center frequency and signal bandwidth.  AREDN&#174; reminds operators that they must select frequencies, bandwidths, and power levels which comply with their country's amateur radio license requirements.<br><br></li>
 
-<li><a name=power></a>The <strong>Power</strong> setting controls the maximum power the unit may transmit. A node may decrease its power output automatically as it enters higher data rates to maintain a linear spectrum. Some devices may have max power levels that change based on which channel/frequency the hardware is operating on, and in this case the max level will change when you save settings and will be capped at the max level supported by the hardware for that frequency.</li>
+<li><a name=power></a>The <strong>Power</strong> setting controls the maximum power the unit may transmit. Some devices may have max power levels that change based on which channel/frequency the hardware is operating on, and in this case the max level will change when you save settings and will be capped at the max level supported by the hardware for that frequency.</li>
 </ul></p>
 
 <p>The final section of the <strong>Mesh RF</strong> column will show <strong>Power &amp; Distance</strong> settings if you have the <strong>Link Quality Manager</strong> <em>disabled</em>.</p>


### PR DESCRIPTION
Remove reference to nodes reducing power levels per @ae6xe Joe.

> Re: node may reduce power at higher link rates.  While this behavior is stated in Ubiquiti specifications, I've never seen anything in ath9k or openwrt forums that suggests this occurs in the open source implementations. I'd speculate that open source, and thus AREDN, does not have this behavior. I've also not seen any information of what other vendor's do.