### PR TITLE
Switch to first party Ubiquiti firmware

### DIFF
--- a/configs/ath79-mikrotik-ath10k.config
+++ b/configs/ath79-mikrotik-ath10k.config
@@ -11,6 +11,7 @@ CONFIG_TARGET_ROOTFS_INITRAMFS=y
 # DEVICE_PACKAGES are not included in the initramfs, but for these devices we need
 # extra packages pre-installed to successfully install sysupgrade.
 #
+CONFIG_PACKAGE_ath10k-board-qca988x=y
 CONFIG_PACKAGE_ath10k-firmware-qca988x-ct=y
 CONFIG_PACKAGE_kmod-ath10k-ct=y
 CONFIG_PACKAGE_nand-utils=y

--- a/patches/744-dd-wrt-firmware.patch
+++ b/patches/744-dd-wrt-firmware.patch
@@ -5,7 +5,7 @@
  $(eval $(call BuildPackage,ath10k-firmware-qca9887-ct))
  $(eval $(call BuildPackage,ath10k-firmware-qca9887-ct-full-htt))
 -$(eval $(call BuildPackage,ath10k-firmware-qca988x-ct))
-+#$(eval $(call BuildPackage,ath10k-firmware-qca988x-ct))
++$(eval $(call BuildPackage,ath10k-firmware-qca988x-ct))
  $(eval $(call BuildPackage,ath10k-firmware-qca988x-ct-full-htt))
  $(eval $(call BuildPackage,ath10k-firmware-qca99x0-ct))
  $(eval $(call BuildPackage,ath10k-firmware-qca99x0-ct-full-htt))


### PR DESCRIPTION
Investigating problems with Ubiquiti devices not connecting. Switch to Ubiquiti firmware rather than third-party.