### PR TITLE
Fix progress bars broken on latest Safari builds

### DIFF
--- a/files/app/main/status/e/firmware.ut
+++ b/files/app/main/status/e/firmware.ut
@@ -631,7 +631,7 @@
                             p.removeAttribute("value");
                         }
                         else {
-                            p.setAttribute("value", v);
+                            p.setAttribute("value", Math.round(v));
                         }
                     });
                     htmx.ajax("POST", "{{request.env.REQUEST_URI}}", {
@@ -682,7 +682,7 @@
                         p.removeAttribute("value");
                     }
                     else {
-                        p.setAttribute("value", v);
+                        p.setAttribute("value", Math.round(v));
                     }
                 });
                 htmx.ajax("POST", "{{request.env.REQUEST_URI}}", {

--- a/files/app/main/status/e/packages.ut
+++ b/files/app/main/status/e/packages.ut
@@ -360,7 +360,7 @@ const po = getPackageOptions();
             const download = htmx.find("#download-package").value;
             const remove = htmx.find("#remove-package").value;
             if (upload) {
-                htmx.on(e.currentTarget, "htmx:xhr:progress", e => htmx.find("#package-upload progress").setAttribute("value", e.detail.loaded / e.detail.total * 100));
+                htmx.on(e.currentTarget, "htmx:xhr:progress", e => htmx.find("#package-upload progress").setAttribute("value", Math.round(e.detail.loaded / e.detail.total * 100)));
                 htmx.ajax("POST", "{{request.env.REQUEST_URI}}", {
                     source: e.currentTarget,
                     values: {


### PR DESCRIPTION
New Safari builds no longer support non-integers when setting progress bar values