### PR TITLE
Resolve unresponsive node problems with Mikrotik AC devices.

### DIFF
--- a/files/usr/local/bin/mgr/station_monitor.lua
+++ b/files/usr/local/bin/mgr/station_monitor.lua
@@ -33,10 +33,28 @@
 
 --]]
 
+local unresponsive_max = 3
+local unresponsive = 0
 local wifiiface
+local frequency
+local ssid
 
 local IW = "/usr/sbin/iw"
 local ARPING = "/usr/sbin/arping"
+
+local logfile = "/tmp/station_monitor.log"
+if not file_exists(logfile) then
+    io.open(logfile, "w+"):close()
+end
+local log = aredn.log.open(logfile, 8000)
+
+function rejoin_network()
+    os.execute(IW .. " " .. wifiiface .. " ibss leave")
+    nixio.nanosleep(1, 0)
+    os.execute(IW .. " " .. wifiiface .. " ibss join " .. ssid .. " " .. frequency .. " fixed-freq")
+    log:write("Rejoining network")
+    log:flush()
+end
 
 function station_monitor()
     if not string.match(get_ifname("wifi"), "^wlan") then
@@ -45,24 +63,28 @@ function station_monitor()
         wait_for_ticks(math.max(1, 120 - nixio.sysinfo().uptime))
 
         wifiiface = get_ifname("wifi")
+        frequency = iwinfo.nl80211.frequency(wifiiface)
+        ssid = iwinfo.nl80211.ssid(wifiiface)
+
+        -- Mikrotik AC hardware has some startup issues which we try to resolve
+        -- by leaving and rejoining the network
+        local boardid = aredn.hardware.get_board_id():lower()
+        if boardid:match("mikrotik") and boardid:match("ac") then
+            rejoin_network()
+        end
 
         while true
         do
             run_station_monitor()
-            wait_for_ticks(300) -- 5 minute
+            wait_for_ticks(60) -- 1 minute
         end
     end
 end
 
-local logfile = "/tmp/station_monitor.log"
-if not file_exists(logfile) then
-    io.open(logfile, "w+"):close()
-end
-local log = aredn.log.open(logfile, 8000)
-
 function run_station_monitor()
 
     -- Check each station to make sure we can broadcast and unicast to them
+    local total = 0
     arptable(
         function (entry)
             if entry.Device == wifiiface then
@@ -75,8 +97,9 @@ function run_station_monitor()
                         -- If we see exactly one response then we neeed to force the station to reassociate
                         -- This indicates that broadcasts work, but unicasts dont
                         if line:match("Received 1 response") then
-                            log:write("Unresponsive node: ip " .. ip .. ", mac " .. mac)
+                            log:write("Possible unresponsive node: " .. ip .. " [" .. mac .. "]")
                             log:flush()
+                            total = total + 1
                             break
                         end
                     end
@@ -84,6 +107,18 @@ function run_station_monitor()
             end
         end
     )
+
+    -- If we find unresponsive nodes too often then we leave and rejoin the network
+    -- to reset everything
+    if total == 0 then
+        unresponsive = 0
+    else
+        unresponsive = unresponsive + 1
+        if unresponsive >= unresponsive_max then
+            unresponsive = 0
+            rejoin_network()
+        end
+    end
 end
 
 return station_monitor


### PR DESCRIPTION
Mikrotik AC devices get into a state where they wont communicate with non-AC devices .. sometimes. Leaving and rejoining the network resets everything. We monitor for this situation and rejoin the network when detected to resolve the issue.

Diagnosis:

It looks like somewhere in the Mikrotik AC firmware, devices broadcast their beacons with an incorrect channel width. This will then confuse devices connecting to them resulting in failed communications. The situation is very intermittent and not all devices seem to be effected, and not every time even if they are.

I'm trying to detect the issue using the arping process as before. This is imperfect as devices sometimes dont answer (wifi broadcasts are unreliable) so I'm looking for failures over time before leaving and rejoining the IBSS network. This means detection and correct can take a few minutes. I'm trying to head the problem off for Mikrotk AC devices by doing a rejoin early on regardless.
