### PR TITLE
Added antennas to Ubiquiti NanoBridge M5

### DIFF
--- a/files/etc/antennas.json
+++ b/files/etc/antennas.json
@@ -323,6 +323,18 @@
             "beamwidth": 30
         },
         {
+            "model": "NBM5-22",
+            "description": "airMAX NanoBridge M5, 22 dBi 8&deg; dish;",
+            "gain": 22,
+            "beamwidth": 8
+        },
+        {
+            "model": "NBM5-25",
+            "description": "airMAX NanoBridge M5, 25 dBi 8&deg; dish",
+            "gain": 25,
+            "beamwidth": 8
+        },        
+        {
             "model": "STH-30-USMA",
             "description": "RF Elements StarterHorn&trade; 30 USMA, 18 dBi 30&deg; Horn",
             "gain": 18,

--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -779,7 +779,8 @@
   "0xe235": {
     "name": "Ubiquiti NanoBridge M5",
     "maxpower": "22",
-    "pwroffset": "1"
+    "pwroffset": "1",
+    "antenna": "external"
   },
   "0xe239": {
     "name": "Ubiquiti NanoBridge M9",


### PR DESCRIPTION
<!-- Thank you so much for contributing! -->

### Description
Added antennas to Ubiquiti NanoBridge M5 to get gain and beamwidth info

### Relevant Links
[Datasheet](https://dl.ubnt.com/nb5_datasheet)
[Antenna Info](https://dl.ubnt.com/UBNT-AOS_prod-specs-rf_3.pdf)

### Screenshots
None

### Additional context
The NanoBridge M5 comes in 2 versions with different dishes, but both use the same radio and will show as the same hardware.
Added antennas to combat this issue.
