### PR TITLE
Fix missing vlan tag in advance networking

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,1 +1,1 @@
-src-git arednpackages https://github.com/kn6plv/aredn_packages;working
+src-git arednpackages https://github.com/aredn/aredn_packages;develop


### PR DESCRIPTION
If a vlan was set and saved before any ports were selected, the vlan would end up untagged.