### PR TITLE
Eliminate false network rejoins using LQM information

### DIFF
--- a/files/usr/local/bin/mgr/station_monitor.lua
+++ b/files/usr/local/bin/mgr/station_monitor.lua
@@ -74,6 +74,12 @@ function station_monitor()
             rejoin_network()
         end
 
+        -- Only monitor if we have LQM information
+        if uci.cursor():get("aredn", "@lqm[0]", "enable") ~= "1" then
+            exit_app()
+            return
+        end
+
         while true
         do
             run_station_monitor()


### PR DESCRIPTION
Weak connection which aren't being used can look like faulty connections. We use LQM information to ignore these and avoid false rejoin events which degrade the network.