### PR TITLE
Stop messing with the iperf3 package version number

### DIFF
--- a/patches/709-iperf-fw-restart.patch
+++ b/patches/709-iperf-fw-restart.patch
@@ -2,15 +2,6 @@ Index: openwrt/feeds/packages/net/iperf3/Makefile
 ===================================================================
 --- openwrt.orig/feeds/packages/net/iperf3/Makefile
 +++ openwrt/feeds/packages/net/iperf3/Makefile
-@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
- 
- PKG_NAME:=iperf
- PKG_VERSION:=3.16
--PKG_RELEASE:=1
-+PKG_RELEASE:=1AREDN
- 
- PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
- PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
 @@ -72,6 +72,18 @@ endef
  define Package/iperf3/install
  	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
This patch had to be fixed on every openwrt upgrade just because the version number would change. We dont
do this with other packages so stop doing it here.