### PR TITLE
Improve LQM distance management 02/11/2023

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -827,7 +827,7 @@ function lqm()
                 -- Find the most distant, unblocked, RF node
                 if track.type == "RF" then
                     if track.distance then
-                        if track.distance > distance and ((not track.blocked and track.routable) or is_pending(track)) then
+                        if track.distance > distance and (not track.blocked or is_pending(track)) then
                             distance = track.distance
                         end
                     elseif is_pending(track) then


### PR DESCRIPTION
Improve the way LQM manages the distance, and therefore the wifi coverage.
Some devices, notably AC devices, seem much more sensible to accurate distance settings. This means we need an improved approach to managing the coverage when adding new devices to an existing set, particularly in PtoMP situations. Now, when new devices are added but distances not yet known, we assume the worst (the maximum allowed distance configured in settings) until we have better information. This avoid cutting of devices which are added but much further away than the current "flock". The downside is that, until the pending distance is measured, bandwidth on error prone channels with be slightly impaired as retransmissions will slightly delayed.