### PR TITLE
Improve the initial nvram setup

### DIFF
--- a/files/etc/init.d/local
+++ b/files/etc/init.d/local
@@ -4,11 +4,6 @@
 START=99
 boot() {
 
-  [ -x /usr/local/bin/aredn_postupgrade ] && /usr/local/bin/aredn_postupgrade
-
-  # setup nvram variables
-  [ -x /usr/local/bin/nvram-setup ] &&  /usr/local/bin/nvram-setup
-
   # run mode specific setup
   [ -x /etc/config/local ] && /etc/config/local
   [ -x /etc/local/services ] && /etc/local/services

--- a/files/etc/init.d/upgrade
+++ b/files/etc/init.d/upgrade
@@ -1,0 +1,11 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006 OpenWrt.org
+
+START=45
+boot() {
+
+  [ -x /usr/local/bin/nvram-setup ] &&  /usr/local/bin/nvram-setup
+
+  [ -x /usr/local/bin/aredn_postupgrade ] && /usr/local/bin/aredn_postupgrade
+
+}

--- a/files/usr/local/bin/aredn_postupgrade
+++ b/files/usr/local/bin/aredn_postupgrade
@@ -55,8 +55,8 @@ if config ~= "mesh" then
 end
 
 local node = aredn.info.get_nvram("node")
-local mac2 = mac_to_ip(aredn.hardware.get_interface_mac(aredn.hardware.get_iface_name("wifi")), 0)
-local dtdmac = mac_to_ip(aredn.hardware.get_interface_mac(aredn.hardware.get_iface_name("lan")), 0)
+local mac2 = aredn.info.get_nvram("mac2")
+local dtdmac = aredn.info.get_nvram("dtdmac")
 
 local cfg = {}
 local defaultcfg = {}
@@ -75,14 +75,35 @@ do
     end
 end
 
+-- specific settings for variables that are not in the default config but are added by the system
+local keys = { 'dmz_dhcp_end', 'dmz_dhcp_limit', 'dmz_dhcp_start', 'dmz_lan_ip', 'dmz_lan_mask', 'wan_gw', 'wan_ip', 'wan_mask', 'wan_intf' }
+
 for line in io.lines("/etc/config.mesh/_setup.default")
 do
     if not (line:match("^%s*#") or line:match("^%s*$")) then
         line = line:gsub("<NODE>", node):gsub("<MAC2>", mac2):gsub("<DTDMAC>", dtdmac)
         local k, v = line:match("^(%S+)%s*=%s*(.*)%s*$")
         defaultcfg[k] = v
+        -- add default config key
+        keys[#keys + 1] = k
     end
 end
+
+table.sort(keys)
+for _, key in ipairs(keys)
+do
+    local v = cfg[key]
+    if v then
+        tmp:write(key .. " = " .. v .. "\n")
+    elseif defaultcfg[key] then
+        tmp:write(key .. " = " .. defaultcfg[key] .. "\n")
+    end
+end
+
+tmp:close()
+
+filecopy("/tmp/.mesh_setup", "/etc/config.mesh/_setup")
+os.remove("/tmp/.mesh_setup")
 
 -- set variables in special conditions
 if cfg.dmz_mode == "0" or cfg.wan_proto == "disabled" then
@@ -91,36 +112,6 @@ if cfg.dmz_mode == "0" or cfg.wan_proto == "disabled" then
     c:commit("aredn")
 end
 -- end special condition overrides
-
-local keys = {}
-for k, v in pairs(defaultcfg)
-do
-    keys[#keys + 1] = k
-end
-table.sort(keys)
-for _, key in ipairs(keys)
-do
-    local v = cfg[key]
-    if v then
-        tmp:write(key .. " = " .. v .. "\n")
-    else
-        tmp:write(key .. " = " .. defaultcfg[key] .. "\n")
-    end
-end
-
--- specific settings for variables that are not in the default config but are added by the system
-for _, key in ipairs({ 'dmz_dhcp_end', 'dmz_dhcp_limit', 'dmz_dhcp_start', 'dmz_lan_ip', 'dmz_lan_mask', 'wifi_rxant', 'wifi_txant', 'wan_gw', 'wan_ip', 'wan_mask', 'wan_intf' })
-do
-    local v = cfg[key]
-    if v then
-        tmp:write(key .. " = " .. v .. "\n")
-    end
-end
-
-tmp:close()
-
-filecopy("/tmp/.mesh_setup", "/etc/config.mesh/_setup")
-os.remove("/tmp/.mesh_setup")
 
 os.execute("/usr/local/bin/node-setup")
 

--- a/files/usr/local/bin/nvram-setup
+++ b/files/usr/local/bin/nvram-setup
@@ -93,14 +93,11 @@ if wifi_mac == "" or mac2 == "" then
         end
     end
     if not hardware_mac then
+        -- Fallback, create a random mac address instead
+        hardware_mac = capture([[hexdump -n5 -e'/5 "02" 5/1 ":%02X"' /dev/urandom]]):match("^(%S+)")
         if not aredn.hardware.has_wifi() then
-            -- Non wifi device, create a random mac address instead
-            hardware_mac = capture([[hexdump -n5 -e'/5 "02" 5/1 ":%02X"' /dev/urandom]]):match("^(%S+)")
             -- Disable wifi
             os.execute("sed -i -e 's/wifi_enable = 1/wifi_enable = 0/' /etc/config.mesh/_setup")
-        else
-            io.stderr:write("ERROR: hardware mac not found\n")
-            os.exit(-1)
         end
     end
 end

--- a/files/usr/local/bin/nvram-setup
+++ b/files/usr/local/bin/nvram-setup
@@ -95,7 +95,7 @@ if wifi_mac == "" or mac2 == "" then
     if not hardware_mac then
         if not aredn.hardware.has_wifi() then
             -- Non wifi device, create a random mac address instead
-            hardware_mac = capture([[hexdump -n5 -e'/5 "02" 5/1 ":%02X"' /dev/random]]):match("^(%S+)")
+            hardware_mac = capture([[hexdump -n5 -e'/5 "02" 5/1 ":%02X"' /dev/urandom]]):match("^(%S+)")
             -- Disable wifi
             os.execute("sed -i -e 's/wifi_enable = 1/wifi_enable = 0/' /etc/config.mesh/_setup")
         else
@@ -115,13 +115,21 @@ if mac2 == "" then
     aredn.info.set_nvram("mac2", mac2)
 end
 
-if node == "" then
-    aredn.info.set_nvram("node", "NOCALL-" .. mac2:gsub("%.", "-"))
-end
-
 if dtdmac == "" then
-    local a, b, c = aredn.hardware.get_interface_mac(aredn.hardware.get_iface_name("lan")):match("%w%w:%w%w:%w%w:(%w%w):(%w%w):(%w%w)")
-    dtdmac = string.format("%d.%d.%d", tonumber(a, 16), tonumber(b, 16), tonumber(c, 16))
+    local a, b, c
+    for i = 1,5
+    do
+        a, b, c = aredn.hardware.get_interface_mac(aredn.hardware.get_iface_name("lan")):match("%w%w:%w%w:%w%w:(%w%w):(%w%w):(%w%w)")
+        if a then
+            break
+        end
+        sleep(5)
+    end
+    if a then
+        dtdmac = string.format("%d.%d.%d", tonumber(a, 16), tonumber(b, 16), tonumber(c, 16))
+    else
+        dtdmac = mac2
+    end
     if dtdmac == mac2 then
         a = tonumber(a, 16) + 1
         if a > 255 then


### PR DESCRIPTION
Improve the initial setup on the nvram parameters, specifically mac2 and dtdmac. Avoid various race conditions when using the network devices to seed these values, and provide fallbacks if they fail.