### PR TITLE
Show progress bar during reboot/reflash and show estimated time remaining in MM:SS.

### DIFF
--- a/files/usr/lib/lua/aredn/html.lua
+++ b/files/usr/lib/lua/aredn/html.lua
@@ -194,7 +194,7 @@ function html.wait_for_reboot(delay, countdown, address)
         const div = document.getElementById("countdown");
         if (div) {
             let t = Math.round(]] .. countdown .. [[ - (Date.now() - start) / 1000);
-	    div.innerHTML = t <= 0 ? "" : new Date(1000 * t).toISOString().substring(14, 19);
+            div.innerHTML = t <= 0 ? "" : new Date(1000 * t).toISOString().substring(14, 19);
             const cdp = document.getElementById("cdProgress");
             if (cdp) {
                 cdp.value = cdp.max - t;

--- a/files/usr/lib/lua/aredn/html.lua
+++ b/files/usr/lib/lua/aredn/html.lua
@@ -194,10 +194,13 @@ function html.wait_for_reboot(delay, countdown, address)
         const div = document.getElementById("countdown");
         if (div) {
             let t = Math.round(]] .. countdown .. [[ - (Date.now() - start) / 1000);
-            div.innerHTML = t <= 0 ? "" : new Date(1000 * t).toISOString().substring(14, 19);
-            const cdp = document.getElementById("cdProgress");
+            div.innerHTML = t <= 0 ? "..." : new Date(1000 * t).toISOString().substring(14, 19);
+            const cdp = document.getElementById("cdprogress");
             if (cdp) {
-                cdp.value = cdp.max - t;
+                if (t < 0)
+                    cdp.removeAttribute("value");
+                else
+                    cdp.setAttribute("value", cdp.getAttribute("max") - t);
             }
         }
     }
@@ -265,8 +268,8 @@ function html.reboot()
             html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
         end
     end
-    html.print("<br><h3><label for='cdProgress'>Rebooting: </label><progress id='cdProgress' max='120'/></h3>")
-    html.print("<h1>Time Remaining: <span id='countdown'></h1>")
+    html.print("<br><h3><label for='cdprogress'>Rebooting: </label><progress id='cdprogress' max='120'/></h3>")
+    html.print("<h1>Time Remaining: <span id='countdown'/></h1>")
     html.print("</center></body></html>")
     http_footer()
     os.execute("reboot >/dev/null 2>&1")

--- a/files/usr/lib/lua/aredn/html.lua
+++ b/files/usr/lib/lua/aredn/html.lua
@@ -194,14 +194,10 @@ function html.wait_for_reboot(delay, countdown, address)
         const div = document.getElementById("countdown");
         if (div) {
             let t = Math.round(]] .. countdown .. [[ - (Date.now() - start) / 1000);
-            if (t <= 0) {
-                div.innerHTML = ""
-            }
-            else if (t == 1) {
-                div.innerHTML = t + " second";
-            }
-            else {
-                div.innerHTML = t + " seconds";
+	    div.innerHTML = t <= 0 ? "" : new Date(1000 * t).toISOString().substring(14, 19);
+            const cdp = document.getElementById("cdProgress");
+            if (cdp) {
+                cdp.value = cdp.max - t;
             }
         }
     }
@@ -257,7 +253,6 @@ function html.reboot()
         html.print("<h3>When the node reboots you get your new DHCP lease and reconnect with<br>")
         html.print("<a href='http://localnode.local.mesh:8080/'>http://localnode.local.mesh:8080/</a><br>or<br>")
         html.print("<a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
-        html.print("<br><h1 id='countdown'></h1>")
     else
         html.header(node .. " rebooting", false)
         html.wait_for_reboot(20, 120)
@@ -269,8 +264,9 @@ function html.reboot()
         if node ~= "Node" then
             html.print("or<br><a href='http://" .. node .. ".local.mesh:8080/'>http://" .. node .. ".local.mesh:8080/</a></h3>")
         end
-        html.print("<br><h1 id='countdown'></h1>")
     end
+    html.print("<br><h3><label for='cdProgress'>Rebooting: </label><progress id='cdProgress' max='120'/></h3>")
+    html.print("<h1>Time Remaining: <span id='countdown'></h1>")
     html.print("</center></body></html>")
     http_footer()
     os.execute("reboot >/dev/null 2>&1")

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -113,6 +113,22 @@ function word_wrap(len, lines)
     return output:sub(1, #output - 1)
 end
 
+function print_firmware_notice(reboot_when, href_addr, text_addr)
+    html.print([[
+	<center><h2>Firmware will be written in the background.</h2>
+	<h3>If your computer is connected to the LAN of this node you may need to acquire<br>
+	a new IP address and reset any name service caches you may be using.</h3>
+	<h3>The node will reboot ]] .. reboot_when .. [[.<br>
+	When the node has finished booting you should ensure your computer has<br>
+	received a new IP address and reconnect with<br>
+	<a href='http://]] .. href_addr .. [[:8080/'>http://]] .. text_addr .. [[:8080/</a><br>
+	This page will automatically reload once the upgrade has completed</h3>
+	<br><h3><label for='cdProgress'>Writing firmware: </label><progress id='cdProgress' max='300'/></h3>
+	<h1>Time Remaining: <span id='countdown'></h1>
+	</center></body></html>
+    ]])
+end
+
 -- read_postdata
 local parms = {}
 local firmfile = ""
@@ -496,18 +512,7 @@ if fw_install and nixio.fs.stat(tmpdir .. "/firmware") then
                     aredn.info.set_nvram("nodeupgraded", "0")
                     os.execute("reboot >/dev/null 2>&1")
                 else
-                    html.print([[
-                        <center><h2>Firmware will be written in the background.</h2>
-                        <h3>If your computer is connected to the LAN of this node you may need to acquire<br>
-                        a new IP address and reset any name service caches you may be using.</h3>
-                        <h3>The node will reboot twice while the configuration is applied<br>
-                        When the node has finished booting you should ensure your computer has<br>
-                        received a new IP address and reconnect with<br>
-                        <a href='http://]] .. displayaddress .. [[:8080/'>http://]] .. displayaddress .. [[:8080/</a><br>
-                        This page will automatically reload once the upgrade has completed</h3>
-                        <br><h1 id='countdown'></h1>
-                        </center></body></html>
-                    ]])
+                    print_firmware_notice("twice while the configuration is applied", displayaddress, displayaddress)
                     http_footer()
                     nixio.fs.remove("/tmp/sysupgradefilelist")
                     upgradecmd = "/usr/local/bin/aredn_sysupgrade -f /tmp/arednsysupgradebackup.tgz -q " .. tmpdir .. "/firmware 2>&1 &"
@@ -530,19 +535,7 @@ if fw_install and nixio.fs.stat(tmpdir .. "/firmware") then
             os.execute("reboot >/dev/null 2>&1")
         end
     else
-        html.print([[
-            <center><h2>Firmware will be written in the background.</h2>
-            <h3>If your computer is connected to the LAN of this node you may need to acquire<br>
-            a new IP address and reset any name service caches you may be using.</h3>
-            <h3>The node will reboot after the firmware has been written to flash memory<br>
-            When the node has finished booting you should ensure your computer has<br>
-            received a new IP address and reconnect with<br>
-            <a href='http://localnode.local.mesh:8080/'>http://192.168.1.1:8080/</a><br>
-            and continue setup of the node in firstboot state.<br>
-            This page will automatically reload once the upgrade has completed</h3>
-            <br><h1 id='countdown'></h1>
-            </center></body></html>
-        ]])
+        print_firmware_notice("after the firmware has been written to flash memory", "localnode.local.mesh", "192.168.1.1")
         http_footer()
         upgradecmd = "/usr/local/bin/aredn_sysupgrade -q -n " .. tmpdir .. "/firmware 2>&1 &"
     end

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -123,7 +123,7 @@ function print_firmware_notice(reboot_when, href_addr, text_addr)
 	received a new IP address and reconnect with<br>
 	<a href='http://]] .. href_addr .. [[:8080/'>http://]] .. text_addr .. [[:8080/</a><br>
 	This page will automatically reload once the upgrade has completed</h3>
-	<br><h3><label for='cdProgress'>Writing firmware: </label><progress id='cdProgress' max='300'/></h3>
+	<br><h3><label for='cdprogress'>Writing firmware: </label><progress id='cdprogress' max='300'/></h3>
 	<h1>Time Remaining: <span id='countdown'></h1>
 	</center></body></html>
     ]])


### PR DESCRIPTION
<!-- Thank you so much for contributing! -->

### Description
When rebooting or reflashing the node, display a progress bar as
well as the estimated time remaining. Also, show the time remaining
in MM:SS format.