### PR TITLE
Simply the watchdog by fixing various timeouts.

### DIFF
--- a/files/usr/local/bin/manager.lua
+++ b/files/usr/local/bin/manager.lua
@@ -54,12 +54,12 @@ function wait_for_ticks(ticks)
 	local when = nixio.sysinfo().uptime + ticks
 	while true
 	do
-		ticks = when - nixio.sysinfo().uptime
-		if ticks > 0 then
+		if ticks >= 0 then
 			coroutine.yield(ticks)
 		else
 			break
 		end
+		ticks = when - nixio.sysinfo().uptime
 	end
 end
 

--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -228,7 +228,7 @@ function lqm()
     end
 
     -- Let things startup for a while before we begin
-    wait_for_ticks(math.max(1, 30 - nixio.sysinfo().uptime))
+    wait_for_ticks(math.max(0, 30 - nixio.sysinfo().uptime))
 
     -- Create filters (cannot create during install as they disappear on reboot)
     os.execute(NFT .. " flush chain ip fw4 input_lqm 2> /dev/null")
@@ -599,6 +599,7 @@ function lqm()
                 local raw = io.popen("/usr/bin/curl --retry 0 --connect-timeout " .. connect_timeout .. " --speed-time " .. speed_time .. " --speed-limit " .. speed_limit .. " -s \"http://" .. track.ip .. ":8080/cgi-bin/sysinfo.json?link_info=1&lqm=1\" -o - 2> /dev/null")
                 local info = luci.jsonc.parse(raw:read("*a"))
                 raw:close()
+                wait_for_ticks(0)
                 if info then
                     rflinks[track.mac] = nil
                     if tonumber(info.lat) and tonumber(info.lon) then
@@ -716,6 +717,7 @@ function lqm()
                 end
                 ptime = socket.gettime(0) - pstart
                 sigsock:close()
+                wait_for_ticks(0)
 
                 local ping_loss_run_avg = 1 - config.ping_penalty / 100
                 if success > 0 then


### PR DESCRIPTION
Unfortunately there doesnt appear to be much flexibility in the various hardware watchdogs on radios, so setting the watchdog > 60 seconds mostly doesnt work. So rework the settings to allow for this and that our watchdog tests must be frequent and quick. It makes it less configurable and care needs to be taken when selecting ping targets (short timeouts)
