### PR TITLE
Fix AC coverage calculation in driver. 02/12/2023

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -227,12 +227,6 @@ function lqm()
     -- Let things startup for a while before we begin
     wait_for_ticks(math.max(1, 30 - nixio.sysinfo().uptime))
 
-    -- Detect ath10k - we need some special handling (for the moment)
-    local is_ath10k = false
-    if nixio.fs.stat("/sys/kernel/debug/ieee80211/" .. phy .. "/ath10k") then
-        is_ath10k = true
-    end
-
     -- Create filters (cannot create during install as they disappear on reboot)
     os.execute(NFT .. " flush chain ip fw4 input_lqm 2> /dev/null")
     os.execute(NFT .. " delete chain ip fw4 input_lqm 2> /dev/null")
@@ -246,9 +240,7 @@ function lqm()
     -- We dont know any distances yet
     os.execute(IW .. " " .. phy .. " set distance auto > /dev/null 2>&1")
     -- Or any hidden nodes
-    if not is_ath10k then
-        os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
-    end
+    os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
 
     local noise = -95
     local tracker = {}
@@ -892,13 +884,11 @@ function lqm()
             hidden[#hidden + 1] = ninfo
         end
         -- Don't adjust RTS on ath10k for the moment - appear to be some bug to be worked out here
-        if not is_ath10k then
-            if (#hidden == 0) ~= (#hidden_nodes == 0) and config.rts_threshold >= 0 and config.rts_threshold <= 2347 then
-                if #hidden > 0 then
-                    os.execute(IW .. " " .. phy .. " set rts " .. config.rts_threshold .. " > /dev/null 2>&1")
-                else
-                    os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
-                end
+        if (#hidden == 0) ~= (#hidden_nodes == 0) and config.rts_threshold >= 0 and config.rts_threshold <= 2347 then
+            if #hidden > 0 then
+                os.execute(IW .. " " .. phy .. " set rts " .. config.rts_threshold .. " > /dev/null 2>&1")
+            else
+                os.execute(IW .. " " .. phy .. " set rts off > /dev/null 2>&1")
             end
         end
         hidden_nodes = hidden

--- a/patches/742-5-and-10mhz-ath10k-ct-support.patch
+++ b/patches/742-5-and-10mhz-ath10k-ct-support.patch
@@ -275,3 +275,22 @@ Index: openwrt/package/kernel/ath10k-ct/patches/999-0002-ath10k-5_10Mhz.patch
 + 
 + /* Use random MAC address for TA for Probe Request frame and add
 +  * OUI specified by WMI_SCAN_PROB_REQ_OUI_CMDID to the Probe Request frame.
+--- /dev/null
++++ openwrt/package/kernel/ath10k-ct/patches/999-0004-ath10k-coverage.patch
+@@ -0,0 +1,16 @@
++--- a/ath10k-5.15/hw.c
+++++ b/ath10k-5.15/hw.c
++@@ -665,13 +665,6 @@
++ 
++ 	slottime = MS(slottime_reg, WAVE1_PCU_GBL_IFS_SLOT);
++ 	slottime = slottime / phyclk;
++-	if (slottime != 9 && slottime != 20) {
++-		ath10k_warn(ar,
++-			    "failed to set coverage class: expected slot time of 9 or 20us in HW register. It is %uus.\n",
++-			    slottime);
++-
++-		goto store_regs;
++-	}
++ 
++ 	/* Recalculate the register values by adding the additional propagation
++ 	 * delay (3us per coverage class).


### PR DESCRIPTION
For some reason, there was code in the driver to block the setting of the coverage when a previous setting wasn't a particular value - a value set by the same code!! It's unclear what this was trying to achieve or prevent, but it stopped AC devices operating efficiently (by a factor of 10x or more).

The coverage being wrong had the knock on effect of breaking RTS because the driver wasn't waiting the correct time when using the protocol.