### PR TITLE
Allow and ping and traceroute to auto select the best interface

### DIFF
--- a/files/www/cgi-bin/ping
+++ b/files/www/cgi-bin/ping
@@ -56,8 +56,7 @@ else
     if not server:match("%.") then
         server = server .. ".local.mesh"
     end
-    local ip = uci.cursor("/etc/config.mesh"):get("setup", "globals", "dtdlink_ip")
-    local running = io.popen("/bin/ping -c 5 -w 10 -I " .. ip .. " " .. server .. " 2>&1")
+    local running = io.popen("/bin/ping -c 5 -w 10 " .. server .. " 2>&1")
     if not running then
         print("<html><head><title>ERROR</title></head><body><pre>ping failed</pre></body></html>")
     else

--- a/files/www/cgi-bin/traceroute
+++ b/files/www/cgi-bin/traceroute
@@ -56,8 +56,7 @@ else
     if not server:match("%.") then
         server = server .. ".local.mesh"
     end
-    local ip = uci.cursor("/etc/config.mesh"):get("setup", "globals", "dtdlink_ip")
-    local running = io.popen("/bin/traceroute -q 1 -w 1 -s " .. ip .. " " .. server .. " 2>&1")
+    local running = io.popen("/bin/traceroute -q 1 -w 1 " .. server .. " 2>&1")
     if not running then
         print("<html><head><title>ERROR</title></head><body><pre>traceroute failed</pre></body></html>")
     else


### PR DESCRIPTION
Previously we forced these commands to use the dtdlink ip address as their source. However if this interface isn't actually up then this will fail. Instead let these command pick the best interface for them.