### PR TITLE
Update SUPPORTED_DEVICES.md - add Mikrotik RBDiscG-5acD

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -12,6 +12,7 @@ Mikrotik RBLHG-5nD || 5 | ath79 | mikrotik | mikrotik-lhg-5nd | 64MB | stable | 
 Mikrotik RBLHG-5HPnD || 5 | ath79 | mikrotik | mikrotik-lhg-5hpnd | 64MB | stable | released
 Mikrotik RBLHG-5HPnD-XL || 5 | ath79 | mikrotik | mikrotik-lhg-5hpnd-xl | 64MB | stable | released
 MikroTik RBLHGG-5acD | RBLHGG-5acD | 5 | ipq40xx | mikrotik | mikrotik_lhgg-5acd | 256MB | stable | nightly
+MikroTik RBDiscG-5acD | RBLHGG-5acD | 5 | ipq40xx | mikrotik | mikrotik_lhgg-5acd | 256MB | stable | nightly
 MikroTik RBLHGG-5acD-XL | RBLHGG-5acD-XL | 5 | ipq40xx | mikrotik | mikrotik_lhgg-5acd-xl | 256MB | stable | nightly
 Mikrotik RBLDF-2nD || 2 | ath79 | mikrotik | - | 64MB | unknown | released
 Mikrotik RBLDF-5nD || 5 | ath79 | mikrotik | mikrotik-ldf-5nd | 64MB | stable | nightly


### PR DESCRIPTION
Started testing of Mikrotik RBDiscG-5acD. Documentation available via the FCCID suggests this is the exact same board as the RBLHGG-5acD, with a 21db antenna instead of a 24.5db dish. https://fccid.io/TV7LHG5ACD. I have this firmware loaded on 2 nodes of this model, no unsupported banner is showing, and I have them meshed on 131 at 20MHz, testing across the room, with TX power set to 1dbmV on both, reading 100/100/144.4Mbps on the status page.