### PR TITLE
Work around HTMX bug where downloading files doesnt stop the logo spinning

### DIFF
--- a/files/app/main/status/e/firmware.ut
+++ b/files/app/main/status/e/firmware.ut
@@ -481,7 +481,7 @@
                         <div class="m">Backup this node's configuration.</div>
                     </div>
                     <div style="flex:0">
-                        <button hx-put="/a/status/e/backup-config">Backup</button>
+                        <button hx-put="/a/status/e/backup-config" hx-indicator="head">Backup</button>
                     </div>
                 </div>
                 {{_H("Backup the current configuration. This can be used to transfer a configuration to new hardware or as a safety precaution in case

--- a/files/app/partial/tools.ut
+++ b/files/app/partial/tools.ut
@@ -49,7 +49,7 @@
             <div hx-trigger="click" hx-get="tools/e/ping" hx-target="#ctrl-modal"><div class="icon bolt"></div>Ping</div>
             <div hx-trigger="click" hx-get="tools/e/traceroute" hx-target="#ctrl-modal"><div class="icon plane"></div>Traceroute</div>
             <div hx-trigger="click" hx-get="tools/e/iperf3" hx-target="#ctrl-modal"><div class="icon twoarrow"></div>iPerf3</div>
-            <div hx-trigger="click" hx-put="tools/e/supportdata" hx-swap="none"><div class="icon download"></div>Support Data</div>
+            <div hx-trigger="click" hx-put="tools/e/supportdata" hx-swap="none" hx-indicator="head"><div class="icon download"></div>Support Data</div>
         </div>
     </label>
 </div>


### PR DESCRIPTION
When we use a redirect to force the web browser to download a file after it uses an AJAX request to initiate the operation, htmx looses track of the htmx-request attribute and so doesnt remove it when the operation is done. Work around this by moving the attribute somewhere we dont care about.