### PR TITLE
Add x86 to SUPPORTED_DEVICES.md

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -147,21 +147,21 @@ Model | SKUs | Band | Target | Subtarget | Image | RAM | Stability | Status
 :------ | :----: | :----: | :------: | :---------: | :-----: | :---: | :---------: | :------
 Meraki MR-16 | MR16-HW | 5 | ath79 | - | - | 64MB | unsupported | **brick**
 
-## x86-64 / Virtual Machine
+## x86 / Virtual Machine
 
-Hypervisor | Version | Virtual Type | Target | Subtarget | Image | RAM | Stability | Status
-:------ | :----: | :----: | :------: | :---------: | :-----: | :---: | :---------: | :------
-Vmware ESXi | 7.0 U3 | VMware | x86-64 | generic | x86-64-generic | 128mb+ | unsupported | nightly (5)
-Proxmox pve | 8.1 | QEMU | x86-64 | generic | x86-64-generic | 128mb+ | unsupported | nightly  (5)
-Unraid | 6.12.6 || x86-64 |  QEMU  | x86-64-generic | 128mb+ | unsupported | nightly (5)
-Virtual Box | 7.0.14 || x86-64 |  QEMU  | x86-64-generic | 128mb+ | untested | released (5)
+Hypervisor |  Target | Subtarget | Image | RAM | Stability | Status
+:------ | :------: | :---------: | :-----: | :---: | :---------: | :------
+Vmware ESXi  | x86 | 64 | x86-64-generic-ext4 | 64mb+ | stable | released (5)
+Proxmox pve  | x86 | 64 | x86-64-generic-ext4 | 64mb+ | stable | nightly  (5)
+Unraid | x86 |  64  | x86-64-generic-ext4 | 64mb+ | unsupported | nightly (5)
+
 
 ## Footnotes
  1. This device is supported for new installs. It can also be upgraded from 3.22.12.0 after first installing the [DangerousUpgrade package](https://github.com/kn6plv/DangerousUpgrade/raw/main/dangerousupgrade_0.1_all.ipk) to disable the firmware compatibility checks. Proceed carefully.
  2. Tiny builds exclude support for *tunnels* and *WiFi AP* mode due to lack of resources. The relevant packages can be installed separately but this is not recommended.
  3. These devices are no longer being manufactured by GL-iNET. They may not reboot reliably and you may need to power cycle them (several times) during an update.
  4. 20MHz channels only.
- 5. x86-64 images are for advanced users. All builds are unsupported. See "Installing AREDN Firmware" x86_64 documentation section.
+ 5. x86 images are for advanced users. See "Installing AREDN Firmware" x86 documentation section.
 
 
 Latest installation instructions are found at: https://docs.arednmesh.org/en/latest/

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -151,8 +151,8 @@ Meraki MR-16 | MR16-HW | 5 | ath79 | - | - | 64MB | unsupported | **brick**
 
 Hypervisor |  Target | Subtarget | Image | RAM | Stability | Status
 :------ | :------: | :---------: | :-----: | :---: | :---------: | :------
-Vmware ESXi  | x86 | 64 | x86-64-generic-ext4 | 64mb+ | stable | released (5)
-Proxmox pve  | x86 | 64 | x86-64-generic-ext4 | 64mb+ | stable | nightly  (5)
+Vmware ESXi  | x86 | 64 | x86-64-generic-ext4 | 64mb+ | stable | nightly (5)
+Proxmox pve  | x86 | 64 | x86-64-generic-ext4 | 64mb+ | stable | released  (5)
 Unraid | x86 |  64  | x86-64-generic-ext4 | 64mb+ | unsupported | nightly (5)
 
 

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -147,11 +147,21 @@ Model | SKUs | Band | Target | Subtarget | Image | RAM | Stability | Status
 :------ | :----: | :----: | :------: | :---------: | :-----: | :---: | :---------: | :------
 Meraki MR-16 | MR16-HW | 5 | ath79 | - | - | 64MB | unsupported | **brick**
 
+## x86-64 / Virtual Machine
+
+Hypervisor | Version | Virtual Type | Target | Subtarget | Image | RAM | Stability | Status
+:------ | :----: | :----: | :------: | :---------: | :-----: | :---: | :---------: | :------
+Vmware ESXi | 7.0 U3 | VMware | x86-64 | generic | x86-64-generic | 128mb+ | unsupported | nightly (5)
+Proxmox pve | 8.1 | QEMU | x86-64 | generic | x86-64-generic | 128mb+ | unsupported | nightly  (5)
+Unraid | 6.12.6 || x86-64 |  QEMU  | x86-64-generic | 128mb+ | unsupported | nightly (5)
+Virtual Box | 7.0.14 || x86-64 |  QEMU  | x86-64-generic | 128mb+ | untested | released (5)
+
 ## Footnotes
  1. This device is supported for new installs. It can also be upgraded from 3.22.12.0 after first installing the [DangerousUpgrade package](https://github.com/kn6plv/DangerousUpgrade/raw/main/dangerousupgrade_0.1_all.ipk) to disable the firmware compatibility checks. Proceed carefully.
  2. Tiny builds exclude support for *tunnels* and *WiFi AP* mode due to lack of resources. The relevant packages can be installed separately but this is not recommended.
  3. These devices are no longer being manufactured by GL-iNET. They may not reboot reliably and you may need to power cycle them (several times) during an update.
  4. 20MHz channels only.
+ 5. x86-64 images are for advanced users. All builds are unsupported. See "Installing AREDN Firmware" x86_64 documentation section.
 
 
 Latest installation instructions are found at: https://docs.arednmesh.org/en/latest/


### PR DESCRIPTION
add x86 to supported devices list as a unsupported device - mainly to add clarity on images / tested configs.


<!-- Thank you so much for contributing! -->

### Description
Adds clarity/documentation of x86 images and what it's been tested on.  Lists images as unsupported.

### Relevant Links
https://github.com/aredn/documentation/pull/336
#1089 


### Screenshots
n/a

### Additional context
As a part of a bug I found in #1089  I wanted to make it a bit easier for people to build VMs, as I had some issues. This also helps new supernode owners who are setting up VM for this in datacenters etc.
