### PR TITLE
Hidden node detection (and optional mitigation) 01/12/2023

### DIFF
--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -7,6 +7,7 @@ do
         option enable '0'
         option min_snr '15'
         option margin_snr '1'
+        option rts_theshold '256'
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'

--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -7,7 +7,7 @@ do
         option enable '0'
         option min_snr '15'
         option margin_snr '1'
-        option rts_theshold '256'
+        option rts_theshold '0'
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'

--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -7,7 +7,7 @@ do
         option enable '0'
         option min_snr '15'
         option margin_snr '1'
-        option rts_theshold '0'
+        option rts_theshold '-1'
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -60,7 +60,7 @@ function get_config()
     return {
         margin = tonumber(c:get("aredn", "@lqm[0]", "margin_snr")),
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
-        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "256"),
+        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "0"),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
         auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -230,7 +230,7 @@ function lqm()
     local tracker = {}
     local dtdlinks = {}
     local rflinks = {}
-    local hidden_nodes = false
+    local hidden_nodes = -1
     while true
     do
         now = nixio.sysinfo().uptime
@@ -776,32 +776,32 @@ function lqm()
         end
 
         -- Set the RTS/CTS state depending on whether everyone can see everyone
-        -- First build a list of all the nodes our neighbors can see
-        local theres = {}
-        for mac, rfneighbor in pairs(rflinks)
-        do
-            if tracker[mac] and not tracker[mac].blocked then
-                for nip, _ in pairs(rfneighbor)
-                do
-                    theres[nip] = true
+        local hidden = false
+        if config.rts_theshold >= 0 and config.rts_theshold <= 2347 then
+            -- Build a list of all the nodes our neighbors can see
+            local theres = {}
+            for mac, rfneighbor in pairs(rflinks)
+            do
+                if tracker[mac] and not tracker[mac].blocked then
+                    for nip, _ in pairs(rfneighbor)
+                    do
+                        theres[nip] = true
+                    end
                 end
             end
-        end
-        -- Remove all the nodes we can see from this set
-        for _, track in pairs(tracker)
-        do
-            if track.ip then
-                theres[track.ip] = nil
+            -- Remove all the nodes we can see from this set
+            for _, track in pairs(tracker)
+            do
+                if track.ip then
+                    theres[track.ip] = nil
+                end
             end
-        end
-        -- If there are any nodes left then we have a hidden node and should enable RTS/CTS
-        local hidden = false
-        for _, _ in pairs(theres)
-        do
-            if config.rts_theshold >= 0 and config.rts_theshold <= 2347 then
+            -- If there are any nodes left, then our neighbors can see hidden nodes we cant. Enable RTS/CTS
+            for _, _ in pairs(theres)
+            do
                 hidden = true
+                break
             end
-            break
         end
         if hidden ~= hidden_nodes then
             if hidden then

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -60,7 +60,7 @@ function get_config()
     return {
         margin = tonumber(c:get("aredn", "@lqm[0]", "margin_snr")),
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
-        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "128"),
+        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "256"),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
         auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -230,6 +230,7 @@ function lqm()
     local tracker = {}
     local dtdlinks = {}
     local rflinks = {}
+    local hidden_nodes = false
     while true
     do
         now = nixio.sysinfo().uptime
@@ -797,13 +798,18 @@ function lqm()
         local hidden = false
         for _, _ in pairs(theres)
         do
-            hidden = true
+            if config.rts_size >= 0 and config.rts_size <= 2347 then
+                hidden = true
+            end
             break
         end
-        if hidden and config.rts_size >= 0 and config.rts_size <= 2347 then
-            os.execute(IW .. " " .. phy .. " set rts " .. config.rts_size .. " > /dev/null 2>&1")
-        else
-            os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
+        if hidden ~= hidden_nodes then
+            if hidden then
+                os.execute(IW .. " " .. phy .. " set rts " .. config.rts_size .. " > /dev/null 2>&1")
+            else
+                os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
+            end
+            hidden_nodes = hidden
         end
 
         -- Save this for the UI
@@ -814,7 +820,7 @@ function lqm()
                 trackers = tracker,
                 distance = distance,
                 coverage = coverage,
-                hidden_nodes = hidden
+                hidden_nodes = hidden_nodes
             }, true))
             f:close()
         end

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -495,9 +495,7 @@ function lqm()
                             for _, rtrack in pairs(info.lqm.info.trackers)
                             do
                                 if not rtrack.type or rtrack.type == "RF" then
-                                    if not rtrack.blocked then
-                                        rflinks[track.mac][rtrack.ip] = true
-                                    end
+                                    rflinks[track.mac][rtrack.ip] = true
                                     if myhostname == rtrack.hostname then
                                         if not old_rev_snr or not rtrack.snr then
                                             track.rev_snr = rtrack.snr

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -60,7 +60,7 @@ function get_config()
     return {
         margin = tonumber(c:get("aredn", "@lqm[0]", "margin_snr")),
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
-        rts_size = tonumber(c:get("aredn", "@lqm[0]", "rts_size") or "128"),
+        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "128"),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
         auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),
@@ -798,14 +798,14 @@ function lqm()
         local hidden = false
         for _, _ in pairs(theres)
         do
-            if config.rts_size >= 0 and config.rts_size <= 2347 then
+            if config.rts_theshold >= 0 and config.rts_theshold <= 2347 then
                 hidden = true
             end
             break
         end
         if hidden ~= hidden_nodes then
             if hidden then
-                os.execute(IW .. " " .. phy .. " set rts " .. config.rts_size .. " > /dev/null 2>&1")
+                os.execute(IW .. " " .. phy .. " set rts " .. config.rts_theshold .. " > /dev/null 2>&1")
             else
                 os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
             end

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -60,7 +60,7 @@ function get_config()
     return {
         margin = tonumber(c:get("aredn", "@lqm[0]", "margin_snr")),
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
-        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "0"),
+        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "-1"),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
         auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -132,7 +132,7 @@ local settings = {
         key = "aredn.@lqm[0].rts_theshold",
         type = "string",
         desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_theshold</small>",
-        default = "256",
+        default = "0",
         condition = "lqm_enabled()"
     },
     {

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -132,7 +132,7 @@ local settings = {
         key = "aredn.@lqm[0].rts_theshold",
         type = "string",
         desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_theshold</small>",
-        default = "0",
+        default = "-1",
         condition = "lqm_enabled()"
     },
     {

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -129,6 +129,14 @@ local settings = {
     },
     {
         category = "Link Quality Settings",
+        key = "aredn.@lqm[0].rts_theshold",
+        type = "string",
+        desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_theshold</small>",
+        default = "128",
+        condition = "lqm_enabled()"
+    },
+    {
+        category = "Link Quality Settings",
         key = "aredn.@lqm[0].user_blocks",
         type = "string",
         desc = "<b>User Blocked</b> comma-separated list of blocked MACs<br><br><small>aredn.@lqm[0].user_blocks</small>",

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -132,7 +132,7 @@ local settings = {
         key = "aredn.@lqm[0].rts_theshold",
         type = "string",
         desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_theshold</small>",
-        default = "128",
+        default = "256",
         condition = "lqm_enabled()"
     },
     {

--- a/files/www/cgi-bin/lqm
+++ b/files/www/cgi-bin/lqm
@@ -153,6 +153,9 @@ html.print([[<hr>
             if (track.routable) {
                 return "active";
             }
+            if (track.hidden) {
+                return "hidden";
+            }
             return "idle";
         }
         const get_snr = track => {
@@ -179,6 +182,15 @@ html.print([[<hr>
         const update = data => {
             let links = "";
             const trackers = Object.values(data.info.trackers);
+            data.info.hidden_nodes.forEach(hidden => {
+                trackers.push({
+                    hostname: hidden.hostname,
+                    ip: hidden.ip,
+                    hidden: true,
+                    type: "-",
+                    snr: -1
+                });
+            });
             trackers.sort((a, b) => name(a).localeCompare(name(b)));
             trackers.forEach(track => {
                 let quality = "-";


### PR DESCRIPTION
A new LQM feature which detects hidden nodes which a node cannot see directly and display them as part of the LQM information. It can also (but is off by default) enable RTS/CTS to improve quality by reducing transmission failures when hidden nodes are detected.

RTS/CTS mitigation is off by default, even when hidden nodes are detected. But when it's enabled I've been able to do a little testing locally on a few Omni's we have locally, and its reduced transmission failures from 30% to about 8%. I would expect more, but in my test only a single Omni was using RTS/CTS while all its neighbors were not.