### PR TITLE
Improve when compression is used on http requests

### DIFF
--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -545,47 +545,35 @@ global.handle_request = function(env)
                 res = `<div><b>ERROR: ${e.message}</b><div><pre>${e.stacktrace[0].context}</pre></div>`;
             }
             if (!response.override) {
-                if (index(env.HTTP_ACCEPT_ENCODING || "", "gzip") === -1 || !config.compress) {
-                    response.headers["Content-Length"] = `${length(res)}`;
-                    uhttpd.send(
-                        `Status: ${response.statusCode} OK\r\n`,
-                        join("", map(keys(response.headers), k => k + ": " + response.headers[k] + "\r\n")),
-                        "\r\n",
-                        res
-                    );
-                }
-                else {
+                let datafile = null;
+                if (env.HTTP_ACCEPT_ENCODING && index(env.HTTP_ACCEPT_ENCODING, "gzip") !== -1 && config.compress) {
                     const r = fs.open("/dev/urandom");
-                    let datafile;
                     if (r) {
                         const rid = r.read(8);
                         r.close();
                         datafile = `/tmp/uhttpd.${hexenc(rid)}`;
-                    }
-                    else {
-                        datafile = `/tmp/uhttpd.${time()}${math.rand()}`;
-                    }
-                    try {
-                        fs.writefile(datafile, res);
-                        const z = fs.popen("exec /bin/gzip -c " + datafile);
-                        try {
+                        const x = fs.open(datafile, "wx");
+                        if (x) {
+                            x.close();
+                            fs.writefile(datafile, res);
+                            const z = fs.popen("exec /bin/gzip -c " + datafile);
                             res = z.read("all");
-                            response.headers["Content-Length"] = `${length(res)}`;
-                            uhttpd.send(
-                                `Status: ${response.statusCode} OK\r\nContent-Encoding: gzip\r\n`,
-                                join("", map(keys(response.headers), k => k + ": " + response.headers[k] + "\r\n")),
-                                "\r\n",
-                                res
-                            );
+                            z.close();
+                            fs.unlink(datafile);
                         }
-                        catch (_) {
+                        else {
+                            datafile = null;
                         }
-                        z.close();
                     }
-                    catch (_) {
-                    }
-                    fs.unlink(datafile);
                 }
+                response.headers["Content-Length"] = `${length(res)}`;
+                uhttpd.send(
+                    `Status: ${response.statusCode} OK\r\n`,
+                    (datafile ? `Content-Encoding: gzip\r\n` : ``),
+                    join("", map(keys(response.headers), k => k + ": " + response.headers[k] + "\r\n")),
+                    "\r\n",
+                    res
+                );
             }
             if (response.reboot) {
                 system("(sleep 2; exec /sbin/reboot)&");

--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -554,8 +554,8 @@ global.handle_request = function(env)
                         datafile = `/tmp/uhttpd.${hexenc(rid)}`;
                         const x = fs.open(datafile, "wx");
                         if (x) {
+                            x.write(res);
                             x.close();
-                            fs.writefile(datafile, res);
                             const z = fs.popen("exec /bin/gzip -c " + datafile);
                             res = z.read("all");
                             z.close();


### PR DESCRIPTION
HTTP resources are compressed before they're sent. This involves compressing them in the file system (at least until the next OpenWRT merge, where we can avoid this) which, in turn, requires a unique file as the target. We generate this using a random number read from /dev/urandom (we cannot use ucode's random function because requests are served using forked uhttpd instances, which makes it likely we'll get the same random number when serving simultaneous requests). We had assumed this would always work, but perhaps this is not always true. So now, if we cannot generate a unique filename (which we check in the file system before use) we play it safe and dont compress the response.