### PR TITLE
Corrected names of MikroTik of BaseBox models

### DIFF
--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -122,10 +122,10 @@
     "MikroTik RouterBOARD 952Ui-5ac2nD (hAP ac lite)" : {
       "maxpower"        : "22"
     },
-    "Mikrotik RouterBOARD 912UAG-2HPnD" : {
+    "MikroTik RouterBOARD 912UAG-2HPnD" : {
       "maxpower"        : "30"
     },
-    "Mikrotik RouterBOARD RB912UAG-2HPnD" : {
+    "MikroTik RouterBOARD RB912UAG-2HPnD" : {
       "maxpower"        : "30"
     },
     "MikroTik RouterBOARD 912UAG-5HPnD" : {


### PR DESCRIPTION
Please refer to https://www.arednmesh.org/content/mikrotik-basebox-2-unsupported

Because the current `radios.json` has the entry `Mikrotik RouterBOARD 912UAG-2HPnD` but the system info is reporting back `MikroTik RouterBOARD 912UAG-2HPnD` the unsupported banner is being triggered. This change fixes the case of the `T` in MikroTik so that the BaseBox series shows up correctly as a supported device. 