### PR TITLE
Revert hAP AC Lite xlink support

### DIFF
--- a/files/usr/lib/lua/aredn/nav/admin/65advancednetwork.lua
+++ b/files/usr/lib/lua/aredn/nav/admin/65advancednetwork.lua
@@ -1,4 +1,4 @@
 local board = aredn.hardware.get_board_type()
-if board == "mikrotik,routerboard-952ui-5ac2nd" or board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" or board == "qemu" or board == "glinet,gl-b1300" or board == "vmware" then
+if board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" or board == "qemu" or board == "glinet,gl-b1300" or board == "vmware" then
     return { href = "advancednetwork", display = "Advanced Network" }
 end

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -542,7 +542,7 @@ end
 function supportsVLANChange()
     -- If we support advanced networking, we dont provide this option here
     local board = aredn.hardware.get_board_type()
-    if board == "mikrotik,routerboard-952ui-5ac2nd" or board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" then
+    if board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" then
         return false
     end
     local stat = nixio.fs.stat("/etc/aredn_include/swconfig")

--- a/files/www/cgi-bin/advancednetwork
+++ b/files/www/cgi-bin/advancednetwork
@@ -58,7 +58,6 @@ local function default_n_port_layout(board_type)
     return { ports = ports }
 end
 local layouts = {
-    ["mikrotik,routerboard-952ui-5ac2nd"] = default_5_port_layout,
     ["mikrotik,hap-ac2"] = default_5_port_layout,
     ["mikrotik,hap-ac3"] = default_5_port_layout,
     ["glinet,gl-b1300"] = default_3_port_layout,
@@ -127,7 +126,6 @@ local default_1_port_config = {
     }
 }
 local default_configs = {
-    ["mikrotik,routerboard-952ui-5ac2nd"] = default_5_port_config,
     ["mikrotik,hap-ac2"] = default_5_port_config,
     ["mikrotik,hap-ac3"] = default_5_port_config,
     ["glinet,gl-b1300"] = default_3_port_config,


### PR DESCRIPTION
I forgot we need DSA support to have xlinks, and the old hap doesnt have it.