### PR TITLE
Exclude the Mikrotik hAP ac3 from the v7 check (it doesnt use it)

### DIFF
--- a/files/app/main/status/e/firmware.ut
+++ b/files/app/main/status/e/firmware.ut
@@ -317,13 +317,8 @@
         let fwimage = null;
 
         let booter_version = null;
-        const bv = fs.open("/sys/firmware/mikrotik/soft_config/bios_version");
-        if (bv) {
-            const v = bv.read("all");
-            bv.close();
-            if (substr(v, 2) === "7.") {
-                booter_version = "v7"
-            }
+        if (index(hardware.getHardwareType(), "mikrotik-v7") !== -1) {
+            booter_version = "v7"
         }
         for (let i = 0; i < length(overview.images); i++) {
             const image = overview.images[i];

--- a/files/usr/share/ucode/aredn/hardware.uc
+++ b/files/usr/share/ucode/aredn/hardware.uc
@@ -571,13 +571,20 @@ export function getHardwareType()
     }
     else if (match(mfg, /[Mm]ikro[Tt]ik/)) {
         mfgprefix = "mikrotik";
-        const bv = fs.open("/sys/firmware/mikrotik/soft_config/bios_version");
-        if (bv) {
-            const v = bv.read("all");
-            bv.close();
-            if (substr(v, 2) === "7.") {
-                targettype += "-v7"
-            }
+        switch (hardwaretype) {
+            case "hap-ac3":
+                // Exception: hAP ac3 doesn't need this
+                break;
+            default:
+                const bv = fs.open("/sys/firmware/mikrotik/soft_config/bios_version");
+                if (bv) {
+                    const v = bv.read("all");
+                    bv.close();
+                    if (substr(v, 2) === "7.") {
+                        targettype += "-v7"
+                    }
+                }
+                break;
         }
     }
     else if (match(mfg, /[Tt][Pp]-[Ll]ink/)) {


### PR DESCRIPTION
The Mikrotik hAP ac3 can install the usual sys image with either the v6 or v7 bootloader. NAND devices are just different I guess.