### PR TITLE
Upgrade to OpenWRT 22.03.5

### DIFF
--- a/openwrt.mk
+++ b/openwrt.mk
@@ -2,5 +2,5 @@
 OPENWRT_SRC=https://github.com/openwrt/openwrt.git
 
 # what branch, tag or commit in this repo?
-OPENWRT_COMMIT=v22.03.4
+OPENWRT_COMMIT=v22.03.5
 


### PR DESCRIPTION
Smoke tested on my bank of 20 nodes without issue. Not sure there's anything material in this update for us.