### PR TITLE
More fixes for AP mode

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -196,6 +196,10 @@ local cfive = { 36,40,44,48,149,153,157,161,163,165,167,169,171,173,175,177 }
 local wifiintf = aredn.hardware.get_iface_name("wifi")
 local phy = iwinfo.nl80211.phyname(wifiintf)
 local phycount = tonumber(capture("ls -1d /sys/class/ieee80211/* | wc -l"):chomp())
+local radio_name = aredn.hardware.get_radio().name or ""
+local M9model = radio_name:match("M9")
+local M3model = radio_name:match("M3")
+local M39model = M9model or M3model
 
 -- post_data
 local parms = {}
@@ -1051,7 +1055,7 @@ html.print([[
 
 -- mesh rf settings
 html.print("<table width=100% style='border-collapse: collapse;'>")
-html.print("<tr><th colspan=2>Mesh RF</th></tr>")
+html.print("<tr><th colspan=2>Mesh RF (" .. (M3model and "3GHz" or M9model and "900MHz" or wifi_channel < 36 and "2GHz" or "5GHz") .. ")</th></tr>")
 hidden[#hidden + 1] = "<input type=hidden name=wifi_proto value='static'>"
 
 -- add enable/disable
@@ -1209,7 +1213,6 @@ end
 html.print("<tr><td colspan=2><hr></hr></td></tr>")
 
 local APokay = nixio.fs.stat("/usr/sbin/wpad")
-local M39model = aredn.hardware.get_board_id():match("M[39]")
 if APokay and ((phycount > 1 and (wifi_enable ~= "1" or wifi3_enable ~= "1")) or (phycount == 1 and wifi_enable ~= "1" and wifi3_enable ~= "1") and not M39model) then
     -- lan ap shows as an option
     -- determine hardware options and set band ahd channels accordingly
@@ -1231,7 +1234,8 @@ if APokay and ((phycount > 1 and (wifi_enable ~= "1" or wifi3_enable ~= "1")) or
     else
         -- 2 band device
         if wifi_enable == "1" then
-            local rc3 = os.execute("iw phy phy1 info | grep -v disabled | grep -q '5180 MHz' > /dev/null")
+            local alt_phy = phy == "phy0" and "phy1" or "phy0"
+            local rc3 = os.execute("iw " .. alt_phy .. " info | grep -v disabled | grep -q '5180 MHz' > /dev/null")
             if rc3 ~= 0 then
                 wifi2_hwmode = "11g"
                 if wifi2_channel > 14 then
@@ -1273,6 +1277,7 @@ if APokay and ((phycount > 1 and (wifi_enable ~= "1" or wifi3_enable ~= "1")) or
             html.print("<option value='11a'".. (wifi2_hwmode == "11a" and " selected" or "") .. ">5GHz</option>")
             html.print("</select></td></tr>")
         else
+            html.print("<tr><td>AP band</td><td>" .. (wifi2_hwmode == "11g" and "2GHz" or "5GHz") .. "</td></tr>")
             hidden[#hidden + 1] = "<input type=hidden name=wifi2_hwmode  value='" .. wifi2_hwmode .."'>"
         end
     else


### PR DESCRIPTION
AP radio isn't always phy1 so handle these cases.
Add in some labels to RF and AP for which bands are in use.