### PR TITLE
Add missing table entries in the Advanced Network tab

### DIFF
--- a/files/www/cgi-bin/advancednetwork
+++ b/files/www/cgi-bin/advancednetwork
@@ -51,6 +51,7 @@ local default_1_port_layout = { ports = { [1] = "eth0" } }
 local layouts = {
     ["mikrotik,hap-ac2"] = default_5_port_layout,
     ["mikrotik,hap-ac3"] = default_5_port_layout,
+    ["glinet,gl-b1300"] = default_3_port_layout,
     ["qemu-standard-pc-i440fx-piix-1996"] = default_1_port_layout,
     ["VMware, Inc. VMware Virtual Platform"] = default_1_port_layout
 }
@@ -100,6 +101,7 @@ local default_configs = {
     ["mikrotik,hap-ac3"] = default_5_port_config,
     ["glinet,gl-b1300"] = default_3_port_config,
     ["qemu-standard-pc-i440fx-piix-1996"] = nil,
+    ["VMware, Inc. VMware Virtual Platform"] = nil
 }
 
 function read_user_config(network)


### PR DESCRIPTION
The Advanced Network tab was blank for the GL-B1300 because of a missing entry in the layouts table.
Also, while not required, to maintain consistency between the tables, I also added the missing default_configs table entry for the VMware Virtual Platform.
- Add missing layouts table entry for the GL-B1300.
- Add missing default_configs table entry for VMware Virtual Platform


<!-- Thank you so much for contributing! -->

### Description
Describe the goals that the pull request accomplishes.

### Relevant Links
If there are related issues, please link them here.

Please also include links relevant to the changes.

### Screenshots
If applicable, please include screenshots before and after your changes.

### Additional context
Add any other context about the problem or changes here.
