### PR TITLE
Make 3 column layour responsive if browser is narrow

### DIFF
--- a/files/app/partial/status.ut
+++ b/files/app/partial/status.ut
@@ -42,58 +42,60 @@
         {{_R("location")}}
     </div>
 </div>
-<div id="c2">
-    <div hx-get="u-messages" hx-trigger="every 300s [document.visibilityState === 'visible']">
-    {% if (messages.haveMessages() || (auth.isAdmin && messages.haveToDos())) { %}
-        <div id="messages">
-        {{_R("messages")}}
-        </div>
-    {% } %}
-    </div>
-    <div id="services">
-        {% if (auth.isAdmin) { %}
-        {{_R("internal-services" )}}
+<div id="c2c3">
+    <div id="c2">
+        <div hx-get="u-messages" hx-trigger="every 300s [document.visibilityState === 'visible']">
+        {% if (messages.haveMessages() || (auth.isAdmin && messages.haveToDos())) { %}
+            <div id="messages">
+            {{_R("messages")}}
+            </div>
         {% } %}
-        {{_R("local-services")}}
-    </div>
-    <div id="local-and-neighbor-devices">
-        <hr>
-        <div hx-get="u-local-and-neighbor-devices" hx-trigger="every 60s [document.visibilityState === 'visible']">
-        {{_R("local-and-neighbor-devices")}}
         </div>
-    </div>
-    {{_R("activator", { id: "local-and-neighbor-devices", activate: [ ".noctrl:first-child",  ".noctrl:nth-child(2)" ] })}}
-</div>
-<div id="c3">
-    <div id="radio-and-antenna">
-        {{_R("radio-and-antenna")}}
-    </div>
-    <div id="mesh-summary">
-        <hr>
-        <div hx-get="u-mesh-summary" hx-trigger="every 120s [document.visibilityState === 'visible']">
-        {{_R("mesh-summary")}}
+        <div id="services">
+            {% if (auth.isAdmin) { %}
+            {{_R("internal-services" )}}
+            {% } %}
+            {{_R("local-services")}}
         </div>
-    </div>
-    <div id="dhcp">
-        <hr>
-        <div hx-get="u-dhcp" hx-trigger="every 120s [document.visibilityState === 'visible']">
-        {{_R("dhcp")}}
+        <div id="local-and-neighbor-devices">
+            <hr>
+            <div hx-get="u-local-and-neighbor-devices" hx-trigger="every 60s [document.visibilityState === 'visible']">
+            {{_R("local-and-neighbor-devices")}}
+            </div>
         </div>
+        {{_R("activator", { id: "local-and-neighbor-devices", activate: [ ".noctrl:first-child",  ".noctrl:nth-child(2)" ] })}}
     </div>
-    {% if (length(hardware.getEthernetPorts()) > 0) { %}
-    <div id="ports-and-xlinks">
-        <hr>
-        {{_R("ports-and-xlinks")}}
-    </div>
-    {% } %}
-    {% if (fs.access("/usr/bin/wg") || fs.access("/usr/sbin/vtund")) { %}
-    <div id="tunnels">
-        <hr>
-        <div hx-get="u-tunnels" hx-trigger="every 120s [document.visibilityState === 'visible']">
-        {{_R("tunnels")}}
+    <div id="c3">
+        <div id="radio-and-antenna">
+            {{_R("radio-and-antenna")}}
         </div>
+        <div id="mesh-summary">
+            <hr>
+            <div hx-get="u-mesh-summary" hx-trigger="every 120s [document.visibilityState === 'visible']">
+            {{_R("mesh-summary")}}
+            </div>
+        </div>
+        <div id="dhcp">
+            <hr>
+            <div hx-get="u-dhcp" hx-trigger="every 120s [document.visibilityState === 'visible']">
+            {{_R("dhcp")}}
+            </div>
+        </div>
+        {% if (length(hardware.getEthernetPorts()) > 0) { %}
+        <div id="ports-and-xlinks">
+            <hr>
+            {{_R("ports-and-xlinks")}}
+        </div>
+        {% } %}
+        {% if (fs.access("/usr/bin/wg") || fs.access("/usr/sbin/vtund")) { %}
+        <div id="tunnels">
+            <hr>
+            <div hx-get="u-tunnels" hx-trigger="every 120s [document.visibilityState === 'visible']">
+            {{_R("tunnels")}}
+            </div>
+        </div>
+        {% } %}
     </div>
-    {% } %}
 </div>
 {% } else { %}
 <div id="general">

--- a/files/app/resource/css/user.css
+++ b/files/app/resource/css/user.css
@@ -167,7 +167,6 @@ body.authenticated .ctrl:hover
     display: flex;
     flex-direction: column;
     min-width: 330px;
-    width: 330px;
 }
 #general
 {
@@ -175,8 +174,9 @@ body.authenticated .ctrl:hover
     flex-direction: column;
     padding: 10px 5px;
 }
-#location
+#c2c3
 {
+    display: flex;
 }
 #c2
 {
@@ -204,13 +204,28 @@ body.authenticated .ctrl:hover
     padding: 20px 0 0 5px;
     container-type: inline-size;
 }
+@media (max-width: 1200px)
+{
+    #c2c3
+    {
+        flex-direction: column;
+    }
+    #c3
+    {
+        padding-left: 15px;
+    }
+}
+@media (max-width: 800px)
+{
+    #main-container
+    {
+        flex-direction: column;
+    }
+}
 #radio-and-antenna
 {
     display: flex;
     flex-direction: column;
-}
-#mesh-summary
-{
 }
 #tunnels
 {


### PR DESCRIPTION
For narrow web browser windows, make the layout responsive; 3, 2 and 1 column depending on width.
This is *not* the mobile layout which is somewhat different.