### PR TITLE
DHCP was not always starting on the lan interface like we need it to.

### DIFF
--- a/files/etc/config.mesh/dhcp
+++ b/files/etc/config.mesh/dhcp
@@ -7,7 +7,8 @@ config dhcp
 	option start 		<dhcp_start>
 	option limit		<dhcp_limit>
 	option leasetime	1h
-    option ignore		<lan_dhcp>
+	option force		1
+	option ignore		<lan_dhcp>
 
 config dhcp
 	option interface	wan


### PR DESCRIPTION
Every node starts DHCP on the LAN interface and we rely on this behavior, but without this option it wont happen.