### PR TITLE
Speed up commits

### DIFF
--- a/files/app/partial/changes.ut
+++ b/files/app/partial/changes.ut
@@ -53,7 +53,7 @@
     }
     if (auth.isAdmin) {
         changes = configuration.countChanges();
-        if (fs.access("/tmp/reboot-required")) {
+        if (fs.access("/tmp/reboot-required/reboot")) {
             reboot = true;
         }
     }
@@ -61,7 +61,7 @@
     %}
         <div>
             Pending changes: {{changes}}
-            <button name="commit" value="1" hx-put="/a/status/e/changes">Commit</button>
+            <button name="commit" value="1" hx-put="/a/status/e/changes" hx-request='{"timeout":5000}'>Commit</button>
             <button name="revert" value="1" hx-put="/a/status/e/changes">Revert</button>
         </div>
         <script>
@@ -71,7 +71,7 @@
                 e.target.innerText = "Committing ...";
                 htmx.find("#changes button[name=revert]").style.display = "none";
             });
-            htmx.on(commit, "htmx:afterRequest", _ => htmx.ajax("GET", "/a/changes", "#changes"));
+            htmx.on(commit, "htmx:timeout", _ => htmx.ajax("GET", "/a/changes", { source: commit, target: "#changes" }));
         })();
         </script>
     {% }


### PR DESCRIPTION
When making any sort of network changes, the response to the original commit can just hang until the request times out and we retry it. To improve UI feedback, reduce that timeout and retry the UI update multiple times.