### PR TITLE
Improve ipFromCIDR function to handle /32 cidrs.

### DIFF
--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -211,7 +211,7 @@ end
 
 -- get IP from CIDR (strip network)
 function ipFromCIDR(ip)
-	return string.match(ip,"(.*)/.-")
+	return string.match(ip,"(%d+%.%d+%.%d+%.%d+)")
 end
 
 -- strips newline from a string


### PR DESCRIPTION
Unlike any other /X suffix, the /32 is omitted when turned into a string.