### PR TITLE
Support forced upgrades

### DIFF
--- a/files/usr/local/bin/aredn_sysupgrade
+++ b/files/usr/local/bin/aredn_sysupgrade
@@ -49,4 +49,12 @@ case "$(/usr/local/bin/get_boardid)" in
         ;;
 esac
 
-/sbin/sysupgrade $*
+#
+# Let users force upgrade a node
+#
+force=""
+if [ -f /tmp/force-upgrade-this-is-dangerous ]; then
+  force="--force"
+fi
+
+/sbin/sysupgrade ${force} $*

--- a/files/usr/local/bin/firmwarecheck.sh
+++ b/files/usr/local/bin/firmwarecheck.sh
@@ -16,8 +16,12 @@ then
 		return 1;
 	fi
 	if [ "$(echo "$json" | jsonfilter -e '@.tests.fwtool_device_match')" = "false" ]; then
-		echo "firmware device match failed";
-		return 1
+		if [ -f /tmp/force-upgrade-this-is-dangerous ]; then
+			return 0
+		else
+			echo "firmware device match failed";
+			return 1
+		fi
 	fi
 fi
 echo "platform check image failed";

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -846,6 +846,10 @@ end
 html.print("<tr><td align=center colspan=3><b>Current Version:</b> " .. fw_version .. "&nbsp; &nbsp; &nbsp; <b>Hardware Type:</b> (" .. targettype .. ") " .. mfgprefix .. " (" .. hardwaretype .. ")</td></tr>")
 html.print("<tr><td align=center colspan=3>Keep Existing Configuration Settings <input type=checkbox name=checkbox_keep_settings checked title='keep existing configuration settings'></td></tr>")
 
+if nixio.fs.stat("/tmp/force-upgrade-this-is-dangerous") then
+    html.print("<tr><td align=center colspan=3><span style=background-color:red;font-size:140%;>&nbsp; ALL FIRMWARE UPGRADE COMPATIBILITY CHECKS HAVE BEEN DISABLED &nbsp;</span></td></tr>")
+end
+
 html.print("<tr>")
 html.print("<td>Upload Firmware</td>")
 html.print("<td><input style='width:100%' type=file name=firmfile title='choose the firmware file to install from your hard drive' accept='.bin'></td>")

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -289,14 +289,14 @@ local settings = {
         default = "http://unpkg.com/leaflet@0.7.7/dist/leaflet.js"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].firmwarepath",
         type = "string",
         desc = "<b>Firmware Download URL</b><br><br><small>aredn.@downloads[0].firmwarepath</small>",
         default = "http://downloads.arednmesh.org/firmware"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_core",
         type = "string",
         desc = "<b>Core Packages Download URL</b><br><br><small>aredn.@downloads[0].pkgs_core</small>",
@@ -304,7 +304,7 @@ local settings = {
         postcallback = "writePackageRepo('core')"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_base",
         type = "string",
         desc = "<b>Base Packages URL</b><br><br><small>aredn.@downloads[0].pkgs_base</small>",
@@ -312,7 +312,7 @@ local settings = {
         postcallback = "writePackageRepo('base')"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_arednpackages",
         type = "string",
         desc = "<b>AREDN Packages URL</b><br><br><small>aredn.@downloads[0].pkgs_arednpackages</small>",
@@ -320,7 +320,7 @@ local settings = {
         postcallback = "writePackageRepo('arednpackages')"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_luci",
         type = "string",
         desc = "<b>Luci Packages URL</b><br><br><small>aredn.@downloads[0].pkgs_luci</small>",
@@ -328,7 +328,7 @@ local settings = {
         postcallback = "writePackageRepo('luci')"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_packages",
         type = "string",
         desc = "<b>Package Download URL</b> for packages not included in the other sections<br><br><small>aredn.@downloads[0].pkgs_packages</small>",
@@ -336,7 +336,7 @@ local settings = {
         postcallback = "writePackageRepo('packages')"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_routing",
         type = "string",
         desc = "<b>Routing Packages URL</b><br><br><small>aredn.@downloads[0].pkgs_routing</small>",
@@ -344,7 +344,7 @@ local settings = {
         postcallback = "writePackageRepo('routing')"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_telephony",
         type = "string",
         desc = "<b>Telephony Packages URL</b><br><br><small>aredn.@downloads[0].pkgs_telephony</small>",
@@ -352,12 +352,21 @@ local settings = {
         postcallback = "writePackageRepo('telephony')"
     },
     {
-        category = "Firmware Paths",
+        category = "Firmware",
         key = "aredn.@downloads[0].pkgs_freifunk",
         type = "string",
         desc = "<b>Freifunk Packages URL</b><br><br><small>aredn.@downloads[0].pkgs_freifunk</small>",
         default = defaultPackageRepos('freifunk'),
         postcallback = "writePackageRepo('freifunk')"
+    },
+    {
+        category = "Firmware",
+        key = "aredn.firmware.dangerous_upgrade",
+        type = "boolean",
+        desc = "<b>Dangerous Upgrade Disables</b> all safety checks usually applied when upgrading firmware<br><br><small>aredn.firmware.dangerous_upgrade</small>",
+        default = "0",
+        current = "current_force_upgrade()",
+        postcallback = "update_force_upgrade()"
     },
     {
         category = "AREDN Alert Settings",
@@ -557,6 +566,19 @@ function lqm_defaults()
     cursor_set("aredn", "@lqm[0]", "min_quality", "50")
     cursor_set("aredn", "@lqm[0]", "ping_penalty", "5")
     cursor_set("aredn", "@lqm[0]", "margin_quality", "1")
+end
+
+function current_force_upgrade()
+    return nixio.fs.stat("/tmp/force-upgrade-this-is-dangerous") and 1 or 0
+end
+
+function update_force_upgrade()
+    if not newval or newval ~= "1" then
+        nixio.fs.remove("/tmp/force-upgrade-this-is-dangerous")
+    else
+        io.open("/tmp/force-upgrade-this-is-dangerous", "w+"):close()
+    end
+
 end
 
 function writePackageRepo(repo)


### PR DESCRIPTION
This has come up a few times as people have started to use nightlies and have ended up on the wrong one (having assuming they should continue to use an incorrect model version because that's what they use to do). The fix is to allow technically incompatible upgrades - technically because they might be perfectly valid .. but there's no easy way to know. So, here's a mechanism which requires a push of a button in the advanced configure, and show a big red banner in the firmware upgrade UI. The trade off here is that providing this mechanism with large red warnings will be less of a support problem compared to people using this to shoot themselves in the foot.

UI for setting the option:

<img width="882" alt="Screenshot 2023-03-08 at 10 25 25 PM" src="https://user-images.githubusercontent.com/751258/223938391-a8587267-001f-44cd-af14-7ac7ea9e0dc7.png">

Banner show when option is set:

<img width="863" alt="Screenshot 2023-03-08 at 10 26 04 PM" src="https://user-images.githubusercontent.com/751258/223938510-1757c257-5a85-4d89-869f-d3ba1f5c27e6.png">
