### PR TITLE
Lower default quality

### DIFF
--- a/files/etc/uci-defaults/80_aredn_lqm
+++ b/files/etc/uci-defaults/80_aredn_lqm
@@ -17,3 +17,10 @@ __EOF__
         /sbin/uci -c $c commit aredn
     fi
 done
+
+if [ "$(/sbin/uci -q get aredn.@lqm[0].min_quality)" = "50" ]; then
+    /sbin/uci -q set aredn.@lqm[0].min_quality=35
+    /sbin/uci -q -c /etc/config.mesh set aredn.@lqm[0].min_quality=35
+    /sbin/uci commit aredn
+    /sbin/uci -c /etc/config.mesh commit aredn
+fi


### PR DESCRIPTION
We calculate quality differently (ie. correctly) so drop the default minimum to avoid too many nasty surprises.
