### PR TITLE
Set pkt retry to 2 (was 1) for hub nodes.

### DIFF
--- a/files/usr/local/bin/mgr/lqm.lua
+++ b/files/usr/local/bin/mgr/lqm.lua
@@ -50,9 +50,10 @@ local dtd_distance = 50 -- distance (meters) after which nodes connected with Dt
 local connect_timeout = 5 -- timeout (seconds) when fetching information from other nodes
 local speed_time = 10 --
 local speed_limit = 1000 -- close connection if it's too slow (< 1kB/s for 10 seconds)
-local default_retries_scale = 2
-local default_short_retries = 6
-local default_long_retries = 4
+local default_short_retries = 6 -- Default retries for a node with a single connection
+local default_long_retries = 4 --
+local minimum_short_retries = 2 -- Minimum retries for nodes with multiple connections
+local minimum_long_retries = 2 --
 
 local NFT = "/usr/sbin/nft"
 local IW = "/usr/sbin/iw"
@@ -966,13 +967,13 @@ function lqm()
         hidden_nodes = hidden
 
         -- Adjust retry attempts. If we're just managing a single connection, we can retry failed transmissions.
-        -- If we're managing many, we can't afford the delays associated with retries, to reduce them to the minimum.
+        -- If we're managing many, we can't afford the delays associated with retries, so reduce them to the minimum.
         -- Don't retry when distance is max because the delay makes thing unusable and blocks other closer traffic.
         local short_retries
         local long_retries
         if distance == config.max_distance or rfcount > 1 then
-            short_retries = 1
-            long_retries = 1
+            short_retries = minimum_short_retries
+            long_retries = minimum_long_retries
         else
             short_retries = default_short_retries
             long_retries = default_long_retries


### PR DESCRIPTION
Too many retries appears to cause network congestion issues slowing down links with multiple hops, but reducing this to 1 then caused single links to have poor performance. Try a retry of 2 as a better compromise.
