### PR TITLE
Remove fixed tunnel limits

### DIFF
--- a/files/etc/config.mesh/aredn
+++ b/files/etc/config.mesh/aredn
@@ -20,8 +20,7 @@ config dmz
 config location
 
 config tunnel
-        option maxclients '10'
-        option maxservers '10'
+        option weight '1'
 
 config lqm
         option enable '1'

--- a/files/etc/uci-defaults/90_aredn_default_tunnels
+++ b/files/etc/uci-defaults/90_aredn_default_tunnels
@@ -1,9 +1,6 @@
 #!/bin/sh
 if [ "$(/sbin/uci -c /etc/config.mesh -q get aredn.@tunnel[0])" != "tunnel" ]; then
     /sbin/uci -c /etc/config.mesh -q add aredn tunnel
-    /sbin/uci -c /etc/config.mesh -q set aredn.@tunnel[0].maxclients=10
-    /sbin/uci -c /etc/config.mesh -q set aredn.@tunnel[0].maxservers=10
-    /sbin/uci -c /etc/config.mesh -q set aredn.@tunnel[0].weight=1
     /sbin/uci -c /etc/config.mesh -q commit aredn
 fi
 

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -532,12 +532,12 @@ cm:foreach("vtun", "server",
 )
 
 -- Create the tunnel devices we need
-local maxclients = tonumber(cm:get("aredn", "@tunnel[0]", "maxclients") or 10)
-local maxservers = tonumber(cm:get("aredn", "@tunnel[0]", "maxservers") or 10)
+local maxclients = 0
+local maxservers = 0
 -- No tunnel devices without the vtund app
-if not nixio.fs.stat("/usr/sbin/vtund") then
-    maxclients = 0
-    maxservers = 0
+if nixio.fs.stat("/usr/sbin/vtund") then
+    maxclients = 10 * math.ceil(vtunclients / 10)
+    maxservers = 10 * math.ceil(vtunservers / 10)
 end
 for dev = 50, 50 + maxclients + maxservers - 1
 do
@@ -962,6 +962,8 @@ if nixio.fs.access("/etc/config.mesh/olsrd", "r") then
                 of:write("\toption LinkQualityMult 'default " .. (1 / tun_weight) .. "'\n")
             end
         end
+        nc:set("aredn", "@tunnel[0]", "maxclients", maxclients)
+        nc:set("aredn", "@tunnel[0]", "maxservers", maxservers)
 
         -- add xlink interfaces
         if nixio.fs.stat("/etc/config.mesh/xlink") then
@@ -1056,8 +1058,6 @@ end
 -- Handle /etc/config/aredn specially because only some changes require a restart/reboot
 local config_aredn = {
     lqm_enable = c:get("aredn", "@lqm[0]", "enable"),
-    tunnel_maxclients = c:get("aredn", "@tunnel[0]", "maxclients"),
-    tunnel_maxservers = c:get("aredn", "@tunnel[0]", "maxservers"),
     tunnel_weight = c:get("aredn", "@tunnel[0]", "weight"),
     supernode_enable = c:get("aredn", "@supernode[0]", "enable")
 }
@@ -1085,11 +1085,6 @@ do
             local oc = uci:cursor()
             if oc:get("aredn", "@lqm[0]", "enable") ~= config_aredn.lqm_enable then
                 changes.manager = true
-            end
-            if oc:get("aredn", "@tunnel[0]", "maxclients") ~= config_aredn.tunnel_maxclients or c:get("aredn", "@tunnel[0]", "maxservers") ~= config_aredn.tunnel_maxservers then
-                changes.network = true
-                changes.olsrd = true
-                changes.tunnels = true
             end
             if oc:get("aredn", "@tunnel[0]", "weight") ~= config_aredn.tunnel_weight then
                 changes.olsrd = true

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -544,14 +544,16 @@ do
     cfg.tun_devices_config = cfg.tun_devices_config ..
         string.format("config interface 'tun%d'\n\toption ifname 'tun%d'\n\toption proto 'none'\n\n", dev, dev)
 end
-local maxwgs = nixio.bit.lshift(1, 32 - tonumber(cm:get("wireguard", "@wireguard_server[0]", "masksize") or 26))
 -- Not wireguard devices without the wg app
 if not nixio.fs.stat("/usr/bin/wg") then
-    maxwgs = 0
-else
+    wgclients = 0
+    wgservers = 0
+end
+if wgclients + wgservers > 0 then
+    local maxwgservers = math.min(10 * math.ceil(wgservers / 10), nixio.bit.lshift(1, 32 - tonumber(cm:get("wireguard", "@wireguard_server[0]", "masksize") or 26)))
     cfg.tun_devices_config = cfg.tun_devices_config ..
         string.format("config interface 'wgc'\n\toption ifname 'wgc'\n\toption proto 'none'\n\n")
-    for dev = 0, maxwgs - 1
+    for dev = 0, maxwgservers - 1
     do
         cfg.tun_devices_config = cfg.tun_devices_config ..
             string.format("config interface 'wgs%d'\n\toption ifname 'wgs%d'\n\toption proto 'none'\n\n", dev, dev)

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -234,22 +234,6 @@ local settings = {
     },
     {
         category = "Tunnel Options",
-        key = "aredn.@tunnel[0].maxclients",
-        type = "string",
-        desc = "<b>Tunnel Maxclients</b> specifies the maximum number of tunnel clients this node can serve; must be an integer in the range [0,100].<br><br><small>aredn.@tunnel[0].maxclients</small>",
-        default = "10",
-        precallback = "restrictTunnelLimitToValidRange()"
-    },
-    {
-        category = "Tunnel Options",
-        key = "aredn.@tunnel[0].maxservers",
-        type = "string",
-        desc = "<b>Tunnel Maxservers</b> specifies the maximum number of tunnel servers to which this node can connect; must be an integer in the range [0,100].<br><br><small>aredn.@tunnel[0].maxservers</small>",
-        default = "10",
-        precallback = "restrictTunnelLimitToValidRange()"
-    },
-    {
-        category = "Tunnel Options",
         key = "aredn.@tunnel[0].weight",
         type = "string",
         desc = "<b>Tunnel Weight</b> specifies the cost of using a tunnel. The higher the number, the less likely a tunnel is used.<br><br><small>aredn.@tunnel[0].weight</small>",
@@ -622,20 +606,6 @@ function writePackageRepo(repo)
     local disturl = capture("grep aredn_" .. repo .. " /etc/opkg/distfeeds.conf | cut -d' ' -f3")
     if uciurl and disturl ~= "" then
         os.execute("sed -i 's|" .. disturl:chomp() .. "|" .. uciurl:chomp() .. "|g' /etc/opkg/distfeeds.conf")
-    end
-end
-
-function restrictTunnelLimitToValidRange()
-    newval = tonumber(newval)
-    if not newval then
-        msg(key .. " must be an interger in the range [0,100]")
-        newval = 0
-    elseif newval < 0 then
-        msg("Lower limit of " .. key .. " is 0")
-        newval = 0
-    elseif newval > 100 then
-        msg("Upper limit of " .. key .. " is 100")
-        newval = 100
     end
 end
 

--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -499,14 +499,6 @@ do
     cursor:set("wireguard", client_x, "clientip", parms[clientx .. "_clientip"])
 end
 
-local maxclients = tonumber(cursor:get("aredn", "@tunnel[0]", "maxclients"))
-if not maxclients then
-    maxclients = 10
-end
-if enabled_count > maxclients then
-    err("Number of clients enabled (" .. enabled_count .. ") exceeds maxclients value (" .. maxclients .. ")")
-end
-
 -- save configuration (commit)
 if parms.button_save and #cli_err == 0 then
     cursor:commit("vtun")

--- a/files/www/cgi-bin/vpnc
+++ b/files/www/cgi-bin/vpnc
@@ -347,13 +347,6 @@ do
         enabled_count = enabled_count + 1
     end
 end
-local maxservers = tonumber(cursor:get("aredn", "@tunnel[0]", "maxservers"))
-if not maxservers then
-    maxservers = 10
-end
-if enabled_count > maxservers then
-    err("Number of servers enabled (" .. enabled_count .. " exceeds maxservers (" .. maxservers .. "); only the first 10 will activate.")
-end
 
 -- save the connections the uci vtun file
 if parms.button_save and #conn_err == 0 then


### PR DESCRIPTION
Remove the need to set the maximum number of tunnels a node supports.
We now determine this dynamically for both old vtun tunnels as well as new wireguard tunnels.