### PR TITLE
Periodically sync time if continuous ntpd is unsynchronized

### DIFF
--- a/files/etc/cron.daily/update-clock
+++ b/files/etc/cron.daily/update-clock
@@ -41,8 +41,10 @@ exec 2> /dev/null
 
 # If real ntp is running, we don't need to do this
 if [ "$(pidof ntpd)" != "" ]; then
-  echo -n "ntp" > /tmp/timesync
-  exit 0
+    if [ -f /var/state/ntp-stratum ] && [ $(cat /var/state/ntp-stratum) -lt 16 ]; then
+        echo -n "ntp" > /tmp/timesync
+        exit 0
+    fi
 fi
 
 candidate=$(uci -q get system.ntp.server)

--- a/files/etc/hotplug.d/ntp/10-ntp-stratum
+++ b/files/etc/hotplug.d/ntp/10-ntp-stratum
@@ -1,0 +1,5 @@
+STATEFILE="/var/state/ntp-stratum"
+
+if [[ "${stratum}" != "" ]]; then
+	echo "${stratum}" > "${STATEFILE}"
+fi


### PR DESCRIPTION
When update-clock is run periodically, if ntpd is running continuously, check whether it is actually in sync, as measured by a reported stratum of less than 16.

If it's not in sync, run the full manual clock sync algorithm otherwise used for our periodic-only synchronization.

This should help with hosts that expect to synchronize from an NTP server on the internet, for example, when they've temporarily lost the internet connection. Or alternately, if configured to use a mesh-based NTP server that has disappeared from the mesh.

