### PR TITLE
Use adaptive reload mechanism when node upgrades or reboots

### DIFF
--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -91,58 +91,6 @@ function get_default_gw()
     return "none"
 end
 
-function reboot()
-    local node = aredn.info.get_nvram("node")
-    if node == "" then
-        node = "Node"
-    end
-    local lanip, _, lanmask = aredn.hardware.get_interface_ip4(aredn.hardware.get_iface_name("lan"))
-    local browser = os.getenv("REMOTE_ADDR")
-    local browser6 = browser:match("::ffff:([%d%.]+)")
-    if browser6 then
-        browser = browser6
-    end
-    local fromlan = false
-    local subnet_change = false
-    if lanip then
-        fromlan = validate_same_subnet(browser, lanip, lanmask)
-        if fromlan then
-            lanmask = ip_to_decimal(lanmask)
-            local cfgip = cursor:get("network", "lan", "ipaddr")
-            local cfgmask = ip_to_decimal(cursor:get("network", "lan", "netmask"))
-            if lanmask ~= cfgmask or nixio.bit.band(ip_to_decimal(lanip), lanmask) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
-                subnet_change = true
-            end
-        end
-    end
-    http_header()
-    if fromlan and subnet_change then
-        html.header(node .. " rebooting", true)
-        html.print("<body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>The LAN subnet has changed. You will need to acquire a new DHCP lease<br>")
-        html.print("and reset any name service caches you may be using.</h3><br>")
-        html.print("<h3>When the node reboots you get your new DHCP lease and reconnect with<br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>or<br>")
-        html.print("<a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-    else
-        html.header(node .. " rebooting", false)
-        html.print("<meta http-equiv='refresh' content='60;url=/cgi-bin/status'>")
-        html.print("</head><body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>Your browser should return to this node in 60 seconds.</br><br>")
-        html.print("If something goes astray you can try to connect with<br><br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>")
-        if node ~= "Node" then
-            html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-        end
-    end
-    html.print("</center></body></html>")
-    http_footer()
-    os.execute("reboot >/dev/null 2>&1")
-    os.exit()
-end
-
 function word_wrap(len, lines)
     local output = ""
     for _, str in ipairs(lines)
@@ -206,7 +154,7 @@ if os.getenv("REQUEST_METHOD") == "POST" then
 end
 
 if parms.button_reboot then
-    reboot()
+    html.reboot()
 end
 local node = aredn.info.get_nvram("node")
 local tmpdir = "/tmp/web/admin"
@@ -502,7 +450,7 @@ if fw_install and nixio.fs.stat(tmpdir .. "/firmware") then
     html.print("<style>")
     html.print(read_all("/tmp/web/style.css"))
     html.print("</style>")
-    html.print("<meta http-equiv='refresh' content='300;URL=http://" .. node .. ".local.mesh:8080'>")
+    html.wait_for_reboot(120)
     html.print("</head>")
     html.print("<body><center>")
     html.print("<h2>The firmware is being updated.</h2>")
@@ -543,7 +491,7 @@ if fw_install and nixio.fs.stat(tmpdir .. "/firmware") then
                         When the node has finished booting you should ensure your computer has<br>
                         received a new IP address and reconnect with<br>
                         <a href='http://]] .. node .. [[.local.mesh:8080/'>http://]] .. node .. [[.local.mesh:8080/</a><br>
-                        (This page will automatically reload in 5 minutes)</h3>
+                        This page will automatically reload once the upgrade has completed</h3>
                         </center></body></html>
                     ]])
                     http_footer()
@@ -577,7 +525,7 @@ if fw_install and nixio.fs.stat(tmpdir .. "/firmware") then
             received a new IP address and reconnect with<br>
             <a href='http://localnode.local.mesh:8080/'>http://192.168.1.1:8080/</a><br>
             and continue setup of the node in firstboot state.<br>
-            (This page will automatically reload in 5 minutes)</h3>
+            This page will automatically reload once the upgrade has completed</h3>
             </center></body></html>
         ]])
         http_footer()

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -476,59 +476,6 @@ function cursor_get(a, b, c)
     return cursor:get(a, b, c)
 end
 
-function reboot()
-    local c = uci.cursor()
-    local node = aredn.info.get_nvram("node")
-    if node == "" then
-        node = "Node"
-    end
-    local lanip, _, lanmask = aredn.hardware.get_interface_ip4(aredn.hardware.get_iface_name("lan"))
-    local browser = os.getenv("REMOTE_ADDR")
-    local browser6 = browser:match("::ffff:([%d%.]+)")
-    if browser6 then
-        browser = browser6
-    end
-    local fromlan = false
-    local subnet_change = false
-    if lanip then
-        fromlan = validate_same_subnet(browser, lanip, lanmask)
-        if fromlan then
-            lanmask = ip_to_decimal(lanmask)
-            local cfgip = c:get("network", "lan", "ipaddr")
-            local cfgmask = ip_to_decimal(c:get("network", "lan", "netmask"))
-            if lanmask ~= cfgmask or nixio.bit.band(ip_to_decimal(lanip), lanmask) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
-                subnet_change = true
-            end
-        end
-    end
-    http_header()
-    if fromlan and subnet_change then
-        html.header(node .. " rebooting", true)
-        html.print("<body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>The LAN subnet has changed. You will need to acquire a new DHCP lease<br>")
-        html.print("and reset any name service caches you may be using.</h3><br>")
-        html.print("<h3>When the node reboots you get your new DHCP lease and reconnect with<br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>or<br>")
-        html.print("<a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-    else
-        html.header(node .. " rebooting", false)
-        html.print("<meta http-equiv='refresh' content='60;url=/cgi-bin/status'>")
-        html.print("</head><body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>Your browser should return to this node in 60 seconds.</br><br>")
-        html.print("If something goes astray you can try to connect with<br><br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>")
-        if node ~= "Node" then
-            html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-        end
-    end
-    html.print("</center></body></html>")
-    http_footer()
-    os.execute("reboot >/dev/null 2>&1")
-    os.exit()
-end
-
 -- conditionals
 
 function hasPOE()
@@ -704,7 +651,7 @@ if parms.button_firstboot then
     os.execute("firstboot -y")
 end
 if parms.button_firstboot or parms.button_reboot then
-    reboot()
+    html.reboot()
 end
 local node = aredn.info.get_nvram("node")
 

--- a/files/www/cgi-bin/advancednetwork
+++ b/files/www/cgi-bin/advancednetwork
@@ -341,28 +341,6 @@ function write_xlink_config(configs)
     f:close()
 end
 
-function reboot()
-    local node = aredn_info.get_nvram("node")
-    if node == "" then
-        node = "Node"
-    end
-    http_header()
-    html.header(node .. " rebooting", false)
-    html.print("<meta http-equiv='refresh' content='60;url=/cgi-bin/status'>")
-    html.print("</head><body><center>")
-    html.print("<h1>" .. node .. " is rebooting</h1><br>")
-    html.print("<h3>Your browser should return to this node in 60 seconds.</br><br>")
-    html.print("If something goes astray you can try to connect with<br><br>")
-    html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>")
-    if node ~= "Node" then
-        html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-    end
-    html.print("</center></body></html>")
-    http_footer()
-    os.execute("reboot >/dev/null 2>&1")
-    os.exit()
-end
-
 local get_board_type = aredn.hardware.get_board_type()
 
 local layout = layouts[get_board_type]
@@ -414,7 +392,7 @@ if os.getenv("REQUEST_METHOD") == "POST" then
         write_xlink_config({})
         pending_restart = true
     elseif params.op == "reboot" then
-        reboot()
+        html.reboot()
     end
 end
 

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -69,58 +69,6 @@ function capture_and_match(cmd, pattern)
     end
 end
 
-function reboot()
-    local node = aredn_info.get_nvram("node")
-    if node == "" then
-        node = "Node"
-    end
-    local lanip, _, lanmask = aredn.hardware.get_interface_ip4(aredn.hardware.get_iface_name("lan"))
-    local browser = os.getenv("REMOTE_ADDR")
-    local browser6 = browser:match("::ffff:([%d%.]+)")
-    if browser6 then
-        browser = browser6
-    end
-    local fromlan = false
-    local subnet_change = false
-    if lanip then
-        fromlan = validate_same_subnet(browser, lanip, lanmask)
-        if fromlan then
-            lanmask = ip_to_decimal(lanmask)
-            local cfgip = cursor:get("network", "lan", "ipaddr")
-            local cfgmask = ip_to_decimal(cursor:get("network", "lan", "netmask"))
-            if lanmask ~= cfgmask or nixio.bit.band(ip_to_decimal(lanip), lanmask) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
-                subnet_change = true
-            end
-        end
-    end
-    http_header()
-    if fromlan and subnet_change then
-        html.header(node .. " rebooting", true);
-        html.print("<body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>The LAN subnet has changed. You will need to acquire a new DHCP lease<br>")
-        html.print("and reset any name service caches you may be using.</h3><br>")
-        html.print("<h3>When the node reboots you get your new DHCP lease and reconnect with<br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>or<br>")
-        html.print("<a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-    else
-        html.header(node .. " rebooting", false)
-        html.print("<meta http-equiv='refresh' content='60;url=/cgi-bin/status'>")
-        html.print("</head><body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>Your browser should return to this node in 60 seconds.</br><br>")
-        html.print("If something goes astray you can try to connect with<br><br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>")
-        if node ~= "Node" then
-            html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-        end
-    end
-    html.print("</center></body></html>")
-    http_footer()
-    os.execute("reboot >/dev/null 2>&1")
-    os.exit()
-end
-
 function err(str)
     errors[#errors + 1] = str
 end
@@ -835,14 +783,14 @@ if parms.button_save then
             end 
         end
         if nixio.fs.stat("/tmp/unconfigured") and #errors == 0 then
-            reboot()
+            html.reboot()
         end
     end
 end
 
 remove_all("/tmp/web/save")
 if parms.button_reboot then
-    reboot()
+    html.reboot()
 end
 
 local desc = cursor:get("system", "@system[0]", "description")

--- a/files/www/cgi-bin/vpn
+++ b/files/www/cgi-bin/vpn
@@ -210,55 +210,7 @@ function get_wgclient_info()
 end
 
 if parms.button_reboot then
-    local node = aredn.info.get_nvram("node")
-    if node == "" then
-        node = "Node"
-    end
-    local lanip, _, lanmask = aredn.hardware.get_interface_ip4(aredn.hardware.get_iface_name("lan"))
-    local browser = os.getenv("REMOTE_ADDR")
-    local browser6 = browser:match("::ffff:([%d%.]+)")
-    if browser6 then
-        browser = browser6
-    end
-    local fromlan = false
-    local subnet_change = false
-    if lanip then
-        fromlan = validate_same_subnet(browser, lanip, lanmask)
-        if fromlan then
-            lanmask = ip_to_decimal(lanmask)
-            local cfgip = cursor:get("network", "lan", "ipaddr")
-            local cfgmask = ip_to_decimal(cursor:get("network", "lan", "netmask"))
-            if lanmask ~= cfgmask or nixio.bit.band(ip_to_decimal(lanip), lanmask) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
-                subnet_change = true
-            end
-        end
-    end
-    http_header()
-    if fromlan and subnet_change then
-        html.header(node .. " rebooting", true);
-        html.print("<body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>The LAN subnet has changed. You will need to acquire a new DHCP lease<br>")
-        html.print("and reset any name service caches you may be using.</h3><br>")
-        html.print("<h3>When the node reboots you get your new DHCP lease and reconnect with<br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>or<br>")
-        html.print("<a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-    else
-        html.header(node .. " rebooting", false)
-        html.print("<meta http-equiv='refresh' content='60;url=/cgi-bin/status'>")
-        html.print("</head><body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>Your browser should return to this node in 60 seconds.</br><br>")
-        html.print("If something goes astray you can try to connect with<br><br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>")
-        if node ~= "Node" then
-            html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-        end
-    end
-    html.print("</center></body></html>")
-    http_footer()
-    os.execute("reboot >/dev/null 2>&1")
-    os.exit()
+    aredn.html.reboot()
 end
 
 if nixio.fs.stat("/tmp/reboot-required") then

--- a/files/www/cgi-bin/vpnc
+++ b/files/www/cgi-bin/vpnc
@@ -166,55 +166,7 @@ function get_connection_info()
 end
 
 if parms.button_reboot then
-    local node = aredn.info.get_nvram("node")
-    if node == "" then
-        node = "Node"
-    end
-    local lanip, _, lanmask = aredn.hardware.get_interface_ip4(aredn.hardware.get_iface_name("lan"))
-    local browser = os.getenv("REMOTE_ADDR")
-    local browser6 = browser:match("::ffff:([%d%.]+)")
-    if browser6 then
-        browser = browser6
-    end
-    local fromlan = false
-    local subnet_change = false
-    if lanip then
-        fromlan = validate_same_subnet(browser, lanip, lanmask)
-        if fromlan then
-            lanmask = ip_to_decimal(lanmask)
-            local cfgip = cursor:get("network", "lan", "ipaddr")
-            local cfgmask = ip_to_decimal(cursor:get("network", "lan", "netmask"))
-            if lanmask ~= cfgmask or nixio.bit.band(ip_to_decimal(lanip), lanmask) ~= nixio.bit.band(ip_to_decimal(cfgip), cfgmask) then
-                subnet_change = true
-            end
-        end
-    end
-    http_header()
-    if fromlan and subnet_change then
-        html.header(node .. " rebooting", true);
-        html.print("<body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>The LAN subnet has changed. You will need to acquire a new DHCP lease<br>")
-        html.print("and reset any name service caches you may be using.</h3><br>")
-        html.print("<h3>When the node reboots you get your new DHCP lease and reconnect with<br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>or<br>")
-        html.print("<a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-    else
-        html.header(node .. " rebooting", false)
-        html.print("<meta http-equiv='refresh' content='60;url=/cgi-bin/status'>")
-        html.print("</head><body><center>")
-        html.print("<h1>" .. node .. " is rebooting</h1><br>")
-        html.print("<h3>Your browser should return to this node in 60 seconds.</br><br>")
-        html.print("If something goes astray you can try to connect with<br><br>")
-        html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>")
-        if node ~= "Node" then
-            html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-        end
-    end
-    html.print("</center></body></html>")
-    http_footer()
-    os.execute("reboot >/dev/null 2>&1")
-    os.exit()
+    aredn.html.reboot()
 end
 
 if config == "" or nixio.fs.stat("/tmp/reboot-required") then


### PR DESCRIPTION
Rather than using a reload meta tag with a fixed timeout, use a bit of javascript to check for when a node has rebooted successfully, and then reload the page. This should help things be more timely and result in less reload failures.