### PR TITLE
Add comment for overriding network configuation

### DIFF
--- a/files/etc/config.mesh/network
+++ b/files/etc/config.mesh/network
@@ -1,3 +1,7 @@
+## The template place holders below can be overriden by adding files to
+## /etc/aredn_include of the format "NET.network.user". NET can be one
+## of the following: bridge, wan, wifi, lan or dtdlink.
+
 #### Globals
 config globals 'globals'
 	option packet_steering	'1'


### PR DESCRIPTION
### Description

Added a comment at the top of /etc/config.mesh/network to inform node admins how to override the network configuration for unusual and unique network configurations. See issue #995 for explanation of when overrides may be useful.

### Relevant Links

#995 

Please also include links relevant to the changes.
