### PR TITLE
Add a maximum timeout for service checks 01/08/2023

### DIFF
--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -192,7 +192,7 @@ if validate then
                 valid_services[#valid_services + 1] = service
             elseif proto == "http" then
                 -- http so looks like a link. http check it
-                local status, effective_url = io.popen("/usr/bin/curl --retry 0 --connect-timeout 2 --speed-time 5 --speed-limit 1000 --silent --output /dev/null --location --write-out '%{http_code} %{url_effective}' " .. "http://" .. hostname .. ":" .. port .. path):read("*a"):match("^(%d+) (.*)")
+                local status, effective_url = io.popen("/usr/bin/curl --max-time 10 --retry 0 --connect-timeout 2 --speed-time 5 --speed-limit 1000 --silent --output /dev/null --location --write-out '%{http_code} %{url_effective}' " .. "http://" .. hostname .. ":" .. port .. path):read("*a"):match("^(%d+) (.*)")
                 if status == "200" or status == "401" then
                     valid_services[#valid_services + 1] = service
                 elseif status == "301" or status == "302" or status == "303" or status == "307" or status == "308" then


### PR DESCRIPTION
The connect timeout doest not include DNS lookups, and if DNS is broken this can hang forever. Add a maxmimum timeout so this call will eventually terminate regardless.