### PR TITLE
Enable kmod-eeprom-at24 package

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -60,6 +60,7 @@ CONFIG_PACKAGE_gpsd-clients=m
 CONFIG_PACKAGE_iperf3=y
 CONFIG_PACKAGE_jansson=n
 CONFIG_PACKAGE_kmod-crypto-crc32c=m
+CONFIG_PACKAGE_kmod-eeprom-at24=m
 CONFIG_PACKAGE_kmod-fs-ext4=m
 CONFIG_PACKAGE_kmod-fs-ntfs=m
 CONFIG_PACKAGE_kmod-fs-vfat=m


### PR DESCRIPTION
Create a package to provide the at24 kernel driver, which supports a variety of I2C EEPROMs.


<!-- Thank you so much for contributing! -->

### Description
Add support for AT24-compatible I2C Serial EEPROMs, which are often included, for example, on RTC daughterboards.

### Relevant Links

### Screenshots
After:
```
# echo '24c32 0x57' > /sys/class/i2c-dev/i2c-0/device/new_device
# dmesg
[   54.606884] at24 0-0057: supply vcc not found, using dummy regulator
[   54.614464] at24 0-0057: 4096 byte 24c32 EEPROM, writable, 1 bytes/write
[   54.621598] i2c i2c-0: new_device: Instantiated device 24c32 at 0x57
# ls -l /sys/devices/platform/i2c/i2c-0/0-0057/eeprom
-rw-------    1 root     root          4096 Sep 17 16:14 /sys/devices/platform/i2c/i2c-0/0-0057/eeprom
```
