### PR TITLE
Regenerate key when client name changes

### DIFF
--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -386,6 +386,12 @@ do
             break
         end
 
+        -- Generate a new key if we chance the client name
+        local cname = cursor:get("wireguard", "client_" .. wgclient_num, "name") or ""
+        local ckey = cursor:get("wireguard", "client_" .. wgclient_num, "key") or ""
+        if key == ckey and name ~= cname and name ~= "" then
+            key = ""
+        end
         if key == "" then
             local privS = capture("/usr/bin/wg genkey"):match("(%S+)")
             local pubS = capture("echo " .. privS .. " | /usr/bin/wg pubkey"):match("(%S+)")


### PR DESCRIPTION
If we change the name associated with a wireguard tunnel, we generate a new key.
We do this so that, when reusing a tunnel entry, we start with a fresh key otherwise they
old key, which is still out there, could be reused causing problems.