### PR TITLE
Fix problems with large numbers of tunnels

### DIFF
--- a/files/app/main/status/e/tunnels.ut
+++ b/files/app/main/status/e/tunnels.ut
@@ -47,8 +47,16 @@ if (request.env.REQUEST_METHOD === "PUT") {
         uciMesh.set("aredn", "@tunnel[0]", "weight", request.args.tunnel_weight);
         uciMesh.commit("aredn");
     }
-    if ("tunnels" in request.args) {
-        const tunnels = json(request.args.tunnels);
+    if ("_0" in request.args) {
+        const tunnels = [];
+        for (let k in request.args) {
+            if (ord(k) === 95) { // _ == 95
+                const t = request.args[k];
+                if (t) {
+                    push(tunnels, json(t));
+                }
+            }
+        }
         const found = { ls: {}, lc: {}, ws: {}, wc: {} };
         for (let i = 0; i < length(tunnels); i++) {
             const t = tunnels[i];
@@ -363,7 +371,8 @@ This value is used by default, but each tunnel may overide it.
         const available = {{sprintf("%J", available)}};
         function updateTunnels()
         {
-            const tunnels = [];
+            const tunnels = { _0: "" };
+            let tc = 0;
             const tuns = htmx.findAll("#tunnels .tunnel");
             for (let i = 0; i < tuns.length; i++) {
                 const t = tuns[i];
@@ -377,7 +386,7 @@ This value is used by default, but each tunnel may overide it.
                 const enable = htmx.find(t, "input[name=enable]");
                 const weight = htmx.find(t, "input[name=weight]");
                 if (name.validity.valid && password.validity.valid && network.validity.valid && notes.validity.valid && weight.validity.valid) {
-                    tunnels.push({
+                    tunnels[`_${tc++}`] = JSON.stringify({
                         index: index,
                         type: type,
                         name: name.value,
@@ -392,7 +401,7 @@ This value is used by default, but each tunnel may overide it.
             }
             htmx.ajax("PUT", "{{request.env.REQUEST_URI}}", {
                 swap: "none",
-                values: { tunnels: JSON.stringify(tunnels) }
+                values: tunnels
             });
         }
         htmx.on("input[name=tunnel_server]", "change", e => {


### PR DESCRIPTION
https://github.com/aredn/aredn/issues/1266

urlencoded arguments can be no longer than 4K. With large numbers of tunnels this limit was exceeded causing failures. Break up the argument into individual tunnels instead.