### PR TITLE
Reduce preloaded code

### DIFF
--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -79,8 +79,6 @@ if (config.preload) {
     }
     cp("/main/");
     cp("/partial/");
-    cp("/main/status/e/");
-    cp("/main/tools/e/");
 
     radios.getCommonConfiguration();
 }


### PR DESCRIPTION
Preloading too much seems to be causing stability issue.
Reduce to just the essentials for most visitors
