### PR TITLE
Restore x86/64 nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,10 @@ jobs:
           command: make MAINTARGET=ipq40xx SUBTARGET=mikrotik
           no_output_timeout: 1h
       - run:
+          name: Build x64/64
+          command: make MAINTARGET=x86 SUBTARGET=64
+          no_output_timeout: 2h
+      - run:
           name: Build ramips/mt7621
           command: make MAINTARGET=ramips SUBTARGET=mt7621
           no_output_timeout: 2h


### PR DESCRIPTION
The arednmesh/builder Docker image has been fixed to support building x86.