### PR TITLE
Bump Ubiquiti version number for LiteBeam 5AC

### DIFF
--- a/patches/749-ubiquiti-firmware-version.patch
+++ b/patches/749-ubiquiti-firmware-version.patch
@@ -1,0 +1,10 @@
+--- a/target/linux/ath79/image/generic-ubnt.mk
++++ b/target/linux/ath79/image/generic-ubnt.mk
+@@ -59,6 +59,7 @@
+   DEVICE_MODEL := LiteBeam AC
+   DEVICE_VARIANT := Gen2
+   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
++  UBNT_VERSION := 8.7.4
+ endef
+ TARGET_DEVICES += ubnt_litebeam-ac-gen2
+ 

--- a/patches/series
+++ b/patches/series
@@ -37,6 +37,7 @@
 749-copy-tiny-nodes-to-generic.patch
 749-fix-tiny.patch
 749-ubiquiti-extra-support.patch
+749-ubiquiti-firmware-version.patch
 750-ibss-2g-fix.patch
 751-x86.patch
 800-upgrade-compatibility.patch


### PR DESCRIPTION
Newer LiteBeam hardware wont downgrade lower than 8.7.4, so tweak the LiteBeam config to allow this firmware to install on 8.7.4

This might be safe for other hardware, but it's only tested on LiteBeams so far.