### PR TITLE
Support force upgrades

### DIFF
--- a/files/usr/local/bin/aredn_sysupgrade
+++ b/files/usr/local/bin/aredn_sysupgrade
@@ -49,4 +49,12 @@ case "$(/usr/local/bin/get_boardid)" in
         ;;
 esac
 
-/sbin/sysupgrade $*
+#
+# Let users force upgrade a node
+#
+force=""
+if [ -f /tmp/force-upgrade-this-is-dangerous ]; then
+  force="--force"
+fi
+
+/sbin/sysupgrade ${force} $*


### PR DESCRIPTION
Provide a simple, but very deliberate, way to force an upgrade when the upgrade is - technically - incompatible. This is to help people who make incorrect upgrade choices when moving to the next release.

Obviously we could make this easier to use .. but let's not .. this seems like a fair place to draw the line for the moment.