### PR TITLE
display both types of gateway on Status page

### DIFF
--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -321,7 +321,7 @@ if wifi_disabled then
     col1[#col1 + 1] = "<th align=right><nobr>primary address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
 else
     wifi_gw = get_default_gw("wifi")
-    col1[#col1 + 1] = "<th align=right>--- Mesh RF ---<br><nobr>IP address:</nobr><br><nobr>gateway:</nobr><br><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "<br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
+    col1[#col1 + 1] = "<th align=right><span style=text-decoration:underline;'>Mesh RF</span><br><nobr>IP address:</nobr><br><nobr>gateway:</nobr><br><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "<br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
 end
 
 ip = cursor:get("network", "lan", "ipaddr")
@@ -376,26 +376,26 @@ if wan_iface and not hide_local then
         if wprefix == "" then     -- no wifi wan
             if wan_gw:match("^10%.") or not hide_local then
                 if wan_gw:match("^10%.") then
-                    col1[#col1 + 1] = "<th align=right><nobr>--- WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                    col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                 else
-                    col1[#col1 + 1] = "<th align=right><nobr>--- WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                    col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
                 end
             end
         else     -- with wifi wan
             if wan_wifi_ssid ~= "none" and wan_wifi_snr ~= "none" then
                 if wan_gw:match("^10%.") or not hide_local then
                     if wan_gw:match("^10%.") then
-                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                     else
-                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "</td>"
+                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "</td>"
                     end
                 end
             else
                 if wan_gw:match("^10%.") or not hide_local then
                     if wan_gw:match("^10%.") then
-                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                     else
-                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
                     end
                 end
             end

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -49,7 +49,8 @@ function mesh_ip_to_hostnames(ip)
     if not ip or ip == "" or ip == "none" then
         return ""
     end
-    local pattern = "^" .. ip .. "%s+([%w%-]+)"
+    local pattern = "^" .. ip .. "%s+([%w%-%.]+)"
+    local host = "none"
     for line in io.lines("/etc/hosts")
     do
         local host = line:match(pattern)
@@ -57,35 +58,34 @@ function mesh_ip_to_hostnames(ip)
             return host.gsub("%s+", " / ")
         end
     end
-    local hosts = ""
     if nixio.fs.stat("/var/run/hosts_olsr.stable") then
         for line in io.lines("/var/run/hosts_olsr.stable")
         do
             local host = line:match(pattern)
             if host then
-                hosts = hosts .. " / " .. host
+                host = host:gsub("^dtdlink%.","")
+                host = host:gsub("^mid[0-9]*%.","")
+                host = host:gsub("%.local.mesh$","")
+                return host
             end
         end
     end
-    return hosts:sub(4, #hosts)
+    return host
 end
 
-function get_default_gw()
-    -- a node with a wired default gw will route via this
-    local p = io.popen("ip route list table 254")
-    if p then
-        for line in p:lines()
-        do
-            local gw = line:match("^default%svia%s([%d%.]+)")
-            if gw then
-                p:close()
-                return gw
-            end
-        end
-        p:close()
+function get_default_gw(iface)
+    -- wan will route via table 254 default gw
+    -- wifi will route via OLSR table 31 default gw
+    local rtable = ""
+    if iface == "wan" then
+        rtable = "ip route list table 254"
+    elseif iface == "wifi" then
+        rtable = "ip route list table 31"
+    else
+        return "none"
     end
-    -- table 31 is populated by OLSR
-    p = io.popen("ip route list table 31")
+
+    local p = io.popen(rtable)
     if p then
         for line in p:lines()
         do
@@ -320,7 +320,8 @@ local cidr = netmask_to_cidr(cursor:get("network", "wifi", "netmask"))
 if wifi_disabled then
     col1[#col1 + 1] = "<th align=right><nobr>primary address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
 else
-    col1[#col1 + 1] = "<th align=right><nobr>mesh RF address:</nobr><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
+    wifi_gw = get_default_gw("wifi")
+    col1[#col1 + 1] = "<th align=right>--- Mesh RF ---<br><nobr>IP address:</nobr><br><nobr>gateway:</nobr><br><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "<br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
 end
 
 ip = cursor:get("network", "lan", "ipaddr")
@@ -337,80 +338,84 @@ if remote_ip then
         hide_local = true
     end
 end
-
 if ip:match("^10%.") or not hide_local then
     cidr = netmask_to_cidr(mask)
-    col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
+    col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
 end
 
 local wan_iface = aredn.hardware.get_iface_name("wan")
-if not hide_local and wan_iface then
+if wan_iface and not hide_local then
     local ip, bcast, mask = aredn.hardware.get_interface_ip4(wan_iface)
-    local wprefix = ""
-    local wan_wifi_sig = "none"
-    local wan_wifi_noi = "none"
-    local wan_wifi_snr = "none"
-    if wan_iface:match("^wlan%d+$") then
-        wprefix = "wifi "
-        local s, n = get_wifi_signal(wan_iface)
-        if s ~= "none" and n ~= "none" then
-            wan_wifi_sig = s
-            wan_wifi_noi = n
-            wan_wifi_snr = math.abs(s - n)
-        end
-    end
-    local wan_wifi_ssid
-    cursor:foreach("wireless", "wifi-iface",
-        function (section)
-            if section.network == "wan" then
-                wan_wifi_ssid = section.ssid
-                return false
-            end
-        end
-    )
-    if not wan_wifi_ssid then     -- if still nil then set default
-        wan_wifi_ssid = "none"
-    end
-
-    if ip then
-        cidr = netmask_to_cidr(mask)
-        if wprefix == "" then
-            col1[#col1 + 1] = "<th align=right><nobr>WAN address:</nobr><br><nobr>" .. "</th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
-        else
-            if wan_wifi_ssid ~= "none" and wan_wifi_snr ~= "none" then
-                col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr><br><nobr>" .. wprefix .. "WAN SSID / SNR:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " / " .. wan_wifi_snr .. " dB</td>"
-            else
-                col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
-            end
-        end
+    if not ip then
+        col1[#col1 + 1] = "<th align=right valign=top><nobr>WAN address:</nobr><br><nobr>default gateway:</nobr></th><td>none<br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "</td>"
     else
-        col1[#col1 + 1] = "<th align=right><nobr>WAN address:</nobr></th><td>none</small></td>"
-    end
-end
+        local wprefix = ""
+        local wan_wifi_snr = "none"
+        local wan_wifi_ssid
+        if wan_iface:match("^wlan%d+$") then
+            wprefix = "wifi "
+            local s, n = get_wifi_signal(wan_iface)
+            if s ~= "none" and n ~= "none" then
+                wan_wifi_snr = math.abs(s - n)
+            end
+            cursor:foreach("wireless", "wifi-iface",
+                function (section)
+                    if section.network == "wan" then
+                        wan_wifi_ssid = section.ssid
+                        return false
+                    end
+                end
+            )
+            if not wan_wifi_ssid then     -- if still nil then set default
+                wan_wifi_ssid = "none"
+            end
+        end
 
-ip = get_default_gw()
-if ip:match("^10%.") or not hide_local then
-    col1[#col1 + 1] = "<th align=right valign=top><nobr>default gateway:</nobr></th><td>" .. ip
-    if ip:match("^10%.") then
-        col1[#col1] = col1[#col1] .. "<br><nobr>" ..  mesh_ip_to_hostnames(ip) .. "</nobr>"
+        cidr = netmask_to_cidr(mask)
+        wan_gw = get_default_gw("wan")
+        if wprefix == "" then     -- no wifi wan
+            if wan_gw:match("^10%.") or not hide_local then
+                if wan_gw:match("^10%.") then
+                    col1[#col1 + 1] = "<th align=right><nobr>--- WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                else
+                    col1[#col1 + 1] = "<th align=right><nobr>--- WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                end
+            end
+        else     -- with wifi wan
+            if wan_wifi_ssid ~= "none" and wan_wifi_snr ~= "none" then
+                if wan_gw:match("^10%.") or not hide_local then
+                    if wan_gw:match("^10%.") then
+                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                    else
+                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "</td>"
+                    end
+                end
+            else
+                if wan_gw:match("^10%.") or not hide_local then
+                    if wan_gw:match("^10%.") then
+                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                    else
+                        col1[#col1 + 1] = "<th align=right><nobr>--- " .. wprefix .. "WAN info ---</nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                    end
+                end
+            end
+        end
     end
-    col1[#col1] = col1[#col1] .. "</td>"
 end
 
 if browser_ip then
     col1[#col1 + 1] = "<th align=right><nobr>your address:</nobr></th><td>" .. browser_ip .. "<br><nobr>" ..  mesh_ip_to_hostnames(browser_ip) .. "</nobr></td>"
 end
 
-
 -- right column - system info
 
 if config == "mesh" and not wifi_disabled then
-    col2[#col2 + 1] = "<th align=right valign=middle><nobr>signal / noise / SNR:</nobr></th><td valign=middle><nobr>"
+    col2[#col2 + 1] = "<th align=right valign=middle><nobr>signal|noise|SNR:</nobr></th><td valign=middle><nobr>"
     local s, n = get_wifi_signal(wifi_iface)
     if s == "none" then
         col2[#col2] = col2[#col2] .. "no RF links"
     else
-        col2[#col2] = col2[#col2] .. "<big><b>" .. s .. " / " .. n .. " / " .. math.abs(s - n) .. " dB</b></big>"
+        col2[#col2] = col2[#col2] .. "<b>" .. s .. " | " .. n .. " | " .. math.abs(s - n) .. " dB</b>"
         col2[#col2] = col2[#col2] .. "&nbsp;&nbsp;&nbsp;<button type=button onClick='window.location=\"signal?realtime=1\"' title='Display continuous or archived signal strength on a chart'>Charts</button></nobr></td>"
     end
 end

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -321,7 +321,7 @@ if wifi_disabled then
     col1[#col1 + 1] = "<th align=right><nobr>primary address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
 else
     wifi_gw = get_default_gw("wifi")
-    col1[#col1 + 1] = "<th align=right><nobr>mesh RF IP address:</nobr><br><nobr>gateway:</nobr><br><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "<br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
+    col1[#col1 + 1] = "<th align=right><nobr>mesh RF address:</nobr><br><nobr>mesh gateway:</nobr><br><nobr>gateway node:</nobr><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "<br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
 end
 
 ip = cursor:get("network", "lan", "ipaddr")
@@ -350,9 +350,9 @@ if ip:match("^10%.") or not hide_local then
         end
     )
     if lan_wifi_ssid ~= "none" then
-        col1[#col1 + 1] = "<th align=right><nobr>LAN IP address:</nobr><br><nobr>LAN AP SSID:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. lan_wifi_ssid .. "</td>"
+        col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr><br><nobr>LAN AP SSID:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. lan_wifi_ssid .. "</td>"
     else
-        col1[#col1 + 1] = "<th align=right><nobr>LAN IP address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
+        col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
     end
 end
 
@@ -360,7 +360,7 @@ local wan_iface = aredn.hardware.get_iface_name("wan")
 if wan_iface and not hide_local then
     local ip, bcast, mask = aredn.hardware.get_interface_ip4(wan_iface)
     if not ip then
-        col1[#col1 + 1] = "<th align=right valign=top><nobr>WAN address:</nobr><br><nobr>default gateway:</nobr></th><td>none<br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "</td>"
+        col1[#col1 + 1] = "<th align=right valign=top><nobr>WAN address:</nobr><br><nobr>default gateway:</nobr><br><nobr>gateway node:</nobr></th><td>none<br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "</td>"
     else
         local wprefix = ""
         local wan_wifi_snr = "none"
@@ -389,26 +389,26 @@ if wan_iface and not hide_local then
         if wprefix == "" then     -- no wifi wan
             if wan_gw:match("^10%.") or not hide_local then
                 if wan_gw:match("^10%.") then
-                    col1[#col1 + 1] = "<th align=right><nobr><nobr>WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                    col1[#col1 + 1] = "<th align=right><nobr><nobr>WAN address:</nobr><br>gateway:<br><nobr>gateway node:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                 else
-                    col1[#col1 + 1] = "<th align=right><nobr>WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                    col1[#col1 + 1] = "<th align=right><nobr>WAN address:</nobr><br>default gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
                 end
             end
         else     -- with wifi wan
             if wan_wifi_ssid ~= "none" and wan_wifi_snr ~= "none" then
                 if wan_gw:match("^10%.") or not hide_local then
                     if wan_gw:match("^10%.") then
-                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:<br><nobr>gateway node:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                     else
-                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "</td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr><br><nobr>SSID | SNR:</nobr><br>default gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "</td>"
                     end
                 end
             else
                 if wan_gw:match("^10%.") or not hide_local then
                     if wan_gw:match("^10%.") then
-                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr><br>gateway:<br><nobr>gateway node:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                     else
-                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN address:</nobr><br>default gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
                     end
                 end
             end

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -321,7 +321,7 @@ if wifi_disabled then
     col1[#col1 + 1] = "<th align=right><nobr>primary address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>"
 else
     wifi_gw = get_default_gw("wifi")
-    col1[#col1 + 1] = "<th align=right><span style=text-decoration:underline;'>Mesh RF</span><br><nobr>IP address:</nobr><br><nobr>gateway:</nobr><br><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "<br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
+    col1[#col1 + 1] = "<th align=right><nobr>mesh RF IP address:</nobr><br><nobr>gateway:</nobr><br><br>SSID:<br>channel:<br><nobr>channel width:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wifi_gw .. "<br>" .. mesh_ip_to_hostnames(wifi_gw) .. "<br>" .. wifi_ssid .. "<br>" .. wifi_channel .. "<br>" .. wifi_chanbw .. " MHz</td>"
 end
 
 ip = cursor:get("network", "lan", "ipaddr")
@@ -340,7 +340,20 @@ if remote_ip then
 end
 if ip:match("^10%.") or not hide_local then
     cidr = netmask_to_cidr(mask)
-    col1[#col1 + 1] = "<th align=right><nobr>LAN address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
+    local lan_wifi_ssid = "none"
+    cursor:foreach("wireless", "wifi-iface",
+        function (section)
+            if section.network == "lan" then
+                lan_wifi_ssid = section.ssid
+                return false
+            end
+        end
+    )
+    if lan_wifi_ssid ~= "none" then
+        col1[#col1 + 1] = "<th align=right><nobr>LAN IP address:</nobr><br><nobr>LAN AP SSID:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. lan_wifi_ssid .. "</td>"
+    else
+        col1[#col1 + 1] = "<th align=right><nobr>LAN IP address:</nobr></th><td>" .. ip .. " <small>/ " .. cidr .. "</small></td>"
+    end
 end
 
 local wan_iface = aredn.hardware.get_iface_name("wan")
@@ -376,26 +389,26 @@ if wan_iface and not hide_local then
         if wprefix == "" then     -- no wifi wan
             if wan_gw:match("^10%.") or not hide_local then
                 if wan_gw:match("^10%.") then
-                    col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                    col1[#col1 + 1] = "<th align=right><nobr><nobr>WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                 else
-                    col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                    col1[#col1 + 1] = "<th align=right><nobr>WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
                 end
             end
         else     -- with wifi wan
             if wan_wifi_ssid ~= "none" and wan_wifi_snr ~= "none" then
                 if wan_gw:match("^10%.") or not hide_local then
                     if wan_gw:match("^10%.") then
-                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                     else
-                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "</td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br><nobr>SSID | SNR:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br><nobr>" .. wan_wifi_ssid .. " | " .. wan_wifi_snr .. " dB<br>" .. wan_gw .. "</td>"
                     end
                 end
             else
                 if wan_gw:match("^10%.") or not hide_local then
                     if wan_gw:match("^10%.") then
-                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "<br><nobr>" .. mesh_ip_to_hostnames(wan_gw) .. "</nobr></td>"
                     else
-                        col1[#col1 + 1] = "<th align=right><nobr><span style='text-decoration:underline;'>" .. wprefix .. "WAN info</span></nobr><br><nobr>IP address:</nobr><br>gateway:</th><td><br>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
+                        col1[#col1 + 1] = "<th align=right><nobr>" .. wprefix .. "WAN IP address:</nobr><br>gateway:</th><td>" .. ip .. " <small>/ " .. cidr .. "</small><br>" .. wan_gw .. "</td>"
                     end
                 end
             end


### PR DESCRIPTION
Based on the suggestion from @ae6xe Joe ([see Issue#553](https://github.com/aredn/aredn/issues/553)) here is a possibility for displaying both types of gateway on the **Node Status** page.  Here are some samples of the display under various conditions.

**Mesh node without WAN connection:**
![meshRF-noWAN](https://user-images.githubusercontent.com/69524416/204305476-4e874b5b-ca98-4e8d-af75-e377df40affc.png)

**Mesh node with wired WAN connection:**
![meshRF-wiredWAN](https://user-images.githubusercontent.com/69524416/204305531-032af026-d42e-40c1-ba26-754fba758a87.png)

**Node using its radio for Wifi WAN:**
![noMesh-wifiWAN](https://user-images.githubusercontent.com/69524416/204305589-0f8cb4f0-5cc5-4bda-ba93-24a94659f2f7.png)

**Dual radio node with Mesh RF and LAN AP:**
![meshRF-lanAP](https://user-images.githubusercontent.com/69524416/204305649-b9b3a687-808a-48bf-ba7f-49cf7fb1155b.png)
