### PR TITLE
Force dnsmasq to update itself if no network changes for > 60secs

### DIFF
--- a/files/usr/local/bin/mgr/namechange.lua
+++ b/files/usr/local/bin/mgr/namechange.lua
@@ -39,12 +39,18 @@ function namechange()
     local count = 0
     while true
     do
-        if not nixio.fs.stat("/tmp/namechange") and count < 12 then
+        local exists = nixio.fs.stat("/tmp/namechange")
+        if not exists and count < 12 then
             count = count + 1
             wait_for_ticks(5)
         else
-            os.remove("/tmp/namechange")
+            if exists then
+                os.remove("/tmp/namechange")
+            end
             do_namechange()
+            if not exists then
+                dns_update()
+            end
             count = 0
         end
     end
@@ -112,6 +118,13 @@ function do_namechange()
         f:close()
     end
 
+end
+
+function dns_update()
+    local pid = capture("pidof dnsmasq")
+    if pid ~= "" then
+        nixio.kill(tonumber(pid), 1)
+    end
 end
 
 return namechange

--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -275,7 +275,7 @@ print([[{]])
 print([[    PlParam "sighup-pid-file" "/var/run/dnsmasq/dnsmasq.pid"]])
 print([[    PlParam "interval" "30"]])
 print([[    PlParam "timeout" "300"]])
-print([[    PlParam "name-change-script" "cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot; mv -f /var/run/hosts_olsr.snapshot /var/run/hosts_olsr.stable; touch /tmp/namechange /var/run/hosts_olsr.stable"]])
+print([[    PlParam "name-change-script" "/usr/local/bin/olsrd-namechange"]])
 for _, name in ipairs(names)
 do
     print([[    PlParam "name" "]] .. name .. [["]])

--- a/files/usr/local/bin/olsrd-namechange
+++ b/files/usr/local/bin/olsrd-namechange
@@ -1,0 +1,38 @@
+#!/bin/sh
+<<'LICENSE'
+  Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+  Copyright (C) 2023 Tim Wilkinson
+   See Contributors file for additional contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional Terms:
+
+  Additional use restrictions exist on the AREDN(TM) trademark and logo.
+    See AREDNLicense.txt for more info.
+
+  Attributions to the AREDN Project must be retained in the source code.
+  If importing this code into a new or existing project attribution
+  to the AREDN project must be added to the source code.
+
+  You must not misrepresent the origin of the material contained within.
+
+  Modified versions must be modified to attribute to the original source
+  and be marked in reasonable ways as differentiate it from the original
+  version.
+
+LICENSE
+
+cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot
+mv -f /var/run/hosts_olsr.snapshot /var/run/hosts_olsr.stable
+touch /tmp/namechange


### PR DESCRIPTION
On small networks there are not a lot of OLSR name changes. While dnsmasq watches for changes and updates itself, it will sometimes miss them. On busy networks this doesnt matter as the next change will catch it up. But on smaller network (esp. test networks) a missed change can stop name resolution working for some time. So now, if no changes are detected for > 60 seconds, we force dnsmasq to reload its tables.