### PR TITLE
Block PUT, POST, DELETE unless logged in or firstboot.

### DIFF
--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -440,6 +440,10 @@ global.handle_request = function(env)
                 uhttpd.send("Status: 401 Unauthorized\r\n\r\n");
                 return;
             }
+            if (env.REQUEST_METHOD !== "GET" && config.authenable && !(auth.isAdmin || auth.isFirstUse)) {
+                uhttpd.send("Status: 401 Unauthorized\r\n\r\n");
+                return;
+            }
             const args = {};
             if (env.CONTENT_TYPE === "application/x-www-form-urlencoded") {
                 let b = "";


### PR DESCRIPTION
While there are other mechanisms to prevent you accessing secure pages, it does no harm to block these actions early as an extra security measure.
