### PR TITLE
Put old UI button just on the main page

### DIFF
--- a/files/app/main/app.ut
+++ b/files/app/main/app.ut
@@ -59,7 +59,6 @@
 </head>
 <body class="{{auth.isAdmin ? "authenticated" : ""}}" hx-indicator="body">
     <dialog id="ctrl-modal" onclose="event.target.innerHTML = ''"></dialog>
-    {{_R("oldui")}}
     <div id="all">
         <div id="nav">
             {{_R("nav")}}

--- a/files/app/partial/status.ut
+++ b/files/app/partial/status.ut
@@ -32,6 +32,7 @@
  * version
  */
 %}
+{{_R("oldui")}}
 <div id="c1">
     <div id="general">
         {{_R("general")}}


### PR DESCRIPTION
Mostly to stop people trying to use it when the node is updating or rebooting.