### PR TITLE
Revert the Rocket M5 filename change.

### DIFF
--- a/patches/746-rocket-m-xw-support.patch
+++ b/patches/746-rocket-m-xw-support.patch
@@ -4,13 +4,13 @@
  endef
  TARGET_DEVICES += ubnt_powerbeam-m5-xw
  
-+define Device/ubnt_rocket-m5-xw
++define Device/ubnt_rocket-m-xw
 +  $(Device/ubnt-xw)
-+  DEVICE_MODEL := Rocket M XW
++  DEVICE_MODEL := Rocket M5 XW
 +  DEVICE_PACKAGES += rssileds
-+  SUPPORTED_DEVICES += rocket-m-xw rocket-m5-xw loco-m-xw
++  SUPPORTED_DEVICES += rocket-m-xw ubnt,rocket-m-xw loco-m-xw
 +endef
-+TARGET_DEVICES += ubnt_rocket-m5-xw
++TARGET_DEVICES += ubnt_rocket-m-xw
 +
 +define Device/ubnt_rocket-m2-xw
 +  $(Device/ubnt-xw)
@@ -25,14 +25,14 @@
    SOC := qca9558
 
 --- /dev/null
-+++ b/target/linux/ath79/dts/ar9342_ubnt_rocket-m5-xw.dts
++++ b/target/linux/ath79/dts/ar9342_ubnt_rocket-m-xw.dts
 @@ -0,0 +1,34 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 +
 +#include "ar9342_ubnt_xw.dtsi"
 +
 +/ {
-+	compatible = "ubnt,rocket-m5-xw", "ubnt,xw", "qca,ar9342";
++	compatible = "ubnt,rocket-m-xw", "ubnt,xw", "qca,ar9342";
 +	model = "Ubiquiti Rocket M5 (XW)";
 +};
 +

--- a/patches/748-powerbeam-m5-300-support.patch
+++ b/patches/748-powerbeam-m5-300-support.patch
@@ -41,6 +41,6 @@
 +endef
 +TARGET_DEVICES += ubnt_powerbeam-m5-300
 +
- define Device/ubnt_rocket-m5-xw
+ define Device/ubnt_rocket-m-xw
    $(Device/ubnt-xw)
    DEVICE_MODEL := Rocket M5 XW


### PR DESCRIPTION
This was preventing the currently installed Rocket M5s from finding updates.