### PR TITLE
Fix lua converting empty port object to empty array.

### DIFF
--- a/files/www/cgi-bin/advancednetwork
+++ b/files/www/cgi-bin/advancednetwork
@@ -466,6 +466,11 @@ html.print([[
 html.print([[
     <script>
         const configs = ]] .. luci.jsonc.stringify(configs, true) .. [[;
+        configs.forEach(config => {
+            if (Array.isArray(config.ports)) {
+                config.ports = {}
+            }
+        });
         function port_change(input, network, port, checked) {
             console.log(network, port, checked)
             const config = configs.find(c => c.name == network);


### PR DESCRIPTION
Lua confuses empty objects and empty arrays when converting to JSON.

Problem was observed by @ab7pa when editing port assignments.