### PR TITLE
Fix DTD and WLAN ips derived from matching MACs.

### DIFF
--- a/files/usr/local/bin/nvram-setup
+++ b/files/usr/local/bin/nvram-setup
@@ -119,5 +119,13 @@ end
 
 if dtdmac == "" then
     local a, b, c = aredn.hardware.get_interface_mac(aredn.hardware.get_iface_name("lan")):match("%w%w:%w%w:%w%w:(%w%w):(%w%w):(%w%w)")
-    aredn_info.set_nvram("dtdmac", string.format("%d.%d.%d", tonumber(a, 16), tonumber(b, 16), tonumber(c, 16)))
+    dtdmac = string.format("%d.%d.%d", tonumber(a, 16), tonumber(b, 16), tonumber(c, 16))
+    if dtdmac == mac2 then
+        a = tonumber(a, 16) + 1
+        if a > 255 then
+            a = 0
+        end
+        dtdmac = string.format("%d.%d.%d", a, tonumber(b, 16), tonumber(c, 16))
+    end
+    aredn_info.set_nvram("dtdmac", dtdmac)
 end


### PR DESCRIPTION
On some devices the hardware MAC for the WLAN and ETH are the
same so the 10.DTD and 10.WLAN addresses are identical.
If we detect this, bump the DTD address.
Commonly seen on TP-Link devices (but there are others)
