### PR TITLE
Remove another coverage test which causes problems.

### DIFF
--- a/files/usr/local/bin/mgr/rssi_monitor_ath10k.lua
+++ b/files/usr/local/bin/mgr/rssi_monitor_ath10k.lua
@@ -71,7 +71,23 @@ local station_zero = 0
 local log = aredn.log.open(logfile, 16000)
 
 local function reset_network()
+    local coverage
+    local f = io.popen("iw " .. phy .. " info")
+    if f then
+        for line in f:lines()
+        do
+            coverage = tonumber(line:match("Coverage class: (%d+)"))
+            if coverage then
+                os.execute("iw " .. phy .. " set coverage 0 > /dev/null 2>&1")
+                break
+            end
+        end
+        f:close()
+    end
     write_all("/sys/kernel/debug/ieee80211/" .. phy .. "/ath10k/simulate_fw_crash", "hw-restart")
+    if coverage then
+        os.execute("iw " .. phy .. " set coverage " .. coverage .. " > /dev/null 2>&1")
+    end
 end
 
 function run_monitor_10k()

--- a/patches/742-5-and-10mhz-ath10k-ct-support.patch
+++ b/patches/742-5-and-10mhz-ath10k-ct-support.patch
@@ -280,7 +280,7 @@ Index: openwrt/package/kernel/ath10k-ct/patches/999-0002-ath10k-5_10Mhz.patch
 @@ -0,0 +1,26 @@
 +--- a/ath10k-5.15/hw.c
 ++++ b/ath10k-5.15/hw.c
-+@@ -655,23 +655,8 @@
++@@ -655,23 +655,6 @@
 + 	slottime_reg = ar->fw_coverage.reg_slottime_orig;
 + 	timeout_reg = ar->fw_coverage.reg_ack_cts_timeout_orig;
 + 
@@ -292,8 +292,8 @@ Index: openwrt/package/kernel/ath10k-ct/patches/999-0002-ath10k-5_10Mhz.patch
 +-		goto store_regs;
 +-	}
 +-
-+ 	slottime = MS(slottime_reg, WAVE1_PCU_GBL_IFS_SLOT);
-+ 	slottime = slottime / phyclk;
++-	slottime = MS(slottime_reg, WAVE1_PCU_GBL_IFS_SLOT);
++-	slottime = slottime / phyclk;
 +-	if (slottime != 9 && slottime != 20) {
 +-		ath10k_warn(ar,
 +-			    "failed to set coverage class: expected slot time of 9 or 20us in HW register. It is %uus.\n",

--- a/patches/742-5-and-10mhz-ath10k-ct-support.patch
+++ b/patches/742-5-and-10mhz-ath10k-ct-support.patch
@@ -277,11 +277,21 @@ Index: openwrt/package/kernel/ath10k-ct/patches/999-0002-ath10k-5_10Mhz.patch
 +  * OUI specified by WMI_SCAN_PROB_REQ_OUI_CMDID to the Probe Request frame.
 --- /dev/null
 +++ openwrt/package/kernel/ath10k-ct/patches/999-0004-ath10k-coverage.patch
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,26 @@
 +--- a/ath10k-5.15/hw.c
 ++++ b/ath10k-5.15/hw.c
-+@@ -665,13 +665,6 @@
++@@ -655,23 +655,8 @@
++ 	slottime_reg = ar->fw_coverage.reg_slottime_orig;
++ 	timeout_reg = ar->fw_coverage.reg_ack_cts_timeout_orig;
 + 
++-	/* Do some sanity checks on the slottime register. */
++-	if (slottime_reg % phyclk) {
++-		ath10k_warn(ar,
++-			    "failed to set coverage class: expected integer microsecond value in register\n");
++-
++-		goto store_regs;
++-	}
++-
 + 	slottime = MS(slottime_reg, WAVE1_PCU_GBL_IFS_SLOT);
 + 	slottime = slottime / phyclk;
 +-	if (slottime != 9 && slottime != 20) {


### PR DESCRIPTION
We had removed one of the two coverage checks which prevents ath10k nodes working at large distances. Now remove the second test which is being triggered in some circumstances. I *think* it is unnecessarily restrictive for our use case. Removing it wont make things worse.