### PR TITLE
Bump restart timeouts so dnsmasq will respawn if it crashes.

### DIFF
--- a/patches/704-dnsmasq-restart.patch
+++ b/patches/704-dnsmasq-restart.patch
@@ -1,0 +1,11 @@
+--- a/package/network/services/dnsmasq/files/dnsmasq.init
++++ b/package/network/services/dnsmasq/files/dnsmasq.init
+@@ -1244,7 +1244,7 @@
+ 	procd_set_param command $PROG -C $CONFIGFILE -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid
+ 	procd_set_param file $CONFIGFILE
+ 	[ -n "$user_dhcpscript" ] && procd_set_param env USER_DHCPSCRIPT="$user_dhcpscript"
+-	procd_set_param respawn
++	procd_set_param respawn 1 5 50
+ 
+ 	local instance_ifc instance_netdev
+ 	config_get instance_ifc "$cfg" interface

--- a/patches/series
+++ b/patches/series
@@ -9,6 +9,7 @@
 702-enable-country-hx.patch
 703-disable-ipv6-dnsmasq.patch
 704-enable-telnet.patch
+704-dnsmasq-restart.patch
 705-aredn-banner.patch
 706-MeshNode-SSID.patch
 708-define-aredn-ath79-networks.patch


### PR DESCRIPTION
This is a workaround for dnsmasq crashing on supernodes.
Need a proper fix for that still.
