### PR TITLE
Fix Mikrotik first instal

### DIFF
--- a/files/usr/local/bin/nvram-setup
+++ b/files/usr/local/bin/nvram-setup
@@ -55,34 +55,39 @@ local dtdmac = aredn_info.get_nvram("dtdmac")
 
 local hardware_mac
 if wifi_mac == "" or mac2 == "" then
-    local wlan = get_ifname("wifi")
-    if wlan then
+    if aredn.hardware.has_wifi() then
         local phy
         for i = 1,5
         do
-            local f = io.popen("iwinfo " .. wlan .. " info")
-            if f then
-                for line in f:lines()
+            for _, wlan in ipairs({ "wlan0", "wlan1" })
+            do
+                local f = io.popen("iwinfo " .. wlan .. " info")
+                if f then
+                    for line in f:lines()
+                    do
+                        phy = line:match("PHY name:%s*([a-z0-4]+)")
+                        if phy then
+                            break
+                        end
+                    end
+                    f:close()
+                end
+                if phy then
+                    break
+                end
+            end
+            if phy then
+                for line in io.lines("/sys/class/ieee80211/" .. phy .. "/macaddress")
                 do
-                    phy = line:match("PHY name:%s*([a-z0-4]+)")
-                    if phy then
+                    local m = line:match("(%w%w:%w%w:%w%w:%w%w:%w%w:%w%w)")
+                    if m then
+                        hardware_mac = m
                         break
                     end
                 end
-                f:close()
-            end
-            if phy then
                 break
             end
             sleep(5)
-        end
-        for line in io.lines("/sys/class/ieee80211/" .. phy .. "/macaddress")
-        do
-            local m = line:match("(%w%w:%w%w:%w%w:%w%w:%w%w:%w%w)")
-            if m then
-                hardware_mac = m
-                break
-            end
         end
     end
     if not hardware_mac then

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -171,11 +171,14 @@ local wifi_ssid
 if not wifi_disabled then
     wifi_channel = cursor:get("wireless", radio, "channel")
     wifi_channel = tonumber(wifi_channel) or 0
-    local basefreq = aredn.hardware.get_rfchannels(wifi_iface)[1].frequency
-    if basefreq > 3000 and basefreq < 5000 then
-        wifi_channel = wifi_channel * 5 + 3000
-    elseif basefreq > 900 and basefreq < 2300 then
-        wifi_channel = wifi_channel * 5 + 887
+    local rfchans = aredn.hardware.get_rfchannels(wifi_iface)
+    if rfchans and rfchans[1] then
+        local basefreq = rfchans[1].frequency
+        if basefreq > 3000 and basefreq < 5000 then
+            wifi_channel = wifi_channel * 5 + 3000
+        elseif basefreq > 900 and basefreq < 2300 then
+            wifi_channel = wifi_channel * 5 + 887
+        end
     end
     wifi_chanbw = cursor:get("wireless", radio, "chanbw") or "20"
     wifi_ssid = "none"


### PR DESCRIPTION
On older the hap ac lite the first install now tries to dynamically determine things about the radios which it can't do in this state because the ram image is missing some things by default and the ac radio is not active.

Various fixes to allow for this while running the ram image.