### PR TITLE
Fix host checking

### DIFF
--- a/files/etc/cron.hourly/check-services
+++ b/files/etc/cron.hourly/check-services
@@ -39,7 +39,7 @@ require("aredn.services")
 
 local cursor = uci.cursor()
 
--- Current nameserver state
+-- Current nameservice state
 local ns = cursor:get_all("olsrd", "nameservice")
 if not ns then
     print("Missing nameservice")
@@ -104,15 +104,19 @@ local change = false
 
 -- Apply the changes
 if nnames or not_empty(cnames) then
-    cursor:set("olsrd", "nameserver", "name", names)
+    cursor:set("olsrd", "nameservice", "name", names)
     change = true
 end
 if nhosts or not_empty(chosts) then
-    cursor:set("olsrd", "nameserver", "hosts", hosts)
+    for i, host in ipairs(hosts)
+    do
+        hosts[i] = host.ip .. " " .. host.host
+    end
+    cursor:set("olsrd", "nameservice", "hosts", hosts)
     change = true
 end
 if nservices or not_empty(cservices) then
-    cursor:set("olsrd", "nameserver", "service", services)
+    cursor:set("olsrd", "nameservice", "service", services)
     change = true
 end
 

--- a/files/etc/cron.hourly/check-services
+++ b/files/etc/cron.hourly/check-services
@@ -51,13 +51,10 @@ do
     cnames[name] = true
 end
 local chosts = {}
-for _, v in ipairs(ns.hosts or {})                                                                                                                    
-do                                                                                                                                              
-    local ip, name = v:match("^(%d+%.%d+%.%d+%.%d+)%s+(%S+)$")                                                                                    
-    if ip then                                                                                                                                    
-        chosts[ip] = name                                                                                                                           
-    end                                                                                                                                           
-end                                                                                                                                             
+for _, iphost in ipairs(ns.hosts or {})
+do
+    chosts[iphost] = true
+end
 local cservices = {}
 for _, service in ipairs(ns.service or {})
 do
@@ -75,13 +72,14 @@ do
         nnames = true
     end
 end
-local nhosts = {}
+local nhosts = false
 for _, host in ipairs(hosts)
 do
-    if chosts[host.ip] then
-        chosts[host.ip] = nil
+    local iphost = host.ip .. " " .. host.host
+    if chosts[iphost] then
+        chosts[iphost] = nil
     else
-        nhosts[host.ip] = host.host
+        nhosts = true
     end
 end
 local nservices = false
@@ -109,15 +107,8 @@ if nnames or not_empty(cnames) then
     cursor:set("olsrd", "nameserver", "name", names)
     change = true
 end
-if not_empty(chosts) or not_empty(nhosts) then
-    for k, _ in pairs(chosts)
-    do
-        cursor:delete("olsrd", "nameserver", k)
-    end
-    for k, v in pairs(nhosts)
-    do
-        cursor:set("olsrd", "nameserver", k, v)
-    end
+if nhosts or not_empty(chosts) then
+    cursor:set("olsrd", "nameserver", "hosts", hosts)
     change = true
 end
 if nservices or not_empty(cservices) then
@@ -129,7 +120,7 @@ end
 if change then
     cursor:commit("olsrd")
     print("Change")
-    os.execute("/etc/init.d/olsrd restart > /dev/null 2>&1")
+    os.execute("/usr/local/bin/restart-services.sh --force olsrd")
 else
     print("Unchange")
 end

--- a/files/usr/local/bin/restart-services.sh
+++ b/files/usr/local/bin/restart-services.sh
@@ -36,15 +36,21 @@ LICENSE
 ROOT="/tmp/reboot-required"
 SERVICES="system firewall network wireless dnsmasq tunnels manager olsrd"
 
-# Anything to do?
-if [ ! -d $ROOT ]; then
-  exit 0
-fi
-
 ignore=0
+force=0
+if [ "$1" = "--force" ]; then
+  shift
+  ignore=1
+  force=1
+fi
 if [ "$1" = "--ignore-reboot" ]; then
   shift
   ignore=1
+fi
+
+# Anything to do?
+if [ ! -d $ROOT -a $force = 0 ]; then
+  exit 0
 fi
 
 # If we have to reboot, do nothing (unless ignored)
@@ -59,7 +65,7 @@ fi
 
 for srv in $SERVICES
 do
-  if [ -f $ROOT/$srv ]; then
+  if [ -f $ROOT/$srv -o $force = 1 ]; then
     echo "Restarting $srv"
     if [ $srv = "tunnels" ]; then
       /etc/init.d/vtund restart > /dev/null 2>&1
@@ -69,11 +75,11 @@ do
     elif [ -x /etc/init.d/$srv ]; then
       /etc/init.d/$srv restart > /dev/null 2>&1
     fi
-    rm $ROOT/$srv
+    rm -f $ROOT/$srv
   fi
 done
 
-rmdir --ignore-fail-on-non-empty $ROOT
+rmdir --ignore-fail-on-non-empty $ROOT 2> /dev/null
 if [ -d $ROOT ]; then
   exit 1
 fi


### PR DESCRIPTION
Fix the way we detect changes in reachable hostnames.
The old code was written when hostnames were managed differently in olsrd. This is now a lot simpler.
