### PR TITLE
Dont kill hostapd at start of upgrade process.

### DIFF
--- a/files/usr/local/bin/upgrade_prepare.sh
+++ b/files/usr/local/bin/upgrade_prepare.sh
@@ -37,7 +37,7 @@ LICENSE
 # ServiceName[:ServiceDaemon] pairs.
 # If ServiceDaemon is omitted, we wont first kill the daemon
 #
-SERVICES="dnsmasq:dnsmasq dropbear:dropbear urngd:urngd rpcd:rpcd telnet:telnetd manager:manager.lua log:logd wpad:hostapd"
+SERVICES="dnsmasq:dnsmasq dropbear:dropbear urngd:urngd rpcd:rpcd telnet:telnetd manager:manager.lua log:logd"
 
 #
 # We unceremoniously kill services, and then stop them to prevent


### PR DESCRIPTION
In an attempt to save memory on low memory devices I was killing hostapd early, but that just causes upgrades over wifi to fail completely. So remove this.