### PR TITLE
Fix clocks on Mikrotik Basebox5 and QRT

### DIFF
--- a/patches/747-mikrotik-extra-support.patch
+++ b/patches/747-mikrotik-extra-support.patch
@@ -669,7 +669,7 @@
 
 --- /dev/null
 +++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-5hpnd.dts
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,12 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +
 +#include "ar9342_mikrotik_routerboard-912uag-2hpnd.dts"
@@ -678,9 +678,13 @@
 +	compatible = "mikrotik,routerboard-912uag-5hpnd", "qca,ar9342";
 +	model = "MikroTik RouterBOARD 912UAG-5HPnD";
 +};
++
++&ref {
++	clock-frequency = <25000000>;
++};
 --- /dev/null
 +++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-911g-5hpnd-qrt.dts
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,12 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +
 +#include "ar9342_mikrotik_routerboard-912uag-5hpnd.dts"
@@ -688,6 +692,10 @@
 +/ {
 +        compatible = "mikrotik,routerboard-911g-5hpnd-qrt", "qca,ar9342";
 +        model = "MikroTik RouterBOARD 911G-5HPnD-QRT";
++};
++
++&ref {
++	clock-frequency = <25000000>;
 +};
 --- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
 +++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network


### PR DESCRIPTION
Clock speed inherited from Basebox2 appears to be incorrect. The Basebox2 clock was originally 25 MHz but was changed in 2022 to 40 MHz (see https://github.com/openwrt/openwrt/pull/10990). Assuming this is correct, it does not appear correct for the 5GHz models, so change it back for these.