### PR TITLE
Mikrotik boot loader change to avoid boot lockup problem

### DIFF
--- a/files/etc/uci-defaults/12_mikrotik_boot
+++ b/files/etc/uci-defaults/12_mikrotik_boot
@@ -1,0 +1,11 @@
+#! /bin/sh
+#
+# On Mikrotik devices, make sure the boot mode is 'flasheth' otherwise
+# the node can fail to boot.
+#
+if [ -f /sys/firmware/mikrotik/soft_config/boot_device ]; then
+    if [ "$(grep '\[flasheth\]' /sys/firmware/mikrotik/soft_config/boot_device)" = "" ]; then
+        echo "flasheth" > /sys/firmware/mikrotik/soft_config/boot_device
+        echo "1" > /sys/firmware/mikrotik/soft_config/commit
+    fi
+fi


### PR DESCRIPTION
https://github.com/aredn/aredn/issues/633

Reports that the hAP AC2 will fail to boot when the WAN cable is connected. This does not effect all devices. However, I've also seen this on my hAP Lite device and it is not a new problem (as long as I've owned it!). The forum post below indicates the boot loader can be set to the wrong mode, causing the device to lockup sometimes when booting. Checking my two hAP AC2, they were both in different modes. It looks like it might be possible to accidentally change this mode by holding the reset button for different periods of time when powering on the device. This might explain why some nodes have this problem and some don't.

See: https://forum.openwrt.org/t/openwrt-installed-mikrotik-rb750gr3-wont-boot-when-wan-cable-plugged/146330/7