### PR TITLE
Support CIDR (e.g. /24, /16, etc) on a xlink

### DIFF
--- a/files/usr/lib/lua/aredn/nav/admin/65advancednetwork.lua
+++ b/files/usr/lib/lua/aredn/nav/admin/65advancednetwork.lua
@@ -1,4 +1,4 @@
 local board = aredn.hardware.get_board_type()
-if board == "mikrotik,routerboard-952ui-5ac2nd" or board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" or board == "qemu" or board == "glinet,gl-b1300" or board == "vmware" then
+if board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" or board == "qemu" or board == "glinet,gl-b1300" or board == "vmware" then
     return { href = "advancednetwork", display = "Advanced Network" }
 end

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -981,6 +981,17 @@ if nixio.fs.access("/etc/config.mesh/olsrd", "r") then
         if is_supernode then
             of:write("config Hna4\n\toption netaddr 10.0.0.0\n\toption netmask 255.0.0.0\n\n")
         end
+
+        if nixio.fs.stat("/etc/config.mesh/xlink") then
+            uci.cursor("/etc/config.mesh"):foreach("xlink", "interface",
+                function(section)
+                    if section.netmask ~= "255.255.255.255" then
+                        local addr = decimal_to_ip(nixio.bit.band(ip_to_decimal(section.ipaddr), ip_to_decimal(section.netmask)))
+                        of:write(string.format("config Hna4\n\toption netaddr %s\n\toption netmask %s\n\n", addr, section.netmask))
+                    end
+                end
+            )
+        end
     
         if nc:get("aredn", "@wan[0]", "olsrd_gw") == "1" then
             of:write("config LoadPlugin\n\toption library 'olsrd_dyn_gw.so.0.5'\n\toption Interval '60'\n\tlist Ping '8.8.8.8'\n\tlist Ping '8.8.4.4'\n\n")

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -542,7 +542,7 @@ end
 function supportsVLANChange()
     -- If we support advanced networking, we dont provide this option here
     local board = aredn.hardware.get_board_type()
-    if board == "mikrotik,routerboard-952ui-5ac2nd" or board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" then
+    if board == "mikrotik,hap-ac2" or board == "mikrotik,hap-ac3" then
         return false
     end
     local stat = nixio.fs.stat("/etc/aredn_include/swconfig")

--- a/files/www/cgi-bin/advancednetwork
+++ b/files/www/cgi-bin/advancednetwork
@@ -191,6 +191,7 @@ function read_xlink_config()
                 peer = nil,
                 weight = 0,
                 port = nil,
+                netmask = nil,
                 mac = ""
             }
             configs[#configs + 1] = config
@@ -224,6 +225,10 @@ function read_xlink_config()
             m = line:match("option%s+weight%s+'([%d]+)'")
             if m then
                 config.weight = tonumber(m)
+            end
+            m = line:match("option%s+netmask%s+'([%d%.]+)'")
+            if m then
+                config.netmask = m
             end
         end
     end
@@ -320,8 +325,12 @@ function write_xlink_config(configs)
         f:write("\toption macaddr '" .. config.mac .. "'\n")
         f:write("\toption proto 'static'\n")
         f:write("\toption ipaddr '" .. config.ipaddr .. "'\n")
-        f:write("\toption netmask '255.255.255.255'\n")
         f:write("\toption weight '" .. config.weight .. "'\n")
+        if config.netmask and config.netmask ~= "" then
+            f:write("\toption netmask '" .. config.netmask .. "'\n")
+        else
+            f:write("\toption netmask '255.255.255.255'\n")
+        end
         if config.peer and config.peer ~= "" then
             f:write("\toption peer '" .. config.peer .. "'\n")
             f:write("\nconfig route\n")
@@ -512,13 +521,10 @@ html.print([[
             width: 100px;
             padding-left: 10px;
         }
-        .xlinks td:nth-child(1), .xlinks td:nth-child(4) {
+        .xlinks td:nth-child(1), .xlinks td:nth-child(4), .xlinks td:nth-child(5) {
             width: 40px;
         }
-        .xlinks td:nth-child(5) {
-            width: 55px;
-        }
-        .xlinks td:nth-child(6) {
+        .xlinks td:nth-child(6), .xlinks td:nth-child(7) {
             width: 20px;
         }
         .xlinks td input {
@@ -531,7 +537,7 @@ html.print([[
         .xlinks td:nth-child(1) input, .xlinks td:nth-child(4) input {
             text-align: right;
         }
-        .xlinks td:nth-child(6) button {
+        .xlinks td:nth-child(7) button {
             width: 24px;
             line-height: 14px;
             background-color: #f0f0f0;
@@ -596,6 +602,7 @@ html.print([[
             const row = document.createElement("tr");
             row.innerHTML = "<td><input type='text' value=''></td><td><input type='text' value=''></td><td><input type='text' value=''></td><td><input type='text' value='0'></td>]]
                 .. (function() local s = "<td" if #layout.ports <= 1 then s = s .. " style='display:none'" end s = s .. "><select>" for pos, port in ipairs(layout.ports) do s = s .. "<option value='" .. port .. "'>" .. pos .. "</option>" end return s .. "</select></td>" end)()
+                .. (function() local s = "<td><select><option value=''>-</option>" for v = 30, 16, -1 do s = s .. "<option value='" .. v .. "'>/" .. v .. "</option>" end return s .. "</select></td>" end)()
                 .. [[<td><input type='hidden' value=''><button onclick='xlink_remove(this)'>-</button></td>"
             tbody.appendChild(row)
             validate();
@@ -610,13 +617,32 @@ html.print([[
             const rows = document.querySelectorAll("table.xlinks tr");
             for (let i = 1; i < rows.length; i++) {
                 const cells = rows[i].querySelectorAll("td input");
+                const selects = rows[i].querySelectorAll("select");
                 xlinks.push({
                     name: "xlink" + (i - 1),
                     vlan: parseInt(cells[0].value),
                     ipaddr: cells[1].value,
                     peer: cells[2].value,
                     weight: parseInt(cells[3].value),
-                    port: rows[i].querySelector("select").value,
+                    port: selects[0].value,
+                    netmask: {
+                        "": "255.255.255.255",
+                        "30": "255.255.255.252",
+                        "29": "255.255.255.248",
+                        "28": "255.255.255.240",
+                        "27": "255.255.255.224",
+                        "26": "255.255.255.192",
+                        "25": "255.255.255.128",
+                        "24": "255.255.255.0",
+                        "23": "255.255.254.0",
+                        "22": "255.255.252.0",
+                        "21": "255.255.248.0",
+                        "20": "255.255.240.0",
+                        "19": "255.255.224.0",
+                        "18": "255.255.192.0",
+                        "17": "255.255.128.0",
+                        "16": "255.255.0.0"
+                    }[selects[1].value],
                     mac: cells[4].value
                 });
             }
@@ -744,8 +770,11 @@ end
 html.print([[<table class="xlinks" align="center"><caption>Xlinks</caption>]])
 html.print([[<tr class="h"><td>vlan</td><td>ip address</td><td>peer address</td><td>weight</td>]])
 if #layout.ports > 1 then
-    html.print([[<td>&nbsp;Port</td>]])
+    html.print([[<td>&nbsp;port</td>]])
+else
+    html.print([[<td style='display:none'>&nbsp;port</td>]])
 end
+html.print([[<td>cidr</td>]])
 html.print([[<td><button onclick="xlink_add()">+</button></td></tr>]])
 for _, xlink in ipairs(xlinks)
 do
@@ -756,6 +785,14 @@ do
     for pos, port in ipairs(layout.ports)
     do
         html.print("<option value='" .. port .. "'" .. (xlink.port == port and " selected" or "") .. ">" .. pos .. "</option>")
+    end
+    html.print("</select></td>")
+    html.print("<td><select>")
+    html.print("<option value=''>-</option>")
+    local cidr = netmask_to_cidr(xlink.netmask)
+    for v = 30, 16, -1
+    do
+        html.print("<option value='" .. v .. "'" .. (cidr == v and " selected" or "") .. ">/" .. v .. "</option>")
     end
     html.print("</select></td>")
     html.print("<td><input type='hidden' value='" .. xlink.mac .. "'><button onclick='xlink_remove(this)'>-</button></td>")

--- a/files/www/cgi-bin/advancednetwork
+++ b/files/www/cgi-bin/advancednetwork
@@ -58,7 +58,6 @@ local function default_n_port_layout(board_type)
     return { ports = ports }
 end
 local layouts = {
-    ["mikrotik,routerboard-952ui-5ac2nd"] = default_5_port_layout,
     ["mikrotik,hap-ac2"] = default_5_port_layout,
     ["mikrotik,hap-ac3"] = default_5_port_layout,
     ["glinet,gl-b1300"] = default_3_port_layout,
@@ -127,7 +126,6 @@ local default_1_port_config = {
     }
 }
 local default_configs = {
-    ["mikrotik,routerboard-952ui-5ac2nd"] = default_5_port_config,
     ["mikrotik,hap-ac2"] = default_5_port_config,
     ["mikrotik,hap-ac3"] = default_5_port_config,
     ["glinet,gl-b1300"] = default_3_port_config,


### PR DESCRIPTION
Xlink had originally been envisaged as a point-to-point connection
leaving the "how" of that to other hardware and software. However, there's a use case
where the non-AREDN radios in the xlink need to be accessed, and allocating
addresses within the xlink's address range is a good way to do that.
By supporting a subnet on a xlink we can enable this.