### PR TITLE
change pollrate default to one hour

### DIFF
--- a/files/usr/local/bin/mgr/aredn_message.lua
+++ b/files/usr/local/bin/mgr/aredn_message.lua
@@ -40,7 +40,7 @@ function aredn_message()
 		local pollrate = uci.cursor():get("aredn", "@alerts[0]", "pollrate")
         pollrate = tonumber(pollrate)
         if not pollrate or pollrate <= 0 then
-            pollrate = 12 -- 12 hour default
+            pollrate = 1 -- 1 hour default
         end
         wait_for_ticks(pollrate * 60 * 60)
     end

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -444,7 +444,7 @@ local settings = {
         key = "aredn.@alerts[0].pollrate",
         type = "string",
         desc = "<b>Alert Message Pollrate</b> - how many hours to wait between polling for new AREDN Alerts<br><br><small>aredn.@alerts[0].pollrate</small>",
-        default = "12",
+        default = "1",
         needreboot = true
     },
     {


### PR DESCRIPTION
Change AAM default polling interval to once every hour.  This makes AAM a little more useful from an operational perspective.