### PR TITLE
Focus newly created items

### DIFF
--- a/files/app/main/status/e/dhcp.ut
+++ b/files/app/main/status/e/dhcp.ut
@@ -477,7 +477,9 @@ if (f) {
                                     Object.assign(o, { name: "", mac: "", noprop: true, reserved: true, leased: false });
                                     const item = document.createElement("div");
                                     item.innerHTML = `<div class="cols reservation" data-ip="${o.ip}"><div style="white-space:nowrap"><input name="hostname" type="text" placeholder="hostname" value="${o.name}" required> <select class="dhcp-addresses"></select> <input name="mac" type="text" placeholder="mac a&zwnj;ddress" required pattern="([0-9a-fA-F][0-9a-fA-F]:){5}[0-9a-fA-F][0-9a-fA-F]" value="${o.mac}"><label> <input type="checkbox" ${o.noprop ? "checked" : ""}></label></div><button>-</button></div>`;
-                                    htmx.find("#dhcp-reservations").appendChild(item.firstChild);
+                                    const ic = item.firstChild;
+                                    htmx.find("#dhcp-reservations").appendChild(ic);
+                                    htmx.find(ic, "input").focus();
                                 }
                                 if (!options.find(o => !o.reserved && !o.leased)) {
                                     target.disabled = true;

--- a/files/app/main/status/e/local-services.ut
+++ b/files/app/main/status/e/local-services.ut
@@ -514,6 +514,7 @@ if (f) {
                 htmx.find(div, "select[name=type]").value = t.type || "";
                 const ls = htmx.find("#local-services");
                 ls.insertBefore(div.firstChild, ls.firstChild);
+                htmx.find(ls, "input").focus();
                 refreshHostSelectors();
                 updateServices();
             }
@@ -547,6 +548,7 @@ if (f) {
             </div>`;
             const ha = htmx.find("#host-aliases");
             ha.insertBefore(div.firstChild, ha.firstChild);
+            htmx.find(ha, "input").focus();
             refreshHostSelectors();
             updateAliases();
         });
@@ -607,7 +609,9 @@ if (f) {
     </div>
     <button>-</button>
 </div>`;
-            htmx.find("#port-forwards").appendChild(div.firstChild);
+            const pf = htmx.find("#port-forwards");
+            pf.appendChild(div.firstChild);
+            htmx.find(pf, "input[name=port_sports]").focus();
         });
         htmx.on("#port-forwards", "change", _ => updatePortForwards());
         htmx.on("#port-forwards", "select", _ => updatePortForwards());

--- a/files/app/main/status/e/ports-and-xlinks.ut
+++ b/files/app/main/status/e/ports-and-xlinks.ut
@@ -471,7 +471,9 @@ uciMesh.foreach("xlink", "interface", x => {
 </div>
 <button>-</button>
 </div>`;
-            ls.appendChild(div.firstChild);
+            const fc = div.firstChild;
+            ls.appendChild(fc);
+            htmx.find(fc, "input").focus();
         });
     })();
     </script>

--- a/files/app/main/status/e/tunnels.ut
+++ b/files/app/main/status/e/tunnels.ut
@@ -488,6 +488,7 @@ This value is used by default, but each tunnel may overide it.
 </div>`;
             const t = htmx.find("#tunnels");
             t.insertBefore(div.firstChild, t.firstChild);
+            htmx.find(t, "input").focus();
         });
         htmx.on("#tunnels", "change", updateTunnels);
         htmx.on("#tunnels", "click", event => {


### PR DESCRIPTION
When we add new ports, services, xlink or tunnels, move the focus automatically to the first field of the new item.