### PR TITLE
VHT support (experimental)

### DIFF
--- a/files/app/main/tools/e/wifiscan.ut
+++ b/files/app/main/tools/e/wifiscan.ut
@@ -89,7 +89,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
         const re = regexp(`^Station ([0-9a-fA-F:]+) \\(on ${wifiiface}\\)`);
         const reSi = /signal:[ \t]+(-[0-9]+)/;
         let station;
-        const dmode = radiomode.mode === radios.RADIO_MESH ? "Connected Ad-Hoc Station" : "AP";
+        const dmode = radio.mode === radios.RADIO_MESH ? "Connected Ad-Hoc Station" : "AP";
         for (let l = f.read("line"); length(l); l = f.read("line")) {
             let m = match(l, re);
             if (m) {

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -930,6 +930,9 @@ do
     end
     local is_mesh_rf = false
     local htmode = "HT20"
+    if aredn.hardware.get_board_type():match("ac") then
+        htmode = "VHT20"
+    end
     local disabled = "0"
     local chanbw = nil
     local country = nil
@@ -994,7 +997,11 @@ do
     if distance then
         config = config .. "	option distance '" .. distance .. "'\n"
     end
-    config = config .. "	option hwmode '" .. hwmode .. "'\n"
+    if hwmode == "11g" then
+        config = config .. "	option band '2g'\n"
+    else
+        config = config .. "	option band '5g'\n"
+    end
     if htmode then
         config = config .. "	option htmode '" .. htmode .. "'\n"
     end

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -932,6 +932,16 @@ do
     local htmode = "HT20"
     if nixio.fs.stat("/sys/kernel/debug/ieee80211/" .. devname .. "/ath10k") then
         htmode = "VHT20"
+        if wlan == cfg.wifi_intf then
+            local bw = tonumber(cfg.wifi_chanbw)
+            if bw == 40 then
+                htmode = "VHT40"
+            elseif bw == 80 then
+                htmode = "VHT80"
+            elseif bw == 160 then
+                htmode = "VHT160"
+            end
+        end
     end
     local disabled = "0"
     local chanbw = nil

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -930,7 +930,7 @@ do
     end
     local is_mesh_rf = false
     local htmode = "HT20"
-    if aredn.hardware.get_board_type():match("ac") then
+    if nixio.fs.stat("/sys/kernel/debug/ieee80211/" .. devname .. "/ath10k") then
         htmode = "VHT20"
     end
     local disabled = "0"


### PR DESCRIPTION
* Enable VHT support on AC radios. This is experimental and I dont know if it will improve link performance in the real world.
* Switched to 'band' in wireless config as 'hwmode' was deprecated years ago.
* Fixed wifi scanner misreporting connected stations as APs.