### PR TITLE
Use luci's urldecode_params to handle query string

### DIFF
--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -37,6 +37,7 @@
 
 local nxo = require("nixio")
 local ipc = require("luci.ip")
+require("luci.http")
 require("uci")
 
 function round2(num, idp)
@@ -65,10 +66,7 @@ end
 function parseQueryString(qs)
 	local qsa={}
 	if qs ~=nil then
-		for i,j in pairs(qs:split("&")) do
-			z=j:split("=")
-			qsa[z[1]]=z[2]
-		end
+		qsa = luci.http.urldecode_params(qs)
 	end
 	return qsa
 end


### PR DESCRIPTION
Instead of manually parsing query strings by splitting on & and =, use the already-provided luci.http.urldecode_params() to do it correctly. As a side effect, this will also properly handle url-encoded parameters.

For example:
http://localnode/cgi-bin/api?status=olsr,alerts
vs
http://localnode/cgi-bin/api?status=olsr%2Calerts

```json
$ GET 'http://localnode/cgi-bin/api?status=olsr%2Calerts'

{
  "pages": {
    "status": {
      "alerts": {
        "aredn": "",
        "local": ""
      },
      "olsr": {
        "nodes": "356",
        "entries": "1257"
      }
    }
  },
  "api_version": "1.5"
}
```

Fixes #702 