### PR TITLE
Wifi scan is only available in mesh mode

### DIFF
--- a/files/app/partial/tools.ut
+++ b/files/app/partial/tools.ut
@@ -39,9 +39,9 @@
     </label>
     <div class="menu">
         {% if (hardware.getRadioCount() > 0) { %}
-        <div hx-trigger="click" hx-get="tools/e/wifiscan" hx-target="#ctrl-modal"><div class="icon signal"></div>WiFi Scan</div>
         {% const config = radios.getActiveConfiguration();
         if (config[0]?.mode === radios.RADIO_MESH || config[1]?.mode === radios.RADIO_MESH) { %}
+        <div hx-trigger="click" hx-get="tools/e/wifiscan" hx-target="#ctrl-modal"><div class="icon signal"></div>WiFi Scan</div>
         <div hx-trigger="click" hx-get="tools/e/wifisignal" hx-target="#ctrl-modal"><div class="icon wifi"></div>WiFi Signal</div>
         {% }
         } %}


### PR DESCRIPTION
Matches old UIs support. Might look at extending this later.