### PR TITLE
add WAN wifi ssid and snr to Status page

### DIFF
--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -157,6 +157,8 @@ local config = aredn_info.get_nvram("config")
 if config == "" or nixio.fs.stat("/etc/config.mesh", "type") ~= "dir" then
     config = "not set"
 end
+
+-- get wifi interface info
 local wifi_iface = aredn.hardware.get_iface_name("wifi")
 local wifi_nr = wifi_iface:match("wlan(%d+)")
 local wifi_disabled = true
@@ -166,11 +168,15 @@ if wifi_nr then
     radio = "radio" .. wifi_nr
 end
 
+-- get wan interface info
+local wan_iface = aredn.hardware.get_iface_name("wan")
+
 local cursor = uci.cursor()
 
 local wifi_channel
 local wifi_chanbw
 local wifi_ssid
+local wan_wifi_ssid
 if not wifi_disabled then
     wifi_channel = tonumber(cursor:get("wireless", radio, "channel"))
     if wifi_channel >= 76 and wifi_channel <= 99 then
@@ -182,6 +188,10 @@ if not wifi_disabled then
         function (section)
             if section.network == "wifi" then
                 wifi_ssid = section.ssid
+                return false
+            end
+            if section.network == "wan" then
+                wan_wifi_ssid = section.ssid
                 return false
             end
         end
@@ -336,18 +346,29 @@ if ip:match("^10%.") or not hide_local then
     col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
 end
 
-local wan_iface = aredn.hardware.get_iface_name("wan")
 if not hide_local and wan_iface then
     local ip, bcast, mask = aredn.hardware.get_interface_ip4(wan_iface)
     local wprefix = ""
+    local wan_wifi_snr
     if wan_iface:match("^wlan%d+$") then
-        wprefix = "WiFi "
+        wprefix = "wifi "
+        local s, n = get_wifi_signal(wan_iface)
+        wan_wifi_snr = math.abs(s - n)
     end
+
     if ip then
         cidr = netmask_to_cidr(mask)
-        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
+        if wprefix == "" then
+            col1[#col1 + 1] = "<th align=right><nobr>WAN address:</nobr><br><nobr>" .. "</th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
+        else
+            if wan_wifi_ssid and wan_wifi_snr then
+                col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr><br><nobr>" .. wprefix .. "WAN SSID / SNR:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " / " .. wan_wifi_snr .. " dB</td>"
+            else
+                col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
+            end
+        end
     else
-        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr></th><td>none</small><br>"
+        col1[#col1 + 1] = "<th align=right><nobr>WAN address:</nobr></th><td>none</small></td>"
     end
 end
 
@@ -368,7 +389,7 @@ end
 -- right column - system info
 
 if config == "mesh" and not wifi_disabled then
-    col2[#col2 + 1] = "<th align=right valign=middle><nobr>signal / noise / ratio:</nobr></th><td valign=middle><nobr>"
+    col2[#col2 + 1] = "<th align=right valign=middle><nobr>signal / noise / SNR:</nobr></th><td valign=middle><nobr>"
     local s, n = get_wifi_signal(wifi_iface)
     if s == "N/A" then
         col2[#col2] = col2[#col2] .. "no RF links"

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -131,6 +131,12 @@ function get_wifi_signal(wifiif)
     if signal == -1000 or noise == -1000 then
         return "none", "none"
     else
+        if signal > 0 then
+            signal = (0 - signal)
+        end
+        if noise > 0 then
+            noise = (0 - noise)
+        end
         return signal, noise
     end
 end
@@ -337,16 +343,19 @@ if ip:match("^10%.") or not hide_local then
     col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
 end
 
--- process wan interface
 local wan_iface = aredn.hardware.get_iface_name("wan")
 if not hide_local and wan_iface then
     local ip, bcast, mask = aredn.hardware.get_interface_ip4(wan_iface)
     local wprefix = ""
+    local wan_wifi_sig = "none"
+    local wan_wifi_noi = "none"
     local wan_wifi_snr = "none"
     if wan_iface:match("^wlan%d+$") then
         wprefix = "wifi "
         local s, n = get_wifi_signal(wan_iface)
         if s ~= "none" and n ~= "none" then
+            wan_wifi_sig = s
+            wan_wifi_noi = n
             wan_wifi_snr = math.abs(s - n)
         end
     end
@@ -359,8 +368,9 @@ if not hide_local and wan_iface then
             end
         end
     )
-    if not wan_wifi_ssid then wan_wifi_ssid = "none" end
-
+    if not wan_wifi_ssid then     -- if still nil then set default
+        wan_wifi_ssid = "none"
+    end
 
     if ip then
         cidr = netmask_to_cidr(mask)

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -193,7 +193,7 @@ if not wifi_disabled then
     )
 end
 
-local wan_wifi_ssid = "none"
+local wan_wifi_ssid
 cursor:foreach("wireless", "wifi-iface",
     function (section)
         if section.network == "wan" then
@@ -202,6 +202,7 @@ cursor:foreach("wireless", "wifi-iface",
         end
     end
 )
+if not wan_wifi_ssid then wan_wifi_ssid = "none" end
 
 local node_desc = cursor:get("system", "@system[0]", "description")
 local lat_lon = "<strong>Location Not Available</strong>"

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -196,6 +196,15 @@ if not wifi_disabled then
             end
         end
     )
+else
+    cursor:foreach("wireless", "wifi-iface",
+        function (section)
+            if section.network == "wan" then
+                wan_wifi_ssid = section.ssid
+                return false
+            end
+        end
+    )
 end
 
 local node_desc = cursor:get("system", "@system[0]", "description")

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -158,7 +158,6 @@ if config == "" or nixio.fs.stat("/etc/config.mesh", "type") ~= "dir" then
     config = "not set"
 end
 
--- get wifi interface info
 local wifi_iface = aredn.hardware.get_iface_name("wifi")
 local wifi_nr = wifi_iface:match("wlan(%d+)")
 local wifi_disabled = true
@@ -167,9 +166,6 @@ if wifi_nr then
     wifi_disabled = false
     radio = "radio" .. wifi_nr
 end
-
--- get wan interface info
-local wan_iface = aredn.hardware.get_iface_name("wan")
 
 local cursor = uci.cursor()
 
@@ -192,17 +188,6 @@ if not wifi_disabled then
         end
     )
 end
-
-local wan_wifi_ssid
-cursor:foreach("wireless", "wifi-iface",
-    function (section)
-        if section.network == "wan" then
-            wan_wifi_ssid = section.ssid
-            return false
-        end
-    end
-)
-if not wan_wifi_ssid then wan_wifi_ssid = "none" end
 
 local node_desc = cursor:get("system", "@system[0]", "description")
 local lat_lon = "<strong>Location Not Available</strong>"
@@ -352,6 +337,8 @@ if ip:match("^10%.") or not hide_local then
     col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
 end
 
+-- process wan interface
+local wan_iface = aredn.hardware.get_iface_name("wan")
 if not hide_local and wan_iface then
     local ip, bcast, mask = aredn.hardware.get_interface_ip4(wan_iface)
     local wprefix = ""
@@ -363,6 +350,17 @@ if not hide_local and wan_iface then
             wan_wifi_snr = math.abs(s - n)
         end
     end
+    local wan_wifi_ssid
+    cursor:foreach("wireless", "wifi-iface",
+        function (section)
+            if section.network == "wan" then
+                wan_wifi_ssid = section.ssid
+                return false
+            end
+        end
+    )
+    if not wan_wifi_ssid then wan_wifi_ssid = "none" end
+
 
     if ip then
         cidr = netmask_to_cidr(mask)

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -129,7 +129,7 @@ function get_wifi_signal(wifiif)
         end
     end
     if signal == -1000 or noise == -1000 then
-        return "N/A", "N/A"
+        return "none", "none"
     else
         return signal, noise
     end
@@ -182,7 +182,7 @@ if not wifi_disabled then
         wifi_channel = wifi_channel * 5 + 3000
     end
     wifi_chanbw = cursor:get("wireless", radio, "chanbw")
-    wifi_ssid = "N/A"
+    wifi_ssid = "none"
     cursor:foreach("wireless", "wifi-iface",
         function (section)
             if section.network == "wifi" then
@@ -193,7 +193,7 @@ if not wifi_disabled then
     )
 end
 
-local wan_wifi_ssid
+local wan_wifi_ssid = "none"
 cursor:foreach("wireless", "wifi-iface",
     function (section)
         if section.network == "wan" then
@@ -354,11 +354,13 @@ end
 if not hide_local and wan_iface then
     local ip, bcast, mask = aredn.hardware.get_interface_ip4(wan_iface)
     local wprefix = ""
-    local wan_wifi_snr
+    local wan_wifi_snr = "none"
     if wan_iface:match("^wlan%d+$") then
         wprefix = "wifi "
         local s, n = get_wifi_signal(wan_iface)
-        wan_wifi_snr = math.abs(s - n)
+        if s ~= "none" and n ~= "none" then
+            wan_wifi_snr = math.abs(s - n)
+        end
     end
 
     if ip then
@@ -366,7 +368,7 @@ if not hide_local and wan_iface then
         if wprefix == "" then
             col1[#col1 + 1] = "<th align=right><nobr>WAN address:</nobr><br><nobr>" .. "</th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
         else
-            if wan_wifi_ssid and wan_wifi_snr then
+            if wan_wifi_ssid ~= "none" and wan_wifi_snr ~= "none" then
                 col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr><br><nobr>" .. wprefix .. "WAN SSID / SNR:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " / " .. wan_wifi_snr .. " dB</td>"
             else
                 col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
@@ -396,7 +398,7 @@ end
 if config == "mesh" and not wifi_disabled then
     col2[#col2 + 1] = "<th align=right valign=middle><nobr>signal / noise / SNR:</nobr></th><td valign=middle><nobr>"
     local s, n = get_wifi_signal(wifi_iface)
-    if s == "N/A" then
+    if s == "none" then
         col2[#col2] = col2[#col2] .. "no RF links"
     else
         col2[#col2] = col2[#col2] .. "<big><b>" .. s .. " / " .. n .. " / " .. math.abs(s - n) .. " dB</b></big>"

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -176,7 +176,6 @@ local cursor = uci.cursor()
 local wifi_channel
 local wifi_chanbw
 local wifi_ssid
-local wan_wifi_ssid
 if not wifi_disabled then
     wifi_channel = tonumber(cursor:get("wireless", radio, "channel"))
     if wifi_channel >= 76 and wifi_channel <= 99 then
@@ -190,22 +189,19 @@ if not wifi_disabled then
                 wifi_ssid = section.ssid
                 return false
             end
-            if section.network == "wan" then
-                wan_wifi_ssid = section.ssid
-                return false
-            end
-        end
-    )
-else
-    cursor:foreach("wireless", "wifi-iface",
-        function (section)
-            if section.network == "wan" then
-                wan_wifi_ssid = section.ssid
-                return false
-            end
         end
     )
 end
+
+local wan_wifi_ssid
+cursor:foreach("wireless", "wifi-iface",
+    function (section)
+        if section.network == "wan" then
+            wan_wifi_ssid = section.ssid
+            return false
+        end
+    end
+)
 
 local node_desc = cursor:get("system", "@system[0]", "description")
 local lat_lon = "<strong>Location Not Available</strong>"


### PR DESCRIPTION
Add a line showing the WAN wifi SSID and SNR if the node is using its Wifi as WAN connection.

**Here is the Status page with no WAN connection:**
![2022-11-22_12-34](https://user-images.githubusercontent.com/69524416/203417197-eed677f8-24e0-4628-bf30-386569bfdcf9.png)

**Here is the Status page with Ethernet WAN connection:**
![2022-11-22_12-35](https://user-images.githubusercontent.com/69524416/203417315-ddb7619b-e7ff-40b2-8a47-81816594af90.png)

**Here is the Status page with Wifi WAN connection:**
![Screenshot 2022-11-22 at 12 49 29 PM](https://user-images.githubusercontent.com/69524416/203417401-11b738a3-7c97-4cb3-bd1c-1900f3ef3aa0.png)
