### PR TITLE
Enable ac neg channels

### DIFF
--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -563,9 +563,7 @@
       "maxpower"        : "27",
       "pwroffset"       : "0",
       "usechains"       : true,
-      "rfband"          : "2400",
-      "rfbandwidths"    : [ 10, 20 ],
-      "rfblocked"       : [ -4, -3, -2, -1 ]
+      "rfband"          : "2400"
     },
     "MikroTik hAP ac3" : {
       "name"            : "MikroTik RouterBOARD RBD53iG-5HacD2HnD",
@@ -574,9 +572,7 @@
       "maxpower"        : "27",
       "pwroffset"       : "0",
       "usechains"       : true,
-      "rfband"          : "2400",
-      "rfbandwidths"    : [ 10, 20 ],
-      "rfblocked"       : [ -4, -3, -2, -1 ]
+      "rfband"          : "2400"
     },
     "0xe005" : {
       "name"            : "Ubiquiti NanoStation M5",

--- a/files/usr/local/bin/mgr/rssi_monitor_ath10k.lua
+++ b/files/usr/local/bin/mgr/rssi_monitor_ath10k.lua
@@ -33,7 +33,10 @@
 
 --]]
 
+local periodic_scan_time = 300 -- 5 minutes
+
 local wifiiface
+local last_scan_time = 0
 
 function rssi_monitor_10k()
     if string.match(get_ifname("wifi"), "^eth.") then
@@ -76,10 +79,11 @@ function run_monitor_10k()
         station_count = station_count + 1
     end
 
-    if station_count == 0 and last_station_count ~= 0 then
+    if station_count == 0 and (last_station_count ~= 0 or nixio.sysinfo().uptime > periodic_scan_time + last_scan_time) then
          -- reset
+         last_scan_time = nixio.sysinfo().uptime
          os.execute("/usr/sbin/iw " .. wifiiface .. " scan > /dev/null 2>&1")
-         wait_for_ticks(5)
+         os.execute("/usr/sbin/iw " .. wifiiface .. " scan passive > /dev/null 2>&1")
          log:write("No stations detected")
          log:flush()
     end

--- a/files/usr/local/bin/mgr/rssi_monitor_ath9k.lua
+++ b/files/usr/local/bin/mgr/rssi_monitor_ath9k.lua
@@ -168,6 +168,7 @@ function run_monitor_9k()
     if amac then
         -- reset
         os.execute("/usr/sbin/iw " .. wifiiface .. " scan > /dev/null 2>&1")
+        os.execute("/usr/sbin/iw " .. wifiiface .. " scan passive > /dev/null 2>&1")
         wait_for_ticks(5)
         -- update time
         now = nixio.sysinfo().uptime

--- a/patches/701-extended-spectrum.patch
+++ b/patches/701-extended-spectrum.patch
@@ -303,7 +303,7 @@
 + 
 --- /dev/null
 +++ b/package/kernel/ath10k-ct/patches/999-0000-ath10k-part97-chan-extend.patch
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,100 @@
 +--- a/ath10k-5.15/core.h
 ++++ b/ath10k-5.15/core.h
 +@@ -49,8 +49,8 @@
@@ -312,17 +312,19 @@
 + #define ATH10K_CONNECTION_LOSS_HZ (3 * HZ)
 +-#define ATH10K_NUM_CHANS 41
 +-#define ATH10K_MAX_5G_CHAN 173
-++#define ATH10K_NUM_CHANS 86 
+++#define ATH10K_NUM_CHANS 88 
 ++#define ATH10K_MAX_5G_CHAN 184
 + 
 + /* Antenna noise floor */
 + #define ATH10K_DEFAULT_NOISE_FLOOR -95
 +--- a/ath10k-5.15/mac.c
 ++++ b/ath10k-5.15/mac.c
-+@@ -9089,6 +9089,8 @@
++@@ -9089,6 +9089,10 @@
 + }
 + 
 + static const struct ieee80211_channel ath10k_2ghz_channels[] = {
+++	CHAN2G(252, 2387, 0),
+++	CHAN2G(253, 2392, 0),
 ++	CHAN2G(254, 2397, 0),
 ++	CHAN2G(255, 2402, 0),
 + 	CHAN2G(1, 2412, 0),
@@ -402,3 +404,25 @@
 + /* add wild card ssid probe request even though ssid_list is specified. */
 + #define WMI_SCAN_ADD_BCAST_PROBE_REQ 0x2
 + /* add cck rates to rates/xrate ie for the generated probe request */
+--- /dev/null
++++ b/package/kernel/ath10k-ct/patches/999-0001-ath10k-neg-chans.patch
+@@ -0,0 +1,19 @@
++--- a/ath10k-5.15/wmi.c
+++++ b/ath10k-5.15/wmi.c
++@@ -2709,13 +2709,15 @@
++ 	 */
++ 	if (channel >= 1 && channel <= 14) {
++ 		status->band = NL80211_BAND_2GHZ;
+++	} else if (channel >= -4 && channel <= -1) {
+++		status->band = NL80211_BAND_2GHZ;
++ 	} else if (channel >= 36 && channel <= ATH10K_MAX_5G_CHAN) {
++ 		status->band = NL80211_BAND_5GHZ;
++ 	} else {
++ 		/* Shouldn't happen unless list of advertised channels to
++ 		 * mac80211 has been changed.
++ 		 */
++-		WARN_ON_ONCE(1);
+++		WARN_ONCE(1, "Bad channel %d\n", channel);
++ 		dev_kfree_skb(skb);
++ 		return 0;
++ 	}

--- a/patches/750-ibss-2g-fix.patch
+++ b/patches/750-ibss-2g-fix.patch
@@ -10,10 +10,10 @@
 ++	if (sdata->u.ibss.fixed_channel && 
 ++		band == NL80211_BAND_2GHZ && 
 ++		elems->ds_params && 
-++		channel->center_freq != ieee80211_channel_to_frequency(elems->ds_params[0], band)) {
-++          ibss_dbg(sdata, "Reject beacon: chan %d center_freq %d beacon_freq %d\n", elems->ds_params[0], channel->center_freq, ieee80211_channel_to_frequency(elems->ds_params[0], band));
+++		sdata->u.ibss.chandef.center_freq1 != ieee80211_channel_to_frequency(elems->ds_params[0], band)) {
+++			ibss_dbg(sdata, "Reject beacon: chan %d center_freq1 %d center_freq %d beacon_freq %d\n", elems->ds_params[0], sdata->u.ibss.chandef.center_freq1, channel->center_freq, ieee80211_channel_to_frequency(elems->ds_params[0], band));
 ++			goto put_bss;
-++  }
+++	}
 ++
 + 	if (beacon_timestamp > rx_timestamp) {
 + 		ibss_dbg(sdata,


### PR DESCRIPTION
This makes -ve channels work on AC devices.
This is not a perfect fix as it can still take an AC device a couple of minutes to connect to an existing network as
the initial scans fail to find it. This can probably be improved so connect is more immediate.