### PR TITLE
Remember and reinstall packages after firmware upgrade

### DIFF
--- a/files/etc/arednsysupgrade.conf
+++ b/files/etc/arednsysupgrade.conf
@@ -35,3 +35,4 @@
 /etc/local/uci/hsmmmesh
 /etc/passwd
 /etc/shadow
+/etc/package_store

--- a/files/etc/cron.boot/reinstall-packages
+++ b/files/etc/cron.boot/reinstall-packages
@@ -1,7 +1,8 @@
+#!/usr/bin/lua
 --[[
 
 	Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
-	Copyright (C) 2022 Tim Wilkinson
+	Copyright (C) 2023 Tim Wilkinson
 	See Contributors file for additional contributors
 
 	This program is free software: you can redistribute it and/or modify
@@ -33,38 +34,26 @@
 
 --]]
 
-function run_scripts(dir)
-    if nixio.fs.stat(dir, "type") == "dir" then
-        for script in nixio.fs.dir(dir)
-        do
-            local stat = nixio.fs.stat(dir .. "/" .. script)
-            if script:match("^[a-zA-Z0-9_%-]+$") and stat.type == "reg" and nixio.bit.band(tonumber(stat.modedec, 8), tonumber(111, 8)) ~= 0 then
-                os.execute("(cd /tmp;" .. dir .. "/" .. script .. " 2>&1 | logger -p daemon.debug -t " .. script .. ")&")
-            end
-        end
-    end
-end
+require("nixio")
+require("luci.jsonc")
 
-function periodic()
-    wait_for_ticks(120) -- Initial wait before starting up period tasks
-    local hours = 0
-    local days = 0
-    run_scripts("/etc/cron.boot")
-    while true
+local package_store = "/etc/package_store"
+local package_catalog = package_store .. "/catalog.json"
+
+if nixio.fs.stat(package_catalog) then
+    os.execute("opkg update")
+    local catalog = luci.jsonc.parse(io.open(package_catalog):read("*a"))
+    for ipkg, state in pairs(catalog.installed)
     do
-        run_scripts("/etc/cron.hourly")
-        hours = hours - 1
-        if hours <= 0 then
-            run_scripts("/etc/cron.daily")
-            hours = 24
-            days = days - 1
-            if days <= 0 then
-                run_scripts("/etc/cron.weekly")
-                days = 7
+        if state == "local" then
+            local file = package_store .. "/" .. ipkg .. ".ipk"
+            if nixio.fs.stat(file) then
+                os.execute("opkg install " .. file)
             end
+        elseif state == "global" then
+            os.execute("opkg install " .. ipkg)
         end
-        wait_for_ticks(60 * 60)
     end
 end
 
-return periodic
+os.remove("/etc/cron.boot/reinstall-packages")

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -591,6 +591,31 @@ function update_advertised_services()
     end
 end
 
+local package_store = "/etc/package_store"
+local package_catalog = package_store .. "/catalog.json"
+
+function record_package(op, ipkg, file)
+    nixio.fs.mkdir(package_store)
+    local catalog = luci.jsonc.parse(read_all(package_catalog) or '{"installed":{}}')
+    if op == "upload" then
+        local package = ipkg:match("^([^_]+)")
+        if package then
+            os.execute("/bin/cp -f " .. file .. " " .. package_store .. "/" .. package .. ".ipk")
+            catalog.installed[package] = "local"
+        end
+    elseif op == "download" then
+        local result = capture("opkg status " .. ipkg .. " 2>&1")
+        local package = result:match("Package: (%S+)")
+        if package then
+            catalog.installed[package] = "global"
+        end
+    elseif op == "remove" then
+        nixio.fs.remove(package_store .. "/" .. ipkg .. ".ipk")
+        catalog.installed[ipkg] = nil
+    end
+    write_all(package_catalog, luci.jsonc.stringify(catalog))
+end
+
 -- upload package
 if parms.button_ul_pkg and nixio.fs.stat("/tmp/web/upload/file") then
     os.execute("mv -f /tmp/web/upload/file /tmp/web/upload/newpkg.ipk")
@@ -603,6 +628,7 @@ if parms.button_ul_pkg and nixio.fs.stat("/tmp/web/upload/file") then
         result = capture("opkg -force-overwrite install /tmp/web/upload/newpkg.ipk 2>&1")
     end
     pkgout(result)
+    record_package("upload", firmfile, "/tmp/web/upload/newpkg.ipk")
     os.execute("rm -rf /tmp/opkg-*")
     nixio.fs.remove("/tmp/web/upload/newpkg.ipk")
     if os.execute("/usr/local/bin/uploadctlservices restore > /dev/null 2>&1") ~= 0 then
@@ -624,6 +650,7 @@ if parms.button_dl_pkg and parms.dl_pkg ~= "default" then
             result = capture("opkg -force-overwrite install " .. parms.dl_pkg .. " 2>&1")
         end
         pkgout(result)
+        record_package("download", parms.dl_pkg)
         if os.execute("/usr/local/bin/uploadctlservices restore > /dev/null 2>&1") ~= 0 then
             pkgout("Failed to restart all services, please reboot this node.")
         else
@@ -651,6 +678,7 @@ if parms.button_rm_pkg and parms.rm_pkg ~= "default" and not permpkg[parms.rm_pk
     if not output:match("No packages removed") then
         pkgout("Package removed successfully")
         update_advertised_services()
+        record_package("remove", parms.rm_pkg)
     end
 end
 


### PR DESCRIPTION
Remember what packages get installed by the user, and reinstall them on the next firmware upgrades.
Locally installed packages are stored and moved across with the upgrade.
It waits a couple of minutes after the upgrade to activate (so the network should have stablised).

Would be good to get some eyes on this to see how reliable it is.