### PR TITLE
Add locking around operations which change the configuration.

### DIFF
--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -54,12 +54,11 @@ import * as constants from "./constants.uc";
 
 const pageCache = {};
 const resourceVersions = {};
+const lockfile = "/tmp/ui.lock";
 
 log.openlog("uhttpd.aredn", log.LOG_PID, log.LOG_USER);
 
-const light = fs.readfile(`${config.application}/resource/css/themes/light.css`);
-const dark = fs.readfile(`${config.application}/resource/css/themes/dark.css`);
-fs.writefile(`${config.application}/resource/css/themes/default.css`, `${light}@media (prefers-color-scheme: dark) {\n${dark}\n}`);
+fs.writefile(`${config.application}/resource/css/themes/default.css`, `${fs.readfile(`${config.application}/resource/css/themes/light.css`)}@media (prefers-color-scheme: dark) {\n${fs.readfile(`${config.application}/resource/css/themes/dark.css`)}\n}`);
 if (!fs.access(`${config.application}/resource/css/theme.css`)) {
     fs.symlink("themes/default.css", `${config.application}/resource/css/theme.css`);
 }
@@ -80,8 +79,6 @@ if (config.preload) {
     }
     cp("/main/");
     cp("/partial/");
-
-    radios.getCommonConfiguration();
 }
 
 if (config.resourcehash) {
@@ -144,6 +141,8 @@ else {
     }
     fs.unlink(`${config.application}/resource/css/theme.version`);
 }
+
+fs.writefile(lockfile, "");
 
 global._R = function(path, arg)
 {
@@ -452,6 +451,14 @@ global.handle_request = function(env)
                     return;
                 }
             }
+            let changelock = null;
+            if (env.REQUEST_METHOD !== "GET") {
+                changelock = fs.open(lockfile);
+                if (!(changelock && changelock.lock("x"))) {
+                    uhttpd.send("Status: 500 Internal server error\r\n\r\n");
+                    return;
+                }
+            }
             const args = {};
             if (env.CONTENT_TYPE === "application/x-www-form-urlencoded") {
                 let b = "";
@@ -589,6 +596,9 @@ global.handle_request = function(env)
                     "\r\n",
                     res
                 );
+            }
+            if (changelock) {
+                changelock.close();
             }
             if (response.reboot) {
                 system(`(sleep 2; ${response.reboot})&`);

--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -601,7 +601,7 @@ global.handle_request = function(env)
                 changelock.close();
             }
             if (response.reboot) {
-                system(`(sleep 2; ${response.reboot})&`);
+                system(`(sleep 2; sync; ${response.reboot})&`);
             }
             return;
         }

--- a/files/usr/share/ucode/aredn/configuration.uc
+++ b/files/usr/share/ucode/aredn/configuration.uc
@@ -102,15 +102,12 @@ function initSetup()
         setupKeys = [];
         const f = fs.open("/etc/config.mesh/_setup");
         if (f) {
-            for (;;) {
-                const line = f.read("line");
-                if (!length(line)) {
-                    break;
-                }
-                const kv = split(line, " =", 2);
+            for (let l = f.read("line"); length(l); l = f.read("line")) {
+                const kv = split(l, "=", 2);
                 if (length(kv) === 2) {
-                    setup[kv[0]] = trim(kv[1]);
-                    push(setupKeys, kv[0]);
+                    const k = trim(kv[0]);
+                    setup[k] = trim(kv[1]);
+                    push(setupKeys, k);
                 }
             }
             f.close();
@@ -121,7 +118,9 @@ function initSetup()
 export function reset()
 {
     setup = null;
+    setupKeys = null;
     cursor = null;
+    setupChanged = false;
 };
 
 export function getSettingAsString(key, def)


### PR DESCRIPTION
Avoid any potential race conditions when changing the configuration by putting a lock around any non-GET operations.
