### PR TITLE
Limit reported GPS precision

### DIFF
--- a/files/usr/lib/lua/aredn/hardware.lua
+++ b/files/usr/lib/lua/aredn/hardware.lua
@@ -583,8 +583,12 @@ function hardware.gps_read_llt(gps, maxlines)
         local j = gps_read(s)
         if j.class == "TPV" then
             info.time = j.time:gsub("T", " "):gsub(".000Z", "")
-            info.lat = j.lat
-            info.lon = j.lon
+            if j.lat then
+                info.lat = tonumber(string.format("%.5f", j.lat))
+            end
+            if j.lon then
+                info.lon = tonumber(string.format("%.5f", j.lon))
+            end
             break
         end
         maxlines = maxlines - 1

--- a/files/usr/local/bin/mgr/gps.lua
+++ b/files/usr/local/bin/mgr/gps.lua
@@ -85,6 +85,7 @@ function app.run()
             local clat = tonumber(c:get("aredn", "@location[0]", "lat") or 0)
             local clon = tonumber(c:get("aredn", "@location[0]", "lon") or 0)
             if math.abs(clat - j.lat) > CHANGEMARGIN or math.abs(clon - j.lon) > CHANGEMARGIN then
+                nixio.syslog("notice", "Updating lat/lon: " .. j.lat .. "," .. j.lon)
                 -- Calculate gridsquare from lat/lon
                 local alat = j.lat + 90
                 local flat = 65 + math.floor(alat / 10)


### PR DESCRIPTION
5 decimal places is good enough, although the hardware reports more.
There *may* be a Lua bug related to excessive precision numbers in certain trig functions, so this avoids that also.