### PR TITLE
Improve firmwarepath override

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,1 +1,1 @@
-src-git arednpackages https://github.com/kn6plv/aredn_packages;working
+src-git arednpackages https://github.com/aredn/aredn_packages;develop

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -253,7 +253,7 @@ if parms.button_refresh_fw then
         local config_serverpath
         for _, serverpath in ipairs(serverpaths)
         do
-            config_serverpath = serverpath:match("^(.*)/firmware") .. "/afs/www/"
+            config_serverpath = (serverpath:match("^(.*)/firmware") or serverpath) .. "/afs/www/"
             for line in io.popen(wget .. " -O - " .. config_serverpath .. "config.js 2> /dev/null"):lines()
             do
                 local v = line:match("versions: {(.+)}")


### PR DESCRIPTION
Code had assumed firmware path always ended in .../firmware but it may not if the user overrides this. Allow for that.