### PR TITLE
Sort node list in mesh display

### DIFF
--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -894,7 +894,7 @@ do
             end
             -- Build this row
             local row = "<tr class=s><td class='s f'>" .. c1 .. "</td><td class='s f'>" .. c2 .. "</td><td>" .. c3 .. "</td><td class='s f'>" .. c4 .. "</td></tr>"
-            rows[#rows + 1] = { key = host.etx, row = row }
+            rows[#rows + 1] = { key = string.format("%05d/%s", math.floor(100 * host.etx), host.name), row = row }
         end
     end
 end


### PR DESCRIPTION
Alphabetically sort node with the same ETX so the list doesnt jump around as much