### PR TITLE
Provide a timeout on the iperf client.

### DIFF
--- a/files/www/cgi-bin/iperf
+++ b/files/www/cgi-bin/iperf
@@ -75,7 +75,7 @@ else
             f:close();
         end
         if status:match("running") then
-            print("<html><head><title>SUCCESS</title></head><body><pre>Client: " .. node .. "\nServer: " .. server .. "\n" .. io.popen("/usr/bin/iperf3 --forceflush -b 0 -Z -c " .. server .. (protocol == "udp" and " -u" or "") .. " 2>&1"):read("*a") .. "</pre></body></html>")
+            print("<html><head><title>SUCCESS</title></head><body><pre>Client: " .. node .. "\nServer: " .. server .. "\n" .. io.popen("p=$$;setsid sh -c \"(sleep 20; kill $p)\" > /dev/null 2>&1 & /usr/bin/iperf3 --forceflush -b 0 -Z -c " .. server .. (protocol == "udp" and " -u" or "") .. " 2>&1"):read("*a") .. "</pre></body></html>")
         else
             print("<html><head><title>SERVER ERROR</title></head><body><pre>iperf client failed to start server</pre></body></html>")
         end


### PR DESCRIPTION
This cryptic bit of shell script adds a maximum timeout for the iperf client to run as it appears it can get stuck occasionally. The server has a built-in timeout (not available in client mode)