### PR TITLE
remove WAN Wifi Client key lower limit

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -662,11 +662,11 @@ if parms.button_save then
         end
     end
     if wifi3_enable == "1" then
-        if #wifi3_key ~= 0 and (#wifi3_key < 8 or #wifi3_key > 64) then
-            err("WAN Wifi Client Password must be between 8 and 64 characters")
+        if #wifi3_key > 64 then
+            err("WAN Wifi Client Password must be 64 characters or less")
         end
         if wifi3_key:match("'") or wifi3_ssid:match("'") then
-            err("The WAN Wifi Client password and ssid may not contain a single quote character")
+            err("The WAN Wifi Client password and ssid cannot contain a single quote character")
         end
     end
 


### PR DESCRIPTION
The WAN Wifi Client password is currently limited to zero characters (for connecting to an open AP) or between 8 and 64 characters.  Unfortunately the node owner has no control over the number of characters in the key for the Wifi AP he is using.  This situation occurs fairly frequently when using a travel node at a hotel.  Chuck NC8Q just ran into the issue at a Country Inn and Suites in Fredericksburg VA where the key was only 7 characters in length.  As an upper limit hopefully 64 characters will be enough, but this PR removes the lower limit on the number of characters allowed for the WAN Wifi AP key.