### PR TITLE
update vtun name when changing nodename

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -567,6 +567,15 @@ if not ntp_period then
     ntp_period = "daily"
 end
 
+function is_vtun_client()
+    for line in io.lines("/etc/config/vtun") do
+        if line:match("^config server") then
+            return true
+        end
+    end
+    return false
+end
+
 -- validate and save configuration
 if parms.button_save then
     for _,zone in ipairs(tz_db_names)
@@ -742,6 +751,35 @@ if parms.button_save then
     if #errors == 0 then
         parms.node = node
         parms.tactical = tactical
+
+        if is_vtun_client() then
+            local vtun_name
+            cursor:foreach("vtun", "server",
+                function(section)
+                    local netlen = #section.netip + 1
+                    vtun_name = section.node:sub(1, #section.node - (#section.netip + 1) )
+                end
+            )
+            if vtun_name and parms.node and (vtun_name:upper() ~= parms.node:upper()) then
+                cursor:foreach("vtun", "server",
+                    function(section)
+                        local servnum
+                        for k,v in pairs(section) do
+                            if k == ".name" then
+                                servnum = "@" .. v:gsub("%_","%[") .. "]"
+                            end
+                        end
+                        local newname = parms.node .. "-" .. section.netip:gsub("%.", "%-")
+                        if newname and servnum then
+                            cursor:set("vtun", servnum, "node", newname)
+                        end
+                    end
+                )
+                cursor:commit("vtun")
+                write_all("/etc/config.mesh/vtun", read_all("/etc/config/vtun"))
+            end
+        end
+
         if nixio.fs.stat("/etc/config/unconfigured") then
             io.open("/tmp/unconfigured", "w"):close()
         end


### PR DESCRIPTION
Update the tunnel client name in /etc/config/vtun & /etc/config.mesh/vtun when a Tunnel Client node is being renamed.  Fixes #555 