### PR TITLE
Support wildcard DNS subdomains

### DIFF
--- a/files/etc/config.mesh/dhcp
+++ b/files/etc/config.mesh/dhcp
@@ -1,10 +1,12 @@
+config dnsmasq
+	option confdir		'/tmp/dnsmasq.d,*.conf'
+
 config dhcp
 	option interface	lan
 	option start 		<dhcp_start>
 	option limit		<dhcp_limit>
 	option leasetime	1h
-        option ignore           <lan_dhcp>
-
+    option ignore		<lan_dhcp>
 
 config dhcp
 	option interface	wan

--- a/files/etc/init.d/local-early
+++ b/files/etc/init.d/local-early
@@ -1,0 +1,7 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006 OpenWrt.org
+
+START=10
+boot() {
+    mkdir -p /tmp/dnsmasq.d
+}

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -531,6 +531,9 @@ if h and e then
             if not (line:match("^%s*#") or line:match("^%s*$")) then
                 local ip, host = line:match("(%S+)%s+(%S+)")
                 if ip then
+                    if host:match("%.") and not host:match("%.local%.mesh$") then
+                        host = host .. ".local.mesh"
+                    end
                     h:write(ip .. "\t" .. host .. " #ALIAS\n")
                 end
             end

--- a/files/usr/local/bin/olsrd-namechange
+++ b/files/usr/local/bin/olsrd-namechange
@@ -1,38 +1,81 @@
-#!/bin/sh
-<<'LICENSE'
-  Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
-  Copyright (C) 2023 Tim Wilkinson
-   See Contributors file for additional contributors
+#!/usr/bin/lua
+--[[
 
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation version 3 of the License.
+	Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+	Copyright (C) 2023 Tim Wilkinson
+	See Contributors file for additional contributors
 
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation version 3 of the License.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-  Additional Terms:
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-  Additional use restrictions exist on the AREDN(TM) trademark and logo.
-    See AREDNLicense.txt for more info.
+	Additional Terms:
 
-  Attributions to the AREDN Project must be retained in the source code.
-  If importing this code into a new or existing project attribution
-  to the AREDN project must be added to the source code.
+	Additional use restrictions exist on the AREDN(TM) trademark and logo.
+		See AREDNLicense.txt for more info.
 
-  You must not misrepresent the origin of the material contained within.
+	Attributions to the AREDN Project must be retained in the source code.
+	If importing this code into a new or existing project attribution
+	to the AREDN project must be added to the source code.
 
-  Modified versions must be modified to attribute to the original source
-  and be marked in reasonable ways as differentiate it from the original
-  version.
+	You must not misrepresent the origin of the material contained within.
 
-LICENSE
+	Modified versions must be modified to attribute to the original source
+	and be marked in reasonable ways as differentiate it from the original
+	version
 
-cp /var/run/hosts_olsr /var/run/hosts_olsr.snapshot
-mv -f /var/run/hosts_olsr.snapshot /var/run/hosts_olsr.stable
-touch /tmp/namechange
+--]]
+
+local dns_file = "/tmp/dnsmasq.d/subdomains.conf"
+
+local f = io.open("/var/run/hosts_olsr")
+if f then
+    local data = ""
+    local subdomains = ""
+    for line in f:lines()
+    do
+        local ip, host = line:match("^(%S+)%s+%*%.(%S+)")
+        if host then
+            if not host:match("%.local%.mesh$") then
+                host = host .. ".local.mesh"
+            end
+            subdomains = subdomains .. "server=/" .. host .. "/" ..  ip .. "\n"
+        else
+            data = data .. line .. "\n"
+        end
+    end
+    f:close()
+
+    local w = io.open("/var/run/hosts_olsr.stable", "w+")
+    if w then
+        w:write(data)
+        w:close()
+    end
+
+    -- Write out the subdomains to lookup
+    local osubdomains = ""
+    f = io.open(dns_file)
+    if f then
+        osubdomains = f:read("*a")
+        f:close()
+    end
+    if osubdomains ~= subdomains then
+        local w = io.open(dns_file, "w+")
+        if w then
+            w:write(subdomains)
+            w:close()
+        end
+        os.execute("/etc/init.d/dnsmasq restart")
+    end
+
+end
+
+io.open("/tmp/namechange", "w+"):close()

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -647,7 +647,7 @@ do
                         end
                     end
                 end
-                if host:match("_") or not host:match("^[%w%-%.]+$") then
+                if not host:match("^%*%.") and (host:match("_") or not host:match("^[%w%-%.]+$")) then
                     aliaserr(val .. " <font color='red'>Warning!</font> The alias name: '" .. host .."' is invalid")
                 end
             end

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -631,7 +631,6 @@ do
         local ip = parms["alias" .. val .. "_ip"]
         -- if adding aliases check the name is not already in use,
         -- also check that it dos not contain anything that will be weird on the mesh
-        -- for instance: supercoolservice.kg6wxc-host.local.mesh is certainly a valid host name, but it won't work for the mesh.
         if val == "_add" then
             if host ~= "" then
                 local pattern = "%s" .. host .. "%s"
@@ -648,11 +647,8 @@ do
                         end
                     end
                 end
-                if not validate_hostname(host) then
+                if host:match("_") or not host:match("^[%w%-%.]+$") then
                     aliaserr(val .. " <font color='red'>Warning!</font> The alias name: '" .. host .."' is invalid")
-                end
-                if host:match("%.") then
-                    aliaserr(val .. " '" .. host .. "' cannot contain the dot '.' character")
                 end
             end
             if not ((host ~= "" or ip ~= "" or foundhost) and (parms.alias_add or parms.button_save)) then


### PR DESCRIPTION
Allow a node to specify a wildcard (starting with *.) subdomain as a DNS alias. DNS request for this subdomain will be delegated to the alias IP address.