### PR TITLE
Alternate ath9k and ath10k radio reset for deaf nodes

### DIFF
--- a/files/usr/local/bin/mgr/rssi_monitor_ath10k.lua
+++ b/files/usr/local/bin/mgr/rssi_monitor_ath10k.lua
@@ -36,8 +36,6 @@
 local periodic_scan_tick = 5
 
 local wifiiface
-local frequency
-local ssid
 
 function rssi_monitor_10k()
     if not string.match(get_ifname("wifi"), "^wlan") then
@@ -53,8 +51,6 @@ function rssi_monitor_10k()
             exit_app()
             return
         end
-        frequency = iwinfo.nl80211.frequency(wifiiface)
-        ssid = iwinfo.nl80211.ssid(wifiiface)
 
         while true
         do
@@ -74,8 +70,7 @@ local station_zero = 0
 local log = aredn.log.open(logfile, 16000)
 
 local function reset_network()
-    os.execute("/usr/sbin/iw " .. wifiiface .. " ibss leave > /dev/null 2>&1")
-    os.execute("/usr/sbin/iw " .. wifiiface .. " ibss join " .. ssid .. " " .. frequency .. " fixed-freq > /dev/null 2>&1")
+    write_all("/sys/kernel/debug/ieee80211/" .. phy .. "/ath10k/simulate_fw_crash", "hw-restart")
 end
 
 function run_monitor_10k()

--- a/files/usr/local/bin/mgr/rssi_monitor_ath9k.lua
+++ b/files/usr/local/bin/mgr/rssi_monitor_ath9k.lua
@@ -37,8 +37,6 @@
 local wifiiface
 local phy
 local multiple_ant = false
-local frequency
-local ssid
 
 function rssi_monitor_9k()
     if not string.match(get_ifname("wifi"), "^wlan") then
@@ -48,8 +46,6 @@ function rssi_monitor_9k()
 
         wifiiface = get_ifname("wifi")
         phy = iwinfo.nl80211.phyname(wifiiface)
-        frequency = iwinfo.nl80211.frequency(wifiiface)
-        ssid = iwinfo.nl80211.ssid(wifiiface)
     
         -- Supports ath9k
         if not phy or not nixio.fs.stat("/sys/kernel/debug/ieee80211/" .. phy .. "/ath9k") then
@@ -84,8 +80,7 @@ local periodic_scan_tick = 5
 local log = aredn.log.open(logfile, 16000)
 
 local function reset_network()
-    os.execute("/usr/sbin/iw " .. wifiiface .. " ibss leave > /dev/null 2>&1")
-    os.execute("/usr/sbin/iw " .. wifiiface .. " ibss join " .. ssid .. " " .. frequency .. " fixed-freq > /dev/null 2>&1")
+    write_all("/sys/kernel/debug/ieee80211/" .. phy .. "/ath9k/reset", "1")
 end
 
 function run_monitor_9k()

--- a/files/usr/local/bin/mgr/station_monitor.lua
+++ b/files/usr/local/bin/mgr/station_monitor.lua
@@ -51,7 +51,6 @@ local log = aredn.log.open(logfile, 8000)
 
 function rejoin_network()
     os.execute(IW .. " " .. wifiiface .. " ibss leave")
-    nixio.nanosleep(1, 0)
     os.execute(IW .. " " .. wifiiface .. " ibss join " .. ssid .. " " .. frequency .. " fixed-freq")
     log:write("Rejoining network")
     log:flush()

--- a/patches/701-ath9k-reset.patch
+++ b/patches/701-ath9k-reset.patch
@@ -1,0 +1,99 @@
+--- /dev/null
++++ b/package/kernel/mac80211/patches/ath/301-ath-reset.patch
+@@ -0,0 +1,96 @@
++diff --git a/drivers/net/wireless/ath/ath9k/debug.c b/drivers/net/wireless/ath/ath9k/debug.c
++index 4c81b1d7f417..fb7a2952d0ce 100644
++--- a/drivers/net/wireless/ath/ath9k/debug.c
+++++ b/drivers/net/wireless/ath/ath9k/debug.c
++@@ -749,9 +749,9 @@  static int read_file_misc(struct seq_file *file, void *data)
++ 
++ static int read_file_reset(struct seq_file *file, void *data)
++ {
++-	struct ieee80211_hw *hw = dev_get_drvdata(file->private);
++-	struct ath_softc *sc = hw->priv;
+++	struct ath_softc *sc = file->private;
++ 	static const char * const reset_cause[__RESET_TYPE_MAX] = {
+++		[RESET_TYPE_USER] = "User reset",
++ 		[RESET_TYPE_BB_HANG] = "Baseband Hang",
++ 		[RESET_TYPE_BB_WATCHDOG] = "Baseband Watchdog",
++ 		[RESET_TYPE_FATAL_INT] = "Fatal HW Error",
++@@ -779,6 +779,55 @@  static int read_file_reset(struct seq_file *file, void *data)
++ 	return 0;
++ }
++ 
+++static int open_file_reset(struct inode *inode, struct file *f)
+++{
+++	return single_open(f, read_file_reset, inode->i_private);
+++}
+++
+++static ssize_t write_file_reset(struct file *file,
+++				const char __user *user_buf,
+++				size_t count, loff_t *ppos)
+++{
+++	struct ath_softc *sc = file_inode(file)->i_private;
+++	struct ath_hw *ah = sc->sc_ah;
+++	struct ath_common *common = ath9k_hw_common(ah);
+++	unsigned long val;
+++	char buf[32];
+++	ssize_t len;
+++
+++	len = min(count, sizeof(buf) - 1);
+++	if (copy_from_user(buf, user_buf, len))
+++		return -EFAULT;
+++
+++	buf[len] = '\0';
+++	if (kstrtoul(buf, 0, &val))
+++		return -EINVAL;
+++
+++	if (val != 1)
+++		return -EINVAL;
+++
+++	/* avoid rearming hw_reset_work on shutdown */
+++	mutex_lock(&sc->mutex);
+++	if (test_bit(ATH_OP_INVALID, &common->op_flags)) {
+++		mutex_unlock(&sc->mutex);
+++		return -EBUSY;
+++	}
+++
+++	ath9k_queue_reset(sc, RESET_TYPE_USER);
+++	mutex_unlock(&sc->mutex);
+++
+++	return count;
+++}
+++
+++static const struct file_operations fops_reset = {
+++	.read = seq_read,
+++	.write = write_file_reset,
+++	.open = open_file_reset,
+++	.owner = THIS_MODULE,
+++	.llseek = seq_lseek,
+++	.release = single_release,
+++};
+++
++ void ath_debug_stat_tx(struct ath_softc *sc, struct ath_buf *bf,
++ 		       struct ath_tx_status *ts, struct ath_txq *txq,
++ 		       unsigned int flags)
++@@ -1393,8 +1442,8 @@  int ath9k_init_debug(struct ath_hw *ah)
++ 				    read_file_queues);
++ 	debugfs_create_devm_seqfile(sc->dev, "misc", sc->debug.debugfs_phy,
++ 				    read_file_misc);
++-	debugfs_create_devm_seqfile(sc->dev, "reset", sc->debug.debugfs_phy,
++-				    read_file_reset);
+++	debugfs_create_file("reset", 0600, sc->debug.debugfs_phy,
+++			    sc, &fops_reset);
++ 
++ 	ath9k_cmn_debug_recv(sc->debug.debugfs_phy, &sc->debug.stats.rxstats);
++ 	ath9k_cmn_debug_phy_err(sc->debug.debugfs_phy, &sc->debug.stats.rxstats);
++diff --git a/drivers/net/wireless/ath/ath9k/debug.h b/drivers/net/wireless/ath/ath9k/debug.h
++index 33826aa13687..389459c04d14 100644
++--- a/drivers/net/wireless/ath/ath9k/debug.h
+++++ b/drivers/net/wireless/ath/ath9k/debug.h
++@@ -39,6 +39,7 @@  struct fft_sample_tlv;
++ #endif
++ 
++ enum ath_reset_type {
+++	RESET_TYPE_USER,
++ 	RESET_TYPE_BB_HANG,
++ 	RESET_TYPE_BB_WATCHDOG,
++ 	RESET_TYPE_FATAL_INT,
++

--- a/patches/series
+++ b/patches/series
@@ -2,6 +2,7 @@
 001-ath79-cpe220v3-sysupgrade-supported.patch
 001-ath79-reverse-wpad-basic-wolfssl.patch
 006-rocket-m-flash-fix.patch
+701-ath9k-reset.patch
 701-extended-spectrum.patch
 702-enable-country-hx.patch
 703-fix-dnsmasq.patch


### PR DESCRIPTION
There is a well known issue with the ath9k chip set that it will occasionally go deaf. The usual response to this problem is, when detected, to run a wifi scan which will reset the chip and resolve the problem. However, this takes quite a lot of time - 20+ seconds when scanning the 5GHz band - and during this time the radio is unresponsive to normal traffic, causing drop outs in anyone sending traffic over the node, and potentially causing the mesh to start to reconfigure itself as OLSR traffic is no longer sent.

While I've been unable to find a real solution to this problem (there are various proposals but none confirmed as working) it is generally agreed that a wifi chip reset is all that's required rather than the full wifi scan. Using the included patch, we can now do this from our monitoring daemons when problems are detected. In testing this proved as effective and much faster.

I've also moved the ath10k monitor to use a similar approach, although I've not seen a problem with this driver in recent nighty builds (a node I have which connects across town had previous had a deaf problem with the ath10k driver).

This PR includes the this patch - https://patchwork.kernel.org/project/linux-wireless/patch/20210914192515.9273-2-linus.luessing@c0d3.blue/ - which gives user level access to resetting the ath9k chip (there is already a way to do this on the ath10k).