### PR TITLE
Workaround Firefox cookie caching bug

### DIFF
--- a/files/app/partial/login.ut
+++ b/files/app/partial/login.ut
@@ -66,7 +66,7 @@
             if (response.status === 200) {
                 response.json().then(function(json) {
                     if (json.authenticated) {
-                        location.reload();
+                        location.replace(location.origin);
                     }
                 });
             }


### PR DESCRIPTION
To login we create a cookie and hand it to the browser using AJAX. This cookie is then used to authenticate the browse to the device for all subsequent calls. Chrome and Safari are good with this because the new cookie is in the correct context. Firefox does not like this unless you navigate away from the page and back again (refreshing is insufficient). Quite why isn't clear (it must surely be a bug) but this change works around this problem without impacting other browsers.