### PR TITLE
Fix I2C on GL-AR750

### DIFF
--- a/patches/002-ath79-fix-I2C-pins-on-GL-AR750.patch
+++ b/patches/002-ath79-fix-I2C-pins-on-GL-AR750.patch
@@ -1,0 +1,38 @@
+From 5d804deeeccd0a8f2efbc514266799bbf77e1187 Mon Sep 17 00:00:00 2001
+From: Ryan Salsbury <ryanrs@gmail.com>
+Date: Mon, 16 Sep 2024 17:49:21 -0700
+Subject: [PATCH] ath79: fix I2C pins on GL-AR750
+
+Change I2C pin flags to GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN, and
+change SDA to GPIO1.
+
+On my late production GL-AR750 (purchased 2024):
+SCL = GPIO16
+SDA = GPIO1
+
+Bug report:
+I2C bus doesn't work in GL-AR750
+https://github.com/openwrt/openwrt/issues/16319
+
+Signed-off-by: Ryan Salsbury <ryanrs@gmail.com>
+---
+ target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts b/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
+index 4d809b922a7c9..8c9cf1ca464ff 100644
+--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
++++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
+@@ -63,8 +63,10 @@
+ 	i2c {
+ 		compatible = "i2c-gpio";
+ 
+-		sda-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+-		scl-gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
++		sda-gpios = <&gpio  1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++		scl-gpios = <&gpio 16 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++		i2c-gpio,delay-us = <5>;
++		i2c-gpio,timeout-ms = <50>;
+ 	};
+ };
+ 

--- a/patches/series
+++ b/patches/series
@@ -1,5 +1,6 @@
 001-ath79-cpe220v3-sysupgrade-supported.patch
 001-ath79-reverse-wpad-basic-mbedtls.patch
+002-ath79-fix-I2C-pins-on-GL-AR750.patch
 006-flash-fixes.patch
 010-lz77-decompression-support.patch
 011-fix-e750-reset-5g-crash.patch


### PR DESCRIPTION
Adopt patch from OpenWRT upstream to fix the GPIO pin configuration for I2C on the GL-AR750

Fixes https://github.com/aredn/aredn/issues/1526


<!-- Thank you so much for contributing! -->

### Description
Enable the I2C bus on GL-AR750 devices

### Relevant Links
https://github.com/aredn/aredn/issues/1526
https://github.com/openwrt/openwrt/issues/16319
https://github.com/openwrt/openwrt/pull/16406

### Screenshots
Before (note: i2c-tools was installed manually from OpenWRT repo):
```shell
# i2cdetect -y 0
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:                         08 09 0a 0b 0c 0d 0e 0f
10: 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
20: 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f
30: 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
40: 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f
50: 50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f
60: 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f
70: 70 71 72 73 74 75 76 77
```
After (with DS3231 on 0x68 and AT24C32 on 0x57):
```shell
# i2cdetect -y 0
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:                         -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- 57 -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- 68 -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
```