### PR TITLE
Make sure dmz_dhcp_end has a value, even in NAT mode

### DIFF
--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -286,6 +286,9 @@ if dmz_mode ~= 0 then
     parms.dmz_lan_mask = dmz_lan_mask
     parms.dmz_dhcp_start = dmz_dhcp_start
     parms.dmz_dhcp_end = dmz_dhcp_end
+else
+    dmz_dhcp_end = dmz_dhcp_start
+    parms.dmz_dhcp_end = dmz_dhcp_end
 end
 
 parms.dhcp_limit = dhcp_end - dhcp_start + 1


### PR DESCRIPTION
Make sure dmz_dhcp_end has a value, even in NAT mode. The value is lost (set to "") in the config because in NAT mode it's not important. However later code still does math with it, so give it a sensible value here to avoid problems later.