### PR TITLE
 Fix parsing by new UI of advanced-DHCP-option configuration files.

### DIFF
--- a/files/app/main/status/e/dhcp.ut
+++ b/files/app/main/status/e/dhcp.ut
@@ -142,9 +142,10 @@ if (f) {
 f = fs.open(dhcp.dhcptags);
 if (f) {
     for (let l = f.read("line"); length(l); l = f.read("line")) {
-        const m = match(trim(l), /^(.+) (.+) (.+)$/);
+        const m = match(replace(l, /\n+$/, ""), /^([^\W_]+)\s(\w+)\s(.+)$/);
         if (m) {
-            push(advtags, { name: m[1], type: m[2], match: m[3] });
+            const p = replace(replace(replace(m[3], /"/g, "&quot;"), /</g, "&lt;"), />/g, "&gt;");
+            push(advtags, { name: m[1], type: m[2], match: p });
         }
     }
     f.close();
@@ -152,7 +153,7 @@ if (f) {
 f = fs.open(dhcp.dhcpoptions);
 if (f) {
     for (let l = f.read("line"); length(l); l = f.read("line")) {
-        const m = match(trim(l), /^(.*) (force|onrequest) ([0-9]+) (.+)$/);
+        const m = match(replace(l, /\n+$/, ""), /^(\S*)\s(force|onrequest)\s(\d+)\s(.+)$/);
         if (m) {
             push(advoptions, { name: m[1], always: m[2] === "force", type: int(m[3]), value: m[4] });
         }
@@ -266,8 +267,8 @@ if (f) {
                                 <option value="userclass" {{t.type == "userclass" ? "selected": ""}}>User Class</option>
                                 <option value="mac" {{t.type == "mac" ? "selected": ""}}>MAC Address</option>
                                 <option value="circuitid" {{t.type == "circuitid" ? "selected": ""}}>Agent Circuit ID</option>
-                                <option value="agentid" {{t.type == "agentid" ? "selected": ""}}>Agent Remove ID</option>
-                                <option value="subscriberid" {{t.type == "subscribedid" ? "selected": ""}}>Subscriber ID</option>
+                                <option value="remoteid" {{t.type == "remoteid" ? "selected": ""}}>Agent Remote ID</option>
+                                <option value="subscriberid" {{t.type == "subscriberid" ? "selected": ""}}>Subscriber-ID</option>
                             </select>
                             <input name="tag_match" type="text" required value="{{t.match}}">
                         </div>
@@ -567,7 +568,7 @@ if (f) {
                     switch (target.innerText) {
                         case "+":
                             const item = document.createElement("div");
-                            item.innerHTML = `<div class="cols"><div class="row"><input name="tag_name" type="text" required value=""> <select name="tag_type" required><option value="">-</option><option value="vendorclass">Vendor Class</option><option value="userclass">User Class</option><option value="mac">MAC Address</option><option value="circuitid">Agent Circuit ID</option><option value="agentid">Agent Remove ID</option><option value="subscriberid">Subscriber ID</option></select> <input name="tag_match" type="text" required value=""></div><button>-</button></div>`;
+                            item.innerHTML = `<div class="cols"><div class="row"><input name="tag_name" type="text" required value=""> <select name="tag_type" required><option value="">-</option><option value="vendorclass">Vendor Class</option><option value="userclass">User Class</option><option value="mac">MAC Address</option><option value="circuitid">Agent Circuit ID</option><option value="remoteid">Agent Remote ID</option><option value="subscriberid">Subscriber-ID</option></select> <input name="tag_match" type="text" required value=""></div><button>-</button></div>`;
                             htmx.find("#ctrl-modal .dialog .dhcp-tags .list").appendChild(item.firstChild);
                             break;
                         case "-":

--- a/files/app/main/status/e/internal-services.ut
+++ b/files/app/main/status/e/internal-services.ut
@@ -116,7 +116,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
         <div class="cols">
             <div>
                 <div class="o">Remote logging</div>
-                <div class="m">Send internal logging information to a remove server</div>
+                <div class="m">Send internal logging information to a remote server</div>
             </div>
             <div style="flex:0">
                 <input hx-put="{{request.env.REQUEST_URI}}" name="remotelog" type="text" size="24" placeholder="None" pattern="(tcp|udp)://((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}:\d+" value="{{uciMesh.get("aredn", "@remotelog[0]", "url") || ""}}">


### PR DESCRIPTION
<!-- Thank you so much for contributing! -->

### Description

- Fix spellings of suboptions and their keys.
- Do not drop leading spaces, so options with no tag will work.
- Do not drop trailing spaces, which may be required in tag patterns.
- Fix regular expressions to handle embedded spaces in options and tag patterns.
- Handle special characters in tag patterns (primarily for Subscriber-ID).