### PR TITLE
Fix dmz dhcp values

### DIFF
--- a/files/app/main/status/e/network.ut
+++ b/files/app/main/status/e/network.ut
@@ -57,17 +57,17 @@ if (request.env.REQUEST_METHOD === "PUT") {
                 dmz_lan_ip = arrtoip([ (dmz_lan_ip >> 24) & 0xff, (dmz_lan_ip >> 16) & 0xff, (dmz_lan_ip >> 8) & 0xff, dmz_lan_ip & 0xff ]);
                 let dmz_lan_mask = 0xffffffff << mode;
                 dmz_lan_mask = arrtoip([ (dmz_lan_mask >> 24) & 0xff, (dmz_lan_mask >> 16) & 0xff, (dmz_lan_mask >> 8) & 0xff, dmz_lan_mask & 0xff ]);
-                const dmz_dhcp_start = (wifi_shift + 2) & 0xff;
-                const dmz_dhcp_end = dmz_dhcp_start + (2 << (mode - 1)) - 4;
                 configuration.setSetting("dmz_lan_ip", dmz_lan_ip);
                 configuration.setSetting("dmz_lan_mask", dmz_lan_mask);
-                configuration.setSetting("dmz_dhcp_start", dmz_dhcp_start);
-                configuration.setSetting("dmz_dhcp_end", dmz_dhcp_end);
+                configuration.setSetting("dmz_dhcp_start", 2);
+                configuration.setSetting("dmz_dhcp_end", (2 << (mode - 1)) - 2);
                 const dhcp = configuration.getDHCP();
                 let f = fs.open(dhcp.aliases);
                 if (f) {
                     const aliases = [];
-                    const n_lan_ip = iptoarr(configuration.getSettingAsString("dmz_lan_ip"));
+                    const dmz_dhcp_start = (wifi_shift + 2) & 0xff;
+                    const dmz_dhcp_end = dmz_dhcp_start + (2 << (mode - 1)) - 4;
+                    const n_lan_ip = iptoarr(dmz_lan_ip);
                     for (let l = f.read("line"); length(l); l = f.read("line")) {
                         const v = match(trim(l), /^(.+) (.+)$/);
                         if (v) {

--- a/files/etc/uci-defaults/96_fix_dhcp_dmz
+++ b/files/etc/uci-defaults/96_fix_dhcp_dmz
@@ -1,0 +1,55 @@
+#!/bin/sh
+true <<'LICENSE'
+  Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+  Copyright (C) 2024 Tim Wilkinson
+  See Contributors file for additional contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional Terms:
+
+  Additional use restrictions exist on the AREDN(TM) trademark and logo.
+    See AREDNLicense.txt for more info.
+
+  Attributions to the AREDN Project must be retained in the source code.
+  If importing this code into a new or existing project attribution
+  to the AREDN project must be added to the source code.
+
+  You must not misrepresent the origin of the material contained within.
+
+  Modified versions must be modified to attribute to the original source
+  and be marked in reasonable ways as differentiate it from the original
+  version.
+
+LICENSE
+
+cat > /tmp/run_uci_defaults << __EOF__
+
+require("nixio")
+require("uci")
+
+local c = uci.cursor("/etc/config.mesh")
+
+if tonumber(c:get("setup", "globals", "dmz_mode") or 0) > 1 then
+    local dmz_lan_mask = c:get("setup", "globals", "dmz_lan_mask")
+    local dmz_dhcp_start = tonumber(c:get("setup", "globals", "dmz_dhcp_start"))
+    local dmz_dhcp_end = tonumber(c:get("setup", "globals", "dmz_dhcp_end"))
+    local mask = 255 - tonumber(dmz_lan_mask:match("%.(%d+)$"))
+    c:set("setup", "globals", "dmz_dhcp_start", nixio.bit.band(dmz_dhcp_start, mask))
+    c:set("setup", "globals", "dmz_dhcp_end", nixio.bit.band(dmz_dhcp_end, mask))
+    c:commit("setup")
+end
+
+__EOF__
+/usr/bin/lua /tmp/run_uci_defaults
+rm -f /tmp/run_uci_defaults

--- a/files/usr/local/bin/aredn_init
+++ b/files/usr/local/bin/aredn_init
@@ -187,11 +187,10 @@ end
 -- DHCP
 if cfg.dmz_mode == "" then
     local dmz_dhcp_base, net = ("1" .. decimal_to_ip((ip_to_decimal("10." .. mac2) * 8) % 0x1000000)):match("(%d+%.%d+%.%d+%.)(%d+)")
-    net = tonumber(net)
     cfg.dmz_mode = 3
-    cfg.dmz_lan_ip = dmz_dhcp_base .. (net + 1)
-    cfg.dmz_dhcp_start = net + 2
-    cfg.dmz_dhcp_end = net + 6
+    cfg.dmz_lan_ip = dmz_dhcp_base .. (tonumber(net) + 1)
+    cfg.dmz_dhcp_start = 2
+    cfg.dmz_dhcp_end = 6
     cfg.dmz_lan_mask = "255.255.255.248"
 end
 


### PR DESCRIPTION
Turns out the values we set for the dmz dhcp range was always an incorrect interpretation of the documentation (see https://openwrt.org/docs/guide-user/base-system/dhcp), but the problem was hidden because the netmask would fix it up.