### PR TITLE
Lockdown first usage pages.

### DIFF
--- a/files/app/main/firstuse-ram.ut
+++ b/files/app/main/firstuse-ram.ut
@@ -33,7 +33,7 @@
  */
 %}
 {%
-if (request.env.REQUEST_METHOD === "POST") {
+if ((auth.isFirstUse || !config.authenable) && request.env.REQUEST_METHOD === "POST") {
     print(_R("reboot-firstuse-ram"));
     response.upgrade = `/usr/local/bin/aredn_sysupgrade -n -q ${request.args.firmwarefile}`;
     return;

--- a/files/app/main/firstuse.ut
+++ b/files/app/main/firstuse.ut
@@ -33,7 +33,7 @@
  */
 %}
 {%
-if (request.env.REQUEST_METHOD === "PUT") {
+if ((auth.isFirstUse || !config.authenable) && request.env.REQUEST_METHOD === "PUT") {
     system(`/usr/local/bin/firstuse-setup '${request.args.name}' '${request.args.passwd}'`);
     response.reboot = true;
     print(_R("reboot-firstuse"));
@@ -116,7 +116,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
         htmx.on("input[name=name]", "keyup", change);
         htmx.on("input[name=passwd1]", "keyup", change);
         htmx.on("input[name=passwd2]", "keyup", change);
-        htmx.on("button", "click", _ => {
+        htmx.on("button.save", "click", _ => {
             htmx.find("button.save").disabled = true;
             htmx.ajax("PUT", "{{request.env.REQUEST_URI}}", {
                 values: {

--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -294,6 +294,7 @@ const uciMeshMethods =
 };
 
 const auth = {
+    isFirstUse: false,
     isAdmin: false,
     key: null,
     age: 315360000, // 10 years
@@ -386,11 +387,12 @@ global.handle_request = function(env)
     const path = match(env.PATH_INFO, rePath);
     const page = path[1] || "status";
     const secured = index(path[2], "/e/") === 0;
-    const firstuse = !!fs.access("/etc/config/unconfigured");
+
+    auth.isFirstUse = !!fs.access("/etc/config/unconfigured");
 
     if (path[2] == "" || secured) {
         let tpath;
-        if (firstuse) {
+        if (auth.isFirstUse) {
             tpath = `${config.application}/main/firstuse-ram.ut`;
             const f = fs.open("/proc/mounts");
             if (f) {


### PR DESCRIPTION
Unless device is unconfigured, dont let the first use pages do anything.
