### PR TITLE
Automatically enable RTS when hidden nodes detected

### DIFF
--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -7,7 +7,7 @@ do
         option enable '0'
         option min_snr '15'
         option margin_snr '1'
-        option rts_theshold '-1'
+        option rts_theshold '1'
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -59,7 +59,7 @@ function get_config()
     return {
         margin = tonumber(c:get("aredn", "@lqm[0]", "margin_snr")),
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
-        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "-1"),
+        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "1"),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
         auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -132,7 +132,7 @@ local settings = {
         key = "aredn.@lqm[0].rts_theshold",
         type = "string",
         desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_theshold</small>",
-        default = "-1",
+        default = "1",
         condition = "lqm_enabled()"
     },
     {


### PR DESCRIPTION
As we though this was on anyway, I'd say we should enable RTS whenever we detected hidden nodes in order to establish a more reliable network. It can still be disabled in the advanced settings.

Thoughts?