### PR TITLE
Fix all x86 mac addresses

### DIFF
--- a/files/etc/uci-defaults/94_fix_mac_addresses
+++ b/files/etc/uci-defaults/94_fix_mac_addresses
@@ -16,7 +16,7 @@ elif [ "$wlan0" = "" ]; then
 elif [ "$brlan" = "00:03:7F:11:23:C6" ]; then # Fix AR300M
     fix="lan"
 elif [ "$mfg" = "MikroTik" ]; then # Fix all MikroTiks
-    fix="lan"
+    fix="lan wan dtdlink"
 fi
 
 mkdir -p /etc/aredn_include

--- a/files/etc/uci-defaults/94_fix_mac_addresses
+++ b/files/etc/uci-defaults/94_fix_mac_addresses
@@ -12,11 +12,11 @@ mfg=$(/usr/local/bin/get_hardware_mfg)
 if [ "$eth0" = "$wlan0" -a "$eth0" != "" ]; then
     fix="lan wan dtdlink"
 elif [ "$wlan0" = "" ]; then
-    fix="lan"
+    fix="lan wan dtdlink"
 elif [ "$brlan" = "00:03:7F:11:23:C6" ]; then # Fix AR300M
     fix="lan"
 elif [ "$mfg" = "MikroTik" ]; then # Fix all MikroTiks
-    fix="lan wan dtdlink"
+    fix="lan"
 fi
 
 mkdir -p /etc/aredn_include


### PR DESCRIPTION
For x86 devices, make all the bridge mac addresses unique. Gives more flexibility when virtualized.