### PR TITLE
Stop RETURN from refreshing the mesh page 03/16/2023

### DIFF
--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -479,9 +479,9 @@ end
 
 html.print("<table id=nTable>")
 html.print("<tr>")
-html.print("<th width=25%><input class=search type=text id='inNN' onkeyup=nSearch('inNN','nTable',0) placeholder='Node Name'></th>")
-html.print("<th><input class=search type=text id='inNH' onkeyup=nSearch('inNH','nTable',1) placeholder='LAN Hostname'></th>")
-html.print("<th><input class=search type=text id='inNS' onkeyup=nSearch('inNS','nTable',2) placeholder='Service Name'></th>")
+html.print("<th width=25%><input class=search type=text id='inNN' onkeyup=nSearch('inNN','nTable',0) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='Node Name'></th>")
+html.print("<th><input class=search type=text id='inNH' onkeyup=nSearch('inNH','nTable',1) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='LAN Hostname'></th>")
+html.print("<th><input class=search type=text id='inNS' onkeyup=nSearch('inNS','nTable',2) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='Service Name'></th>")
 html.print("</tr>")
 
 if next(localhosts) then
@@ -575,10 +575,10 @@ html.print("</table>")
 -- show current neighbors table
 
 html.print("<br><table id='cTable'><tr>")
-html.print("<th width=25%><input class=search type=text id='inCN' onkeyup=nSearch('inCN','cTable',0) placeholder='Current Neighbors'></th>")
-html.print("<th><input class=search type=text id='inCH' onkeyup=nSearch('inCH','cTable',1) placeholder='LAN Hostname'></th>")
+html.print("<th width=25%><input class=search type=text id='inCN' onkeyup=nSearch('inCN','cTable',0) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='Current Neighbors'></th>")
+html.print("<th><input class=search type=text id='inCH' onkeyup=nSearch('inCH','cTable',1) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='LAN Hostname'></th>")
 html.print("<th>LQ</th><th>NLQ</th><th>TxMbps</th>")
-html.print("<th><input class=search type=text id='inCS' onkeyup=nSearch('inCS','cTable',5) placeholder='Service Name'></th>")
+html.print("<th><input class=search type=text id='inCS' onkeyup=nSearch('inCS','cTable',5) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='Service Name'></th>")
 html.print("</tr>")
 
 local rows = {}
@@ -745,10 +745,10 @@ html.print("</table>")
 -- show remote node table
 
 html.print("<br><table id='rTable'><tr>")
-html.print("<th width=25%><input class=search type=text id='inRN' onkeyup=nSearch('inRN','rTable',0) placeholder='Remote Nodes'></th>")
-html.print("<th><input class=search type=text id='inRH' onkeyup=nSearch('inRH','rTable',1) placeholder='LAN Hostname'</th>")
+html.print("<th width=25%><input class=search type=text id='inRN' onkeyup=nSearch('inRN','rTable',0) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='Remote Nodes'></th>")
+html.print("<th><input class=search type=text id='inRH' onkeyup=nSearch('inRH','rTable',1) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='LAN Hostname'</th>")
 html.print("<th>ETX</th>")
-html.print("<th><input class=search type=text id='inRS' onkeyup=nSearch('inRS','rTable',3) placeholder='Service Name'</th>")
+html.print("<th><input class=search type=text id='inRS' onkeyup=nSearch('inRS','rTable',3) onkeypress='event.keyCode == 13 && event.preventDefault()' placeholder='Service Name'</th>")
 html.print("</tr>")
 
 local rows = {}


### PR DESCRIPTION
When people are using the filters on the mesh page, they sometimes hit RETURN. This submit the page (which is a form) causing the page to reload, lossing the filter, and as a side effect, setting the page to auto-refresh.