### PR TITLE
Add github templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Create a report for firmware related bugs.
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+- [ ] Does this issue still occur on the latest version? (**Required**)
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+Please include a screenshot of your system information (if possible) if the specific system environment is relevant to the bug.
+
+If applicable, add screenshots to help explain your problem.
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: New feature or request
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/new_hardware_support.md
+++ b/.github/ISSUE_TEMPLATE/new_hardware_support.md
@@ -1,0 +1,19 @@
+---
+name: Hardware Support
+about: Suggest supporting new hardware/platforms
+title: ''
+labels: 'new hardware support'
+assignees: ''
+
+---
+
+### What is the hardware/platform
+What is the name of the item? Ex. Ubiquiti Rocket M2
+
+### Links
+Please include relevant links to the content.
+
+e.g. Product page, OpenWRT Table of Hardware page, etc.
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: Question related to the project that is not related to bugs or hardware/feature addition.
+title: ''
+labels: 'question'
+assignees: ''
+
+---
+
+### What is your question
+Describe your question/problem as clearly as possible.
+
+### Links and screenshots
+Please include any relevant links or screenshots, if applicable.
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+
+<!-- Thank you so much for contributing! -->
+
+### Description
+Describe the goals that the pull request accomplishes.
+
+### Relevant Links
+If there are related issues, please link them here.
+
+Please also include links relevant to the changes.
+
+### Screenshots
+If applicable, please include screenshots before and after your changes.
+
+### Additional context
+Add any other context about the problem or changes here.


### PR DESCRIPTION
When opening a new issue or pull request, templates will be provided that can be filled in.

In the case of Issues, 4 options will be given for a template to start with (bug report, feature/enhancement request, new hardware support, and general question), as well as an option for a blank issue. Choosing one of the template will automatically tag the issue. To see what this looks like, you can go here:

https://github.com/BKasin/aredn/issues/new/choose