### PR TITLE
Re-enable kmod-rtc-ds1307 package 01/27/2023

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -74,6 +74,7 @@ CONFIG_PACKAGE_kmod-nls-utf8=m
 CONFIG_PACKAGE_kmod-ppp=m
 CONFIG_PACKAGE_kmod-pppoe=m
 CONFIG_PACKAGE_kmod-pppox=m
+CONFIG_PACKAGE_kmod-rtc-ds1307=m
 CONFIG_PACKAGE_kmod-scsi-core=m
 CONFIG_PACKAGE_kmod-slhc=m
 CONFIG_PACKAGE_kmod-tun=m


### PR DESCRIPTION
Package provides kernel driver for I2C RTC modules such as the DS3231.

Ref #152 #153

This was dropped in the OpenWRT upgrade