### PR TITLE
Half the OLSR maintenance traffic

### DIFF
--- a/files/etc/config.mesh/olsrd
+++ b/files/etc/config.mesh/olsrd
@@ -1,7 +1,4 @@
 config olsrd
-	# uncomment the following line to use a custom config file instead:
-	#option config_file '/etc/olsrd.conf'
-
 	option IpVersion '4'
 	option MainIp '<wifi_ip>'
 	option RtTable '30'
@@ -21,10 +18,6 @@ config LoadPlugin
 	option library 'olsrd_jsoninfo.so.1.1'
 	option accept '0.0.0.0'
 
-#config LoadPlugin 
-#	option library 'olsrd_secure.so.0.6'
-#	option keyfile '/etc/olsrd.d/olsrd_secure_key'
-
 config LoadPlugin
 	option library 'olsrd_dot_draw.so.0.3'
 	option accept '0.0.0.0'
@@ -37,7 +30,15 @@ config LoadPlugin
 
 config Interface
 	list interface 'wifi'
+	option HelloInterval '<hello_interval>'
+	option TcInterval '<tc_interval>'
+	option MidInterval '<mid_interval>'
+	option HnaInterval '<hna_interval>'
 
 config Interface 
-        list interface 'dtdlink'
-        option Mode '<olsrd_dtd_interface_mode>'
+	list interface 'dtdlink'
+	option Mode '<olsrd_dtd_interface_mode>'
+	option HelloInterval '<hello_interval>'
+	option TcInterval '<tc_interval>'
+	option MidInterval '<mid_interval>'
+	option HnaInterval '<hna_interval>'

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -94,7 +94,11 @@ local cfg = {
     tun_network_config = "",
     wireguard_network_config = "",
     olsrd_pollrate = "0.05",
-    tun_devices_config = ""
+    tun_devices_config = "",
+    hello_interval = "4.0",
+    tc_interval = "10.0",
+    mid_interval = "10.0",
+    hna_interval = "10.0"
 }
 -- Track the changes so we can make better decissions about what to restart/reboot
 local changes = {
@@ -1048,6 +1052,10 @@ if nixio.fs.access("/etc/config.mesh/olsrd", "r") then
             elseif tun_weight > 1 then
                 of:write("\toption LinkQualityMult 'default " .. (1 / tun_weight) .. "'\n")
             end
+            of:write("\toption HelloInterval '" .. cfg.hello_interval .. "'\n")
+            of:write("\toption TcInterval '" .. cfg.tc_interval .. "'\n")
+            of:write("\toption MidInterval '" .. cfg.mid_interval .. "'\n")
+            of:write("\toption HnaInterval '" .. cfg.hna_interval .. "'\n")
         end
         nc:set("aredn", "@tunnel[0]", "maxclients", maxclients)
         nc:set("aredn", "@tunnel[0]", "maxservers", maxservers)
@@ -1073,6 +1081,10 @@ if nixio.fs.access("/etc/config.mesh/olsrd", "r") then
                     else
                         of:write("\toption Mode 'ether'\n")
                     end
+                    of:write("\toption HelloInterval '" .. cfg.hello_interval .. "'\n")
+                    of:write("\toption TcInterval '" .. cfg.tc_interval .. "'\n")
+                    of:write("\toption MidInterval '" .. cfg.mid_interval .. "'\n")
+                    of:write("\toption HnaInterval '" .. cfg.hna_interval .. "'\n")
                 end
             )
         end


### PR DESCRIPTION
Double various OLSR traffic intervals to half the maintenance traffic.
Our network isn't very mobile, so reducing this traffic should not result in a less stable mesh.
Might be able to do more here, but starting with this reduction.
Timeouts remain unchanged.