### PR TITLE
More fixes and improvements to DHCP option validation

### DIFF
--- a/files/app/main/status/e/dhcp.ut
+++ b/files/app/main/status/e/dhcp.ut
@@ -158,7 +158,8 @@ if (f) {
     for (let l = f.read("line"); length(l); l = f.read("line")) {
         const m = match(replace(l, /\n+$/, ""), /^(\S*)\s(force|onrequest)\s(\d+)\s(.*)$/);
         if (m) {
-            push(advoptions, { name: m[1], always: m[2] === "force", type: int(m[3]), value: m[4] });
+            const p = replace(replace(replace(m[4], /"/g, "&quot;"), /</g, "&lt;"), />/g, "&gt;");
+            push(advoptions, { name: m[1], always: m[2] === "force", type: int(m[3]), value: p });
         }
     }
     f.close();
@@ -222,7 +223,7 @@ const dhcpOptionTypes = {
     "119": ["domain-search", "text"],
     "120": ["sip-server", "(?:0,(?:(?:(?!-))(?:(?:xn--)?[A-Za-z0-9][A-Za-z0-9\\-]{0,61}[A-Za-z0-9]{0,1}\\.)*(?:xn--)?(?:[A-Za-z0-9\\-]{1,61}|[A-Za-z0-9\\-]{1,30}\\.[A-Za-z]{2,}),?\\b)+)|(?:1,(?:(?:(?:25[0-5]|(?:2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4},?\\b)+)", "0,DNS Names or 1,IP Addresses"],
     "121": ["classless-static-route", "(?:(?:(?:(?:25[0-5]|(?:2[0-4]|1[0-9]|[1-9]|)[0-9])\\.?\\b){4}\\/(?:[1-9]|[12]\\d|3[0-2]),(?:(?:25[0-5]|(?:2[0-4]|1[0-9]|[1-9]|)[0-9])\\.?\\b){4}),?\\b)+", "IP Address/CIDR,IP Address[,...]"],
-    "125": ["vendor-id-encap", "vi-encap:\\d+,(?:\\d|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5]),(?:\"[^\"]*\"|(?:[0-9A-Fa-f]{2}:?\\b)+|(?:(?:25[0-5]|(?:2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}|-?\\d+)", "vi-encap:int,0...255,data"], // https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2010q4/004454.html
+    "125": ["vendor-id-encap", "(?:vi-encap:)?\\d+,(?:\\d|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5]),(?:\"(?:[^\"\\\\]|\\\\.)*\"|(?:[0-9A-Fa-f]{2}:?\\b)+|(?:(?:25[0-5]|(?:2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}|-?\\d+)", "int,0...255,data"], // https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2010q4/004454.html
     "150": ["tftp-server-address", "ip"],
     "255": ["server-ip-address", "ip"]
 };
@@ -376,7 +377,7 @@ const dhcpOptionTypes = {
                                 <select name="option_name">
                                     <option value="{{o.name}}" selected>{{o.name}}</option>
                                 </select>
-                                <input name="option_type" type="text" required list="dhcp-option-type-list" value="{{dhcpOptionTypes[o.type][0] ? `${o.type}: ${dhcpOptionTypes[o.type][0]}` : o.type}}" pattern="([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(: .+)?">
+                                <input name="option_type" type="text" required list="dhcp-option-type-list" value="{{dhcpOptionTypes[o.type] ? `${o.type}: ${dhcpOptionTypes[o.type][0]}` : o.type}}" pattern="([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(: .+)?">
                                 <input name="option_value" type="text" required value="{{o.value}}">
                                 <label><input name="option_always" type="checkbox" {{o.always ? "checked" : ""}}></label>
                             </div>
@@ -642,36 +643,42 @@ const dhcpOptionTypes = {
                     value.pattern = "";
                 }
                 else {
-                    const types = dhcpOptionTypes[`${parseInt(type.value)}`];
-                    const pat = dhcpOptionTypesPatterns[types[1]];
                     value.disabled = false;
-                    if (pat) {
-                        value.type = "text";
-                        value.pattern = "";
-                        value.min = "";
-                        value.max = "";
-                        value.placeholder = pat[1];
-                        value.required = true;
-                        value.style.visibility = null;
-                        switch (pat[0]) {
-                            case "(number)":
-                                value.type = "number";
-                                value.min = pat[2];
-                                value.max = pat[3];
-                                break;
-                            case "(hidden)":
-                                value.style.visibility = "hidden";
-                                value.value = "";
-                                value.required = false;
-                                break;
-                            default:
-                                value.pattern = pat[0];
-                                break;
+                    value.min = "";
+                    value.max = "";
+                    value.required = true;
+                    value.style.visibility = null;
+                    value.type = "text";
+                    const types = dhcpOptionTypes[`${parseInt(type.value)}`];
+                    if (types) {
+                        const pat = dhcpOptionTypesPatterns[types[1]];
+                        if (pat) {
+                            value.pattern = "";
+                            value.placeholder = pat[1];
+                            switch (pat[0]) {
+                                case "(number)":
+                                    value.type = "number";
+                                    value.min = pat[2];
+                                    value.max = pat[3];
+                                    break;
+                                case "(hidden)":
+                                    value.style.visibility = "hidden";
+                                    value.value = "";
+                                    value.required = false;
+                                    break;
+                                default:
+                                    value.pattern = pat[0];
+                                    break;
+                            }
+                        }
+                        else {
+                            value.pattern = types[1];
+                            value.placeholder = types[2] || "";
                         }
                     }
                     else {
-                        value.pattern = types[1];
-                        value.placeholder = types[2] || "";
+                        value.pattern = ".*";
+                        value.placeholder = "";
                     }
                 }
                 if (name.value === "") {

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -93,6 +93,9 @@ end
 
 local FORCED = "force"
 local UNFORCED = "onrequest"
+local OPT_RAPID_COMMIT = "80"
+local OPT_VENDOR_ID_ENCAP = "125"
+local VI_ENCAP = "vi-encap:"
 
 local c = uci.cursor()
 local cm = uci.cursor("/etc/config.mesh")
@@ -815,6 +818,12 @@ local function option_item(tag, option)
     end
     table.insert(parts, option.num)
     if option.val ~= "" then
+        if option.num == OPT_VENDOR_ID_ENCAP and option.val:sub(1,#VI_ENCAP) ~= VI_ENCAP then
+            option.val = VI_ENCAP .. option.val
+        end
+--        if string.find(option.val, '"') then
+--            option.val = '"' .. option.val:gsub('"', '\\"') .. '"'
+--        end
         table.insert(parts, option.val)
     end
     return table.concat(parts, ",")
@@ -828,7 +837,6 @@ local function create_classifying_section(condition, cond_list)
         if (condition == "subscriberid") then
             secname = "subscrid"
             pat = '"' .. pat:gsub('"', '\\"') .. '"'
-            print(props.pattern, "->", pat)
         end
         nc:add("dhcp", secname)
         local section_ref = string.format("@%s[%d]", secname, i-1)
@@ -887,7 +895,7 @@ do
                 for _, option in ipairs(forcelist[UNFORCED]) do
                     table.insert(dhcp_option_list, option_item(tag, option))
                     -- If we detect a rapid-commit option to enable the necessary config flag
-                    if option.num == "80" and option.val == "1" then
+                    if option.num == OPT_RAPID_COMMIT then
                         nc:set("dhcp", "@dhcp[0]", "rapidcommit", "1")
                     end
                 end


### PR DESCRIPTION
### Description
More fixes and improvements to DHCP option validation:
- Handle unknown options (defined by number) as text data.
- Always reset to text input when changing to a non-integer data type.
- Tolerate values containing quotation marks.
- Make specifying "vi-encap:" encoding optional for Option 125 because it is the only supported encoding.
- Allow embedded quotation marks in string-encoded vi-encap data.

Known issues:
- Values containing embedded whitespace are not correctly encoded in /var/etc/dnsmasq.conf; each whitespace-separated token appears as a separate dhcp-option line. This problem is also present in both the old and new UI in previous releases.
- Nothing special is done with values that contain embedded quotation marks; these might confuse the dnsmasq option parser.