### PR TITLE
Fix idle tunnel quality check 01/07/2023

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -551,7 +551,6 @@ function lqm()
                 if track.type == "Tunnel" then
                     -- Tunnels have no MAC, so we can only use IP level pings.
                     local sigsock = nixio.socket("inet", "dgram")
-                    sigsock:setopt("socket", "bindtodevice", track.device)
                     sigsock:setopt("socket", "rcvtimeo", ping_timeout)
                     -- Must connect or we wont see the error
                     sigsock:connect(track.ip, 8080)


### PR DESCRIPTION
When a tunnel is idle, binding to the tun* device fails; so remove it. As we have a direct tunnel route in the routing table (not OLSR table 30) created by vtun, we will still correctly route the quality testing traffic.
Validated for both idle and active tunnels.