### PR TITLE
Remove vestigial getServicesBy* methods

### DIFF
--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -154,8 +154,4 @@ function model.getCurrentNeighbors(RFinfo)
   return info
 end
 
-function model.getServicesByNode(node)
-    return {}
-end
-
 return model

--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -46,7 +46,7 @@ local json = require("luci.jsonc")
 require("iwinfo")
 local nettools = require("aredn.nettools")
 
-local API_VERSION="1.5"
+local API_VERSION="1.6"
 
 -- Function extensions
 os.capture = capture

--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -426,10 +426,6 @@ for page, comps in pairs(qsset) do
 		for i,comp in pairs(comps:split(',')) do
 			if comp=="sysinfo" then
 				info['pages'][page][comp]=getSysinfo()
-			elseif comp=="bynode" then
-				info['pages'][page][comp]=getServicesByNode()
-			elseif comp=="byservice" then
-				info['pages'][page][comp]=getServicesByService()
 			end
 		end
 	elseif page=="chart" then


### PR DESCRIPTION
getServicesByNode is only a dummy method.
getServicesByService doesn't even exist.

Remove the last remaining references to them from cgi-bin/api, and remove the last traces of getServicesByNode from aredn/olsr.lua

Fixes #948
Fixes #949