### PR TITLE
Fix IBSS problem on 2.4GHz

### DIFF
--- a/patches/750-ibss-2g-fix.patch
+++ b/patches/750-ibss-2g-fix.patch
@@ -1,0 +1,20 @@
+--- /dev/null
++++ b/package/kernel/mac80211/patches/ath/302-ibss-2g-fix.patch
+@@ -0,0 +1,17 @@
++--- a/net/mac80211/ibss.c
+++++ b/net/mac80211/ibss.c
++@@ -1197,6 +1197,14 @@
++ 		 (unsigned long long)(rx_timestamp - beacon_timestamp),
++ 		 jiffies);
++ 
+++	if (sdata->u.ibss.fixed_channel && 
+++		band == NL80211_BAND_2GHZ && 
+++		elems->ds_params && 
+++		channel->center_freq != ieee80211_channel_to_frequency(elems->ds_params[0], band)) {
+++          ibss_dbg(sdata, "Reject beacon: chan %d center_freq %d beacon_freq %d\n", elems->ds_params[0], channel->center_freq, ieee80211_channel_to_frequency(elems->ds_params[0], band));
+++			goto put_bss;
+++  }
+++
++ 	if (beacon_timestamp > rx_timestamp) {
++ 		ibss_dbg(sdata,
++ 			 "beacon TSF higher than local TSF - IBSS merge with BSSID %pM\n",

--- a/patches/series
+++ b/patches/series
@@ -34,4 +34,5 @@
 748-powerbeam-m5-300-support.patch
 749-copy-tiny-nodes-to-generic.patch
 749-fix-tiny.patch
+750-ibss-2g-fix.patch
 800-upgrade-compatibility.patch


### PR DESCRIPTION
There's a bug where 2.4GHz channels will associate incorrectly with other 2.4 channels even though they are on different frequencies. The problem appears to be triggered during scans when scan probes are sent and received on many different frequencies, but are then reported as as they arrive as if they come from the selected frequency of the device, causing incorrect stations to be created. This can only occur for IBSS (adhoc) mode, when the IBSS frequency is fixed, and when the SSID is also fixed. We do all this for AREDN. Fortunately these probe contains (but *only* on 2.4 GHz) the actual frequency of the sending device, so we can avoid incorrectly creating stations which are not really a match. This situation does not seem to happen on 5GHz channels. e Please enter the commit message for your changes. Lines starting