### PR TITLE
Re-enable AREDN's reset button behaviour

### DIFF
--- a/patches/100-remove-rcbutton-reset.patch
+++ b/patches/100-remove-rcbutton-reset.patch
@@ -1,0 +1,34 @@
+--- a/package/base-files/files/etc/rc.button/reset
++++ /dev/null
+@@ -1,31 +0,0 @@
+-#!/bin/sh
+-
+-. /lib/functions.sh
+-
+-OVERLAY="$( grep ' /overlay ' /proc/mounts )"
+-
+-case "$ACTION" in
+-pressed)
+-	[ -z "$OVERLAY" ] && return 0
+-
+-	return 5
+-;;
+-timeout)
+-	. /etc/diag.sh
+-	set_state failsafe
+-;;
+-released)
+-	if [ "$SEEN" -lt 1 ]
+-	then
+-		echo "REBOOT" > /dev/console
+-		sync
+-		reboot
+-	elif [ "$SEEN" -ge 5 -a -n "$OVERLAY" ]
+-	then
+-		echo "FACTORY RESET" > /dev/console
+-		jffs2reset -y && reboot &
+-	fi
+-;;
+-esac
+-
+-return 0

--- a/patches/series
+++ b/patches/series
@@ -2,6 +2,7 @@
 001-ath79-cpe220v3-sysupgrade-supported.patch
 001-ath79-reverse-wpad-basic-wolfssl.patch
 006-rocket-m-flash-fix.patch
+100-remove-rcbutton-reset.patch
 701-ath9k-reset.patch
 701-extended-spectrum.patch
 702-enable-country-hx.patch


### PR DESCRIPTION
OpenWRT's reset button handler was overriding ours, so remove it.

https://github.com/aredn/aredn/issues/869