### PR TITLE
separate devices from standard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,111 +12,6 @@ For further information on obtaining an Amateur Radio Technician Class license, 
 
 ## Usage Information
 
-### What to know about the images built with the instructions below
-
-This is the active 'main' branch with latest AREDN® code. The Amateur Radio community is encouraged to participate in loading the images produced from a "nightly build" and run the AREDN® firmware in a variety of environments. Given new features may not yet be documented, participants should already have a basic knowledge of Linux and networking to understand and provide useful feedback to the Developer submitting the code.
-
-The goal of participation is to obtain confidence that new features and the overall mesh node is stable. The more participation, the earlier an issue is found, the faster an enhancement will be turned into a release.
-
-Please refer to https://github.com/aredn/aredn/issues for a list of outstanding defects.
-
-### Images built
-
-Device | Target | Image | RAM | Stability
------- | ------ | ----- | --- | ---------
-AirGrid XM | ath79 | ubnt_bullet-m-ar7241 | 32MB | untested sunset
-AirGrid XW | ath79 | ubnt_bullet-m-xw | 32MB | untested sunset
-AirRouter  | ath79 | ubnt_airrouter | 32MB | untested sunset
-AirRouter HP | ath79 | ubnt_airrouter | 32MB | untested sunset
-Bullet M2Ti/M5/M5Ti | ath79 | - | 32MB | untested sunset
-Bullet M2 | ath79 | ubnt_bullet-m-ar7241 | 32MB | stable sunset
-Bullet M2 XW | ath79 | ubnt_bullet-m-xw | 64MB | untested
-LiteBeam AC5 Gen2 | ath79 | ubnt_litebeam-ac-gen2 | 64MB | stable new
-LiteBeam M5 | ath79 | - | 64MB | untested
-NanoBeam AC 5 | ath79 | ubnt_nanobeam-ac | 64MB | untested new
-NanoBeam AC 5 Gen 2 | ath79 | ubnt_nanobeam-ac-gen2 | 128MB | stable new
-NanoBeam M2-13/M5-16/M5-19 | ath79 | - | 32MB | untested sunset
-NanoBridge 2G18 | ath79 | ubnt_nanobridge-m | 32MB | untested sunset
-NanoBridge 5G22/25 | ath79 | ubnt_nanobridge-m | 32MB | untested sunset
-NanoBridge M9 | ath79 | ubnt_nanobridge-m | 32MB | untested sunset
-NanoStation AC 5 | ath79 | ubnt_nanostation-ac | 64MB | stable new
-NanoStation Loco M2/M5/M9 XM | ath79 | ubnt_nanostation-loco-m | 32MB | untested sunset
-NanoStation Loco M2 XW | ath79 | ubnt_nanostation-loco-m-xw | 64MB | untested
-NanoStation Loco M5 XW | ath79 | ubnt_nanostation-loco-m-xw | 64MB | stable
-NanoStation M2/M3/M5 XM | ath79 | ubnt_nanostation-m | 32MB | stable sunset
-NanoStation M2/M5 XW | ath79 | ubnt_nanostation-m-xw | 64MB | stable
-PicoStation M2 | ath79 | ubnt_picostation-m | 32MB | untested sunset
-PowerBeam AC 5 500 | ath79 | ubnt_powerbeam-5ac-500 | 128MB | stable new
-PowerBeam-M2-400 | ath79 | ubnt_powerbeam-m2-xw | 64MB | untested
-PowerBeam-M5-300 | ath79 | ubnt_powerbeam-m5-300 | 64MB | stable
-PowerBeam-M5-400/400ISO/620 | ath79 | ubnt_powerbeam-m5-xw | 64MB | stable
-PowerBridge | ath79 | ubnt_powerbridge-m | 64MB | untested
-Rocket AC Lite 5 | ath79 | ubnt_rocket-5ac-lite | 128MB | stable new
-Rocket M9/M2/M3/M5/M5GPS XM | ath79 | ubnt_rocket-m | 64MB | stable
-Rocket M2/M5 XM with USB port | ath79 | ubnt_rocket-m | 64MB | untested
-Rocket M2 XW | ath79 | ubnt_rocket-m-xw | 64MB | untested
-Rocket M5 XW | ath79 | ubnt_rocket-m-xw | 64MB | stable
-Rocket M2 Titanium TI | ath79 | - | 64MB | untested
-Rocket M2 Titanium XW | ath79 | ubnt_rocket-m-xw | 64MB | untested
-Rocket M5 Titanium TI | ath79 | - | 64MB | untested
-Rocket M5 Titanium XW | ath79 | ubnt_rocket-m-xw | 64MB | stable
-TPLink CPE210 v1.X | ath79 | tplink_cpe210-v1 | 64MB | stable
-TPLink CPE210 v2.0 | ath79 | tplink_cpe210-v2 | 64MB | stable
-TPLink CPE210 v3.0 | ath79 | tplink_cpe210-v3 | 64MB | untested
-TPLink CPE220 v2.0 | ath79 | tplink_cpe220-v2 | 64MB | untested
-TPLink CPE220 v3.0 | ath79 | tplink_cpe220-v3 | 64MB | untested
-TPLink CPE510 v1.X | ath79 | tplink_cpe510-v1 | 64MB | untested
-TPLink CPE510 v2.0 | ath79 | tplink_cpe510-v2 | 64MB | stable
-TPLink CPE510 v3.0 | ath79 | tplink_cpe510-v3 | 64MB | stable
-TPLink CPE605 v1.0 | ath79 | tplink_cpe605-v1 | 64MB | untested
-TPLink CPE610 v1.0 | ath79 | tplink_cpe610-v1 | 64MB | untested
-TPLink CPE610 v2.0 | ath79 | tplink_cpe610-v2 | 64MB | untested
-TPLink CPE710 v1.0 | ath79 | tplink_cpe710-v1 | 128MB | stable new
-TPLink WBS210 v1.0 | ath79 | tplink_wbs210-v1 | 64MB | untested
-TPLink WBS210 v2.0 | ath79 | tplink_wbs210-v2 | 64MB | untested
-TPLink WBS510 v1.0 | ath79 | tplink_wbs510-v1 | 64MB | untested
-TPLink WBS510 v2.0 | ath79 | tplink_wbs510-v2 | 64MB | untested
-Mikrotik Basebox RB912UAG-2HPnD | ath79 | mikrotik_routerboard-912uag-2hpnd | 64MB | untested
-Mikrotik Basebox RB912UAG-5HPnD | ath79 | - | 64MB | untested
-Mikrotik hAP ac lite 952Ui-5ac2nD | ath79 | mikrotik_routerboard-952ui-5ac2nd | 64MB | stable
-Mikrotik RBLHG-2nD(-XL) | ath79 | mikrotik_routerboard-lhg-2nd | 64MB | stable
-Mikrotik RBLHG-5nD | ath79 | mikrotik_routerboard-lhg-5nd | 64MB | stable
-Mikrotik RBLHG-5HPnD(-XL) | ath79 | mikrotik_routerboard-lhg-5nd | 64MB | stable
-MikroTik RBLHGG-5acD(-XL) | ipq40xx | mikrotik_lhgg-5acd | 256MB | stable new
-Mikrotik RBLDF-2nD | ath79 | - | 64MB | untested
-Mikrotik RBLDF-5nD | ath79 | - | 64MB | untested
-Mikrotik QRT5 RB911G-5HPnD-QRT | ath79 | - | 64MB | untested
-Mikrotik mANTBox RB911G-2HPnD | ath79 | - | 64MB | untested
-Mikrotik mANTBox RB911G-5HPnD | ath79 | - | 64MB | untested
-Mikrotik mANTBox RB912UAG-2HPnD | ath79 | mikrotik_routerboard-912uag-2hpnd | 128MB | untested
-Mikrotik mANTBox RB912UAG-5HPnD | ath79 | mikrotik_routerboard-912uag-5hpnd | 128MB | stable
-Mikrotik mANTBox RB921GS-5HPacD 15s | ath79 | mikrotik_routerboard-921gs-5hpacd-15s | 128MB | stable new
-Mikrotik mANTBox RB921GS-5HPacD 19s | ath79 | mikrotik_routerboard-921gs-5hpacd-19s | 128MB | stable new
-Mikrotik SXTsq 5HPnD | ath79 | mikrotik_routerboard-sxt-5nd | 64MB | stable
-Mikrotik SXTsq 5nD | ath79 | mikrotik_routerboard-sxt-5nd | 64MB | stable
-Mikrotik SXTsq 2nD | ath79 | - | 64MB | untested
-MikroTik RouterBOARD D52G-5HacD2HnD | ipq40xx | mikrotik_hap-ac2 | 128MB | stable new
-MikroTik RouterBOARD D53iG-5HacD2HnD | ipq40xx | mikrotik_hap-ac3 | 256MB | stable new
-MikroTik RouterBOARD SXTsqG-5acD | ipq40xx | mikrotik_sxtsq-5-ac | 256MB | stable new
-GL.iNet GL-AR150 | ath79 | glinet_gl-ar150 | 64MB | stable
-GL.iNet GL-USB150 | ath79 | glinet_gl-usb150 | 64MB | stable
-GL.iNet GL-AR300M16 | ath79 | glinet_gl-ar300m | 64MB | stable
-GL.iNet GL-AR300M w/ 128MB NAND | ath79 | - | 64MB | untested
-GL.iNet GL-AR750 | ath79 | glinet_gl-ar750 | 128MB | stable
-Meraki MR-16 | ath79 | - | 64MB | brick
-
-#### Stability
-
-* *brick* - this image has been tested and will currently brick your hardware. Avoid for now.
-* *untested* - this image has not been tested on hardware. It may or may not work.
-* *stable* - this image has been tested on hardware. There may still be bugs.
-* *sunset* - this device has been sunsetted and support will be deprecated at some point.
-* *new* - this device is newly supported.
-
-The 'target' is a directory to find the image on at http://downloads.arednmesh.org
-
-Latest installation instructions are found at: https://docs.arednmesh.org/en/latest/
-
 ### Ethernet Port usage
 
 The standard Ethernet port of an AREDN® device uses the following vlan tags.  An 802.1Q switch is necessary to utilize the vlan tagged networks:
@@ -170,6 +65,14 @@ Please submit all issues to https://github.com/aredn/aredn/issues
 ## Developer Only Information
 
 The AREDN® firmware is based on OpenWrt with additional packages and patches. A Makefile automates the entire process to create firmware images.
+
+### Images built with the instructions below
+
+This is the active 'main' branch with latest AREDN® code. The Amateur Radio community is encouraged to participate in loading the images produced from a "nightly build" and run the AREDN® firmware in a variety of environments. Given new features may not yet be documented, participants should already have a basic knowledge of Linux and networking to understand and provide useful feedback to the Developer submitting the code.
+
+The goal of participation is to obtain confidence that new features and the overall mesh node is stable. The more participation, the earlier an issue is found, the faster an enhancement will be turned into a release.
+
+Please refer to https://github.com/aredn/aredn/issues for a list of outstanding defects.
 
 ### Building with Docker
 Installing the Docker environment on your windows/linux/mac machine is a pre-requisite. A docker 'container' has been pre-configured with an aredn linux build environment. Alternative instructions are below if you wish to setup your linux install with the compiler pre-requisites necessary to do the build.

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -1,0 +1,98 @@
+# Supported Devices
+
+Device | Target | Subtarget | Image | RAM | Stability | Status
+------ | ------ | --------- | ----- | --- | --------- | ------
+AirGrid XM | ath79 | tiny | ubnt_bullet-m-ar7241 | 32MB | untested | sunset
+AirGrid XW | ath79 | generic | ubnt_bullet-m-xw | 32MB | untested | sunset
+AirRouter  | ath79 | tiny | ubnt_airrouter | 32MB | untested | sunset
+AirRouter HP | ath79 | tiny | ubnt_airrouter | 32MB | untested | sunset
+Bullet M2Ti/M5/M5Ti | ath79 | - | - | 32MB | untested | sunset
+Bullet M2 | ath79 | tiny | ubnt_bullet-m-ar7241 | 32MB | stable | sunset
+Bullet M2 XW | ath79 | generic | ubnt_bullet-m-xw | 64MB | untested
+LiteBeam AC5 Gen2 | ath79 | generic | ubnt_litebeam-ac-gen2 | 64MB | stable | new
+LiteBeam M5 | ath79 | - | - | 64MB | untested
+NanoBeam AC 5 | ath79 | generic | ubnt_nanobeam-ac | 64MB | untested | new
+NanoBeam AC 5 Gen 2 | ath79 | generic | ubnt_nanobeam-ac-gen2 | 128MB | stable | new
+NanoBeam M2-13/M5-16/M5-19 | ath79 | - | - | 32MB | untested | sunset
+NanoBridge 2G18 | ath79 | tiny | ubnt_nanobridge-m | 32MB | untested | sunset
+NanoBridge 5G22/25 | ath79 | tiny | ubnt_nanobridge-m | 32MB | untested | sunset
+NanoBridge M9 | ath79 | tiny | ubnt_nanobridge-m | 32MB | untested | sunset
+NanoStation AC 5 | ath79 | generic | ubnt_nanostation-ac | 64MB | stable | new
+NanoStation Loco M2/M5/M9 XM | ath79 | tiny | ubnt_nanostation-loco-m | 32MB | untested | sunset
+NanoStation Loco M2 XW | ath79 | generic | ubnt_nanostation-loco-m-xw | 64MB | untested
+NanoStation Loco M5 XW | ath79 | generic | ubnt_nanostation-loco-m-xw | 64MB | stable
+NanoStation M2/M3/M5 XM | ath79 | tiny | ubnt_nanostation-m | 32MB | stable | sunset
+NanoStation M2/M5 XW | ath79 | generic | ubnt_nanostation-m-xw | 64MB | stable
+PicoStation M2 | ath79 | tiny | ubnt_picostation-m | 32MB | untested | sunset
+PowerBeam AC 5 500 | ath79 | generic | ubnt_powerbeam-5ac-500 | 128MB | stable | new
+PowerBeam-M2-400 | ath79 | generic | ubnt_powerbeam-m2-xw | 64MB | untested
+PowerBeam-M5-300 | ath79 | generic | ubnt_powerbeam-m5-300 | 64MB | stable
+PowerBeam-M5-400/400ISO/620 | ath79 | generic | ubnt_powerbeam-m5-xw | 64MB | stable
+PowerBridge | ath79 | generic | ubnt_powerbridge-m | 64MB | untested
+Rocket AC Lite 5 | ath79 | generic | ubnt_rocket-5ac-lite | 128MB | stable | new
+Rocket M9/M2/M3/M5/M5GPS XM | ath79 | generic | ubnt_rocket-m | 64MB | stable
+Rocket M2/M5 XM with USB port | ath79 | generic | ubnt_rocket-m | 64MB | untested
+Rocket M2 XW | ath79 | generic | ubnt_rocket-m-xw | 64MB | untested
+Rocket M5 XW | ath79 | generic | ubnt_rocket-m-xw | 64MB | stable
+Rocket M2 Titanium TI | ath79 | - | - | 64MB | untested
+Rocket M2 Titanium XW | ath79 | generic | ubnt_rocket-m-xw | 64MB | untested
+Rocket M5 Titanium TI | ath79 | - | - | 64MB | untested
+Rocket M5 Titanium XW | ath79 | generic | ubnt_rocket-m-xw | 64MB | stable
+TPLink CPE210 v1.X | ath79 | generic | tplink_cpe210-v1 | 64MB | stable
+TPLink CPE210 v2.0 | ath79 | generic | tplink_cpe210-v2 | 64MB | stable
+TPLink CPE210 v3.0 | ath79 | generic | tplink_cpe210-v3 | 64MB | untested
+TPLink CPE220 v2.0 | ath79 | generic | tplink_cpe220-v2 | 64MB | untested
+TPLink CPE220 v3.0 | ath79 | generic | tplink_cpe220-v3 | 64MB | untested
+TPLink CPE510 v1.X | ath79 | generic | tplink_cpe510-v1 | 64MB | untested
+TPLink CPE510 v2.0 | ath79 | generic | tplink_cpe510-v2 | 64MB | stable
+TPLink CPE510 v3.0 | ath79 | generic | tplink_cpe510-v3 | 64MB | stable
+TPLink CPE605 v1.0 | ath79 | generic | tplink_cpe605-v1 | 64MB | untested
+TPLink CPE610 v1.0 | ath79 | generic | tplink_cpe610-v1 | 64MB | untested
+TPLink CPE610 v2.0 | ath79 | generic | tplink_cpe610-v2 | 64MB | untested
+TPLink CPE710 v1.0 | ath79 | generic | tplink_cpe710-v1 | 128MB | stable | new
+TPLink WBS210 v1.0 | ath79 | generic | tplink_wbs210-v1 | 64MB | untested
+TPLink WBS210 v2.0 | ath79 | generic | tplink_wbs210-v2 | 64MB | untested
+TPLink WBS510 v1.0 | ath79 | generic | tplink_wbs510-v1 | 64MB | untested
+TPLink WBS510 v2.0 | ath79 | generic | tplink_wbs510-v2 | 64MB | untested
+Mikrotik Basebox RB912UAG-2HPnD | ath79 | mikrotik | mikrotik-912uag-2hpnd | 64MB | untested
+Mikrotik Basebox RB912UAG-5HPnD | ath79 | mikrotik | mikrotik-912uag-5hpnd | 64MB | untested
+Mikrotik hAP ac lite 952Ui-5ac2nD | ath79 | mikrotik | mikrotik-952ui-5ac2nd | 64MB | stable
+Mikrotik RBLHG-2nD(-XL) | ath79 | mikrotik | mikrotik-lhg-2nd | 64MB | stable
+Mikrotik RBLHG-5nD | ath79 | mikrotik | mikrotik-lhg-5nd | 64MB | stable
+Mikrotik RBLHG-5HPnD(-XL) | ath79 | mikrotik | mikrotik-lhg-5nd | 64MB | stable
+MikroTik RBLHGG-5acD(-XL) | ipq40xx | mikrotik | mikrotik_lhgg-5acd | 256MB | stable | new
+Mikrotik RBLDF-2nD | ath79 | mikrotik | - | 64MB | untested
+Mikrotik RBLDF-5nD | ath79 | mikrotik | - | 64MB | untested
+Mikrotik QRT5 RB911G-5HPnD-QRT | ath79 | mikrotik | - | 64MB | untested
+Mikrotik mANTBox RB911G-2HPnD | ath79 | mikrotik | - | 64MB | untested
+Mikrotik mANTBox RB911G-5HPnD | ath79 | mikrotik | - | 64MB | untested
+Mikrotik mANTBox RB912UAG-2HPnD | ath79 | mikrotik | mikrotik-912uag-2hpnd | 128MB | untested
+Mikrotik mANTBox RB912UAG-5HPnD | ath79 | mikrotik | mikrotik-912uag-5hpnd | 128MB | stable
+Mikrotik mANTBox RB921GS-5HPacD 15s | ath79 | mikrotik | mikrotik-921gs-5hpacd-15s | 128MB | stable | new
+Mikrotik mANTBox RB921GS-5HPacD 19s | ath79 | mikrotik | mikrotik-921gs-5hpacd-19s | 128MB | stable | new
+Mikrotik SXTsq 5HPnD | ath79 | mikrotik | mikrotik-sxt-5nd | 64MB | stable
+Mikrotik SXTsq 5nD | ath79 | mikrotik | mikrotik-sxt-5nd | 64MB | stable
+Mikrotik SXTsq 2nD | ath79 | mikrotik | - | 64MB | untested
+MikroTik RouterBOARD D52G-5HacD2HnD | ipq40xx | mikrotik | mikrotik_hap-ac2 | 128MB | stable | new
+MikroTik RouterBOARD D53iG-5HacD2HnD | ipq40xx | mikrotik | mikrotik_hap-ac3 | 256MB | stable | new
+MikroTik RouterBOARD SXTsqG-5acD | ipq40xx | mikrotik | mikrotik_sxtsq-5-ac | 256MB | stable | new
+GL.iNet GL-AR150 | ath79 | generic | glinet_gl-ar150 | 64MB | stable
+GL.iNet GL-USB150 | ath79 | generic | glinet_gl-usb150 | 64MB | stable
+GL.iNet GL-AR300M16 | ath79 | generic | glinet_gl-ar300m16 | 64MB | stable
+GL.iNet GL-AR300M w/ 128MB NAND | ath79 | nand | gl-ar300m | 64MB | untested
+GL.iNet GL-AR750 (creta) | ath79 | generic | glinet_gl-ar750 | 128MB | stable
+GL.iNet GL-AR750s (slate) | ath79 | nand | gl-ar750s | 128MB | untested
+GL.iNet GL-E750 | ath79 | nand | gl-e750 | 128MB | untested
+Meraki MR-16 | ath79 | - | - | 64MB | unsupported | brick
+
+## Notes
+
+* *brick* - this image has been tested and will currently brick your hardware. Avoid for now.
+* *untested* - this image has not been tested on hardware. It may or may not work.
+* *stable* - this image has been tested on hardware. There may still be bugs.
+* *sunset* - this device has been sunsetted and support will be deprecated at some point.
+* *new* - this device is newly supported.
+
+The 'target' and 'subtarget' identify the directory to find the image on at http://downloads.arednmesh.org
+
+Latest installation instructions are found at: https://docs.arednmesh.org/en/latest/


### PR DESCRIPTION
Make it easier to find Supported Devices by separating from the more static README file, making the README file much easier to maintain going forward.