### PR TITLE
Fix unresponsiveness when network changes

### DIFF
--- a/files/app/partial/changes.ut
+++ b/files/app/partial/changes.ut
@@ -71,7 +71,11 @@
                 e.target.innerText = "Committing ...";
                 htmx.find("#changes button[name=revert]").style.display = "none";
             });
-            htmx.on(commit, "htmx:timeout", _ => htmx.ajax("GET", "/a/changes", { source: commit, target: "#changes" }));
+            function retry()
+            {
+                htmx.ajax("GET", "/a/changes", { timeout: 5000, target: "#changes" }).then(null, retry);
+            }
+            htmx.on(commit, "htmx:timeout", retry);
         })();
         </script>
     {% }

--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -462,6 +462,9 @@ global.handle_request = function(env)
                 }
             }
             let changelock = null;
+/*
+ * The lock file mechanism is failing when the network configuration changes while it's active.
+ * Not obvious why this happens, but disable this for now.
             if (env.REQUEST_METHOD !== "GET") {
                 changelock = fs.open(lockfile);
                 if (!(changelock && changelock.lock("x"))) {
@@ -469,6 +472,7 @@ global.handle_request = function(env)
                     return;
                 }
             }
+*/
             const args = {};
             if (env.CONTENT_TYPE === "application/x-www-form-urlencoded") {
                 let b = "";


### PR DESCRIPTION
Tunnel changes, and possibly any network changes, which occur when we're holding a file system lock are making the entire node lockup. Not clear why this would happen, but disable the locking mechanism for now (was recently added as an extra layer of safety when making UI changes).