### PR TITLE
Refine PUT/POST locking.

### DIFF
--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -461,18 +461,6 @@ global.handle_request = function(env)
                     return;
                 }
             }
-            let changelock = null;
-/*
- * The lock file mechanism is failing when the network configuration changes while it's active.
- * Not obvious why this happens, but disable this for now.
-            if (env.REQUEST_METHOD !== "GET") {
-                changelock = fs.open(lockfile);
-                if (!(changelock && changelock.lock("x"))) {
-                    uhttpd.send("Status: 500 Internal server error\r\n\r\n");
-                    return;
-                }
-            }
-*/
             const args = {};
             if (env.CONTENT_TYPE === "application/x-www-form-urlencoded") {
                 let b = "";
@@ -565,6 +553,14 @@ global.handle_request = function(env)
             const fn = pageCache[tpath] || loadfile(tpath, { raw_mode: false });
             const isMobile = !!(config.forcemobile || match(env.HTTP_USER_AGENT, /iphone/i) || match(env.HTTP_USER_AGENT, /android.*mobile/i));
             let res = "";
+            let changelock = null;
+            if (env.REQUEST_METHOD !== "GET") {
+                changelock = fs.open(lockfile);
+                if (!(changelock && changelock.lock("x"))) {
+                    uhttpd.send("Status: 500 Internal server error\r\n\r\n");
+                    return;
+                }
+            }
             try {
                 res = render(call, fn, null, {
                     config: config,
@@ -596,6 +592,10 @@ global.handle_request = function(env)
                 log.syslog(log.LOG_ERR, `${e.message}\n${e.stacktrace[0].context}`);
                 res = `<div><b>ERROR: ${e.message}</b><div><pre>${e.stacktrace[0].context}</pre></div>`;
             }
+            if (changelock) {
+                changelock.lock("u");
+                changelock.close();
+            }
             if (!response.override) {
                 let gzip = false;
                 if (env.HTTP_ACCEPT_ENCODING && index(env.HTTP_ACCEPT_ENCODING, "gzip") !== -1 && config.compress) {
@@ -610,9 +610,6 @@ global.handle_request = function(env)
                     "\r\n",
                     res
                 );
-            }
-            if (changelock) {
-                changelock.close();
             }
             if (response.reboot) {
                 system(`(sleep 2; sync; ${response.reboot})&`);


### PR DESCRIPTION
Restrict the range of code where we include locking, and explicitly unlock in case the lock descriptor is being held open elsewhere (somehow).
