### PR TITLE
Added external antenna and (XM) destinction to boardID 0xe2b5

### DIFF
--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -813,9 +813,10 @@
     "pwroffset": "6"
   },
   "0xe2b5": {
-    "name": "Ubiquiti NanoBridge M5",
+    "name": "Ubiquiti NanoBridge M5 (XM)",
     "maxpower": "22",
-    "pwroffset": "1"
+    "pwroffset": "1",
+    "antenna": "external"
   },
   "0xe2c2": {
     "name": "Ubiquiti NanoBeam M2 International",


### PR DESCRIPTION
<!-- Thank you so much for contributing! -->

### Description
Added external antenna to boardID `0xe2b5`
Renamed board `Ubiquiti NanoBridge M5 (XM)` to reflect info from support file

### Relevant Links
None

### Screenshots
![image](https://github.com/aredn/aredn/assets/5229105/456204e4-2746-4fc9-9a24-e5ecda303658)


### Additional context
Overlooked this board ID in previous PR #1065 
