### PR TITLE
Disable RTS by default in ath10k devices 02/11/2023

### DIFF
--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -7,7 +7,7 @@ do
         option enable '0'
         option min_snr '15'
         option margin_snr '1'
-        option rts_theshold '1'
+        option rts_threshold '-1'
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'

--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -7,7 +7,7 @@ do
         option enable '0'
         option min_snr '15'
         option margin_snr '1'
-        option rts_threshold '-1'
+        option rts_threshold '1'
         option min_distance '0'
         option max_distance '80467'
         option min_quality '50'

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -62,7 +62,7 @@ function get_config()
     return {
         margin = tonumber(c:get("aredn", "@lqm[0]", "margin_snr")),
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
-        rts_threshold = tonumber(c:get("aredn", "@lqm[0]", "rts_threshold") or "-1"),
+        rts_threshold = tonumber(c:get("aredn", "@lqm[0]", "rts_threshold") or "1"),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
         auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -62,7 +62,7 @@ function get_config()
     return {
         margin = tonumber(c:get("aredn", "@lqm[0]", "margin_snr")),
         low = tonumber(c:get("aredn", "@lqm[0]", "min_snr")),
-        rts_theshold = tonumber(c:get("aredn", "@lqm[0]", "rts_theshold") or "1"),
+        rts_threshold = tonumber(c:get("aredn", "@lqm[0]", "rts_threshold") or "-1"),
         min_distance = tonumber(c:get("aredn", "@lqm[0]", "min_distance")),
         max_distance = tonumber(c:get("aredn", "@lqm[0]", "max_distance")),
         auto_distance = tonumber(c:get("aredn", "@lqm[0]", "auto_distance") or "0"),
@@ -891,9 +891,9 @@ function lqm()
         do
             hidden[#hidden + 1] = ninfo
         end
-        if (#hidden == 0) ~= (#hidden_nodes == 0) and config.rts_theshold >= 0 and config.rts_theshold <= 2347 then
+        if (#hidden == 0) ~= (#hidden_nodes == 0) and config.rts_threshold >= 0 and config.rts_threshold <= 2347 then
             if #hidden > 0 then
-                os.execute(IW .. " " .. phy .. " set rts " .. config.rts_theshold .. " > /dev/null 2>&1")
+                os.execute(IW .. " " .. phy .. " set rts " .. config.rts_threshold .. " > /dev/null 2>&1")
             else
                 os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
             end

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -137,7 +137,7 @@ local settings = {
         key = "aredn.@lqm[0].rts_threshold",
         type = "string",
         desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_threshold</small>",
-        default = "-1",
+        default = "1",
         condition = "lqm_enabled()"
     },
     {

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -134,10 +134,10 @@ local settings = {
     },
     {
         category = "Link Quality Settings",
-        key = "aredn.@lqm[0].rts_theshold",
+        key = "aredn.@lqm[0].rts_threshold",
         type = "string",
-        desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_theshold</small>",
-        default = "1",
+        desc = "<b>RTS Threshold</b> in bytes before using RTS/CTS when hidden nodes are detected<br><br><small>aredn.@lqm[0].rts_threshold</small>",
+        default = "-1",
         condition = "lqm_enabled()"
     },
     {


### PR DESCRIPTION
On the Rocket 5AC Lite if we enable RTS the device fails to send packets.
At the moment we dont understand why or what devices are effected (non-AC devices seem fine).
But disable for every device for now while a solution is found.