### PR TITLE
Temporarily remove x86 nightly build so we can build a nightly again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,6 @@ jobs:
           command: make MAINTARGET=ipq40xx SUBTARGET=mikrotik
           no_output_timeout: 1h
       - run:
-          name: Build x64/64
-          command: make MAINTARGET=x86 SUBTARGET=64
-          no_output_timeout: 2h
-      - run:
           name: Build ramips/mt7621
           command: make MAINTARGET=ipq40xx SUBTARGET=mt7621
           no_output_timeout: 2h


### PR DESCRIPTION
Until we update the docker build image, remove the x86 build