### PR TITLE
Restart lqm when tunnel configuration changes.

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -146,7 +146,8 @@ local changes = {
     localservices = false,
     wpad = false,
     poe = false,
-    pou = false
+    pou = false,
+    lqm = false
 }
 
 function valid_config(config)
@@ -1386,6 +1387,7 @@ do
         elseif file == "network" then
             changes.network = true
             changes.tunnels = true -- restarting network devices requires tunnels to restart
+            changes.lqm = true -- and lqm because device assignment could change
         elseif file == "dhcp" then
             changes.dnsmasq = true
         elseif file == "olsrd" then
@@ -1412,6 +1414,7 @@ do
             end
         elseif file == "vtun" then
             changes.tunnels = true
+            changes.lqm = true
         else
             changes.reboot = true
         end

--- a/files/usr/local/bin/restart-services.sh
+++ b/files/usr/local/bin/restart-services.sh
@@ -34,7 +34,7 @@ true <<'LICENSE'
 LICENSE
 
 ROOT="/tmp/reboot-required"
-SERVICES="log system firewall network wireless dnsmasq tunnels manager olsrd localservices poe pou ntp"
+SERVICES="log system firewall network wireless dnsmasq tunnels lqm manager olsrd localservices poe pou ntp"
 
 ignore=0
 force=0
@@ -85,6 +85,8 @@ do
       else
         /etc/init.d/sysntpd stop
       fi
+    elif [ $srv = "lqm" ]; then
+      touch /tmp/lqm.reset
     elif [ -x /etc/init.d/$srv ]; then
       /etc/init.d/$srv restart > /dev/null 2>&1
     fi


### PR DESCRIPTION
Tunnel devices can get reassigned when tunnel configuration changes so restart LQM otherwise it can get out of sync.
