### PR TITLE
Fix typo of /dev/nul instead of /dev/null

### DIFF
--- a/files/usr/local/bin/mgr/gps.lua
+++ b/files/usr/local/bin/mgr/gps.lua
@@ -76,7 +76,7 @@ function app.run()
 
         -- Update time and date
         if c:get("aredn", "@time[0]", "gps_enable") == "1" and j.time then
-            os.execute("/bin/date -u -s '" .. j.time .. "' > /dev/nul 2>&1")
+            os.execute("/bin/date -u -s '" .. j.time .. "' > /dev/null 2>&1")
             write_all("/tmp/timesync", "gps")
         end
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! -->

### Description
Fix typo of `/dev/nul` instead of `/dev/null` in date command in mgr/gps.lua

Fixes https://github.com/aredn/aredn/issues/1530

