### PR TITLE
Fix MTU failure which broken node-setup

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -175,7 +175,8 @@ if cfg.wifi_enable == "1" then
     if not cfg.wifi_intf or cfg.wifi_intf == "" then
         cfg.wifi_intf = aredn.hardware.get_board_network_ifname("wifi"):match("^(%S+)")
     end
-    local mtu = tonumber(c:get("aredn", "@lqm[0]", "mtu"))
+    local mtu = c:get("aredn", "@lqm[0]", "mtu")
+    mtu = tonumber(mtu)
     if mtu and mtu >= 256 and mtu <= 1500 then
         cfg.wifi_mtu = mtu
     end


### PR DESCRIPTION
When uci:get(...) fails it return 2 arguments not 1, and that messes up tonumber(...) so we have to do this as two steps.