### PR TITLE
Compact the firmware+hardware info in the dialog

### DIFF
--- a/files/app/main/status/e/firmware.ut
+++ b/files/app/main/status/e/firmware.ut
@@ -371,20 +371,12 @@
         <div style="overflow-y:scroll;padding-left:2px">
             <div class="cols compact">
                 <div>
-                    <div class="o">Firmware</div>
-                    <div class="m">Current firmware version</div>
+                    <div class="o">{{configuration.getFirmwareVersion()}}</div>
+                    <div class="m">Current version</div>
                 </div>
-                <div style="flex:0">
-                    <input type="text" disabled size="35" value="{{configuration.getFirmwareVersion()}}">
-                </div>
-            </div>
-            <div class="cols compact">
-                <div>
-                    <div class="o">Hardware</div>
-                    <div class="m">Hardware type</div>
-                </div>
-                <div style="flex:0">
-                    <input type="text" disabled size="35" value="{{hardware.getHardwareType()}}">
+                <div style="text-align:right">
+                    <div class="o">{{hardware.getHardwareType()}}</div>
+                    <div class="m" style="padding-right:0">Hardware type</div>
                 </div>
             </div>
             {{_H("The hardware type is useful when finding firmware files to upload or sideload. When using the download feature


### PR DESCRIPTION
Use less space to show the current firmware and hardware info.

https://github.com/aredn/aredn/issues/1296
https://github.com/aredn/aredn/issues/1343