### PR TITLE
Filter out non-routable ARP entries which confuse LQM

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -362,18 +362,22 @@ function lqm()
         for mac, entry in pairs(arps)
         do
             if entry.Device:match("%.2$") or entry.Device:match("^br%-dtdlink") then
-                stations[#stations + 1] = {
-                    type = "DtD",
-                    device = entry.Device,
-                    signal = nil,
-                    ip = entry["IP address"],
-                    mac = mac:upper(),
-                    tx_packets = 0,
-                    tx_fail = 0,
-                    tx_retries = 0,
-                    tx_bitrate = 0,
-                    rx_bitrate = 0
-                }
+                -- Sometimes we find arp entries are not routable. Filter them out early.
+                local rt = ip.route(entry["IP address"])
+                if rt and tostring(rt.gw) == entry["IP address"] then
+                    stations[#stations + 1] = {
+                        type = "DtD",
+                        device = entry.Device,
+                        signal = nil,
+                        ip = entry["IP address"],
+                        mac = mac:upper(),
+                        tx_packets = 0,
+                        tx_fail = 0,
+                        tx_retries = 0,
+                        tx_bitrate = 0,
+                        rx_bitrate = 0
+                    }
+                end
             end
         end
 

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -262,7 +262,11 @@ function lqm()
         arptable(
             function (entry)
                 if entry["Flags"] ~= "0x0" then
-                    arps[entry["HW address"]:upper()] = entry
+                    -- Sometimes we find arp entries are not routable. Filter them out early.
+                    local rt = ip.route(entry["IP address"])
+                    if rt and tostring(rt.gw) == entry["IP address"] then
+                        arps[entry["HW address"]:upper()] = entry
+                    end
                 end
             end
         )
@@ -362,22 +366,18 @@ function lqm()
         for mac, entry in pairs(arps)
         do
             if entry.Device:match("%.2$") or entry.Device:match("^br%-dtdlink") then
-                -- Sometimes we find arp entries are not routable. Filter them out early.
-                local rt = ip.route(entry["IP address"])
-                if rt and tostring(rt.gw) == entry["IP address"] then
-                    stations[#stations + 1] = {
-                        type = "DtD",
-                        device = entry.Device,
-                        signal = nil,
-                        ip = entry["IP address"],
-                        mac = mac:upper(),
-                        tx_packets = 0,
-                        tx_fail = 0,
-                        tx_retries = 0,
-                        tx_bitrate = 0,
-                        rx_bitrate = 0
-                    }
-                end
+                stations[#stations + 1] = {
+                    type = "DtD",
+                    device = entry.Device,
+                    signal = nil,
+                    ip = entry["IP address"],
+                    mac = mac:upper(),
+                    tx_packets = 0,
+                    tx_fail = 0,
+                    tx_retries = 0,
+                    tx_bitrate = 0,
+                    rx_bitrate = 0
+                }
             end
         end
 


### PR DESCRIPTION
Very occasionally I'm seeing ARP entries for IP addresses which are not routable. These always seem to be for the IP address of a device with mesh RF disabled. It's not clear how this can happen as this IP is not assigned to the DtD VLAN which is how they're being reported in the ARP cache. Also, this problem shows up in both the current release and the nightlies. It doesn't effect the routing on the node (the routing table is correct) so these "bad" arp entries never cause anyone but LQM a problem. This change stops LQM being confused by them.