### PR TITLE
Improve firewalling of LAN

### DIFF
--- a/files/etc/hotplug.d/iface/11-meshrouting
+++ b/files/etc/hotplug.d/iface/11-meshrouting
@@ -13,7 +13,7 @@ if [ "$ACTION" = "ifdown" ] || [ "$ACTION" = "ifup" ] ; then
 
   echo "Deleting specific routing rules that may exist."
 
-  if [ "$INTERFACE" == "wifi" ] || [ "$INTERFACE" == "dtdlink" ] || [ "${INTERFACE:0:3}" == "tun" ] || [ "$xlink" != "" ] ; then
+  if [ "$INTERFACE" == "wifi" ] || [ "$INTERFACE" == "dtdlink" ] || [ "${INTERFACE:0:3}" == "tun" ] || [ "${INTERFACE:0:2}" = "wg" ] || [ "$xlink" != "" ] ; then
     ip rule del pref 20010 iif $DEVICE lookup 29
     ip rule del pref 20020 iif $DEVICE lookup 30
     ip rule del pref 20080 iif $DEVICE lookup 31
@@ -25,7 +25,10 @@ if [ "$ACTION" = "ifdown" ] || [ "$ACTION" = "ifup" ] ; then
     ip rule del pref 30010 iif $DEVICE lookup 29
     ip rule del pref 30020 iif $DEVICE lookup 30
     ip rule del pref 30090 iif $DEVICE lookup main
-    ip rule del pref 30099 iif $DEVICE lookup 31
+    # LAN can route over the mesh if it cannot route of WAN and it can have a default route
+    if [ $is_inet -ne 1 ] || [ $is_defaultrt -eq 1 ]; then
+      ip rule add pref 30099 iif $DEVICE lookup 31
+    fi
   fi
 
   if [ "$INTERFACE" == "loopback" ] ; then
@@ -39,7 +42,9 @@ fi
 
 if [ "$ACTION" = "ifup" ] ; then
 
-  is_olsrgw=$(/sbin/uci -q get aredn.@wan[0].olsrd_gw)
+  is_olsrgw=$(/sbin/uci -q get aredn.@wan[0].olsrd_gw) # MESH -> WAN
+  is_inet=$(/sbin/uci -q get aredn.@wan[0].lan_dhcp_route) # LAN -> WAN
+  is_defaultrt=$(/sbin/uci -q get aredn.@wan[0].lan_dhcp_defaultroute) # LAN default route
 
   # Set routes for wifi or device to device linking
   # unreachable rule is needed  to ensure packets do not traverse a rule later that considers routing to another network.

--- a/files/etc/hotplug.d/iface/11-meshrouting
+++ b/files/etc/hotplug.d/iface/11-meshrouting
@@ -25,10 +25,7 @@ if [ "$ACTION" = "ifdown" ] || [ "$ACTION" = "ifup" ] ; then
     ip rule del pref 30010 iif $DEVICE lookup 29
     ip rule del pref 30020 iif $DEVICE lookup 30
     ip rule del pref 30090 iif $DEVICE lookup main
-    # LAN can route over the mesh if it cannot route of WAN and it can have a default route
-    if [ $is_inet -ne 1 ] || [ $is_defaultrt -eq 1 ]; then
-      ip rule add pref 30099 iif $DEVICE lookup 31
-    fi
+    ip rule del pref 30099 iif $DEVICE lookup 31
   fi
 
   if [ "$INTERFACE" == "loopback" ] ; then
@@ -67,7 +64,10 @@ if [ "$ACTION" = "ifup" ] ; then
     ip rule add pref 30010 iif $DEVICE lookup 29
     ip rule add pref 30020 iif $DEVICE lookup 30
     ip rule add pref 30090 iif $DEVICE lookup main
-    ip rule add pref 30099 iif $DEVICE lookup 31
+    # LAN can route over the mesh if it cannot route of WAN and it can have a default route
+    if [ $is_inet -ne 1 ] && [ $is_defaultrt -eq 1 ]; then
+      ip rule add pref 30099 iif $DEVICE lookup 31
+    fi
 
     # Lets go ahead and set the route to the local network here since we only need to be able to route to it after the interface comes up.
     lan_ipaddr=$(uci -q get network.lan.ipaddr)


### PR DESCRIPTION
When LAN-to-WAN is enabled, we allow any LAN device to access the WAN. But if the WAN isn't active (e.g. not plugged in) the LAN traffic finds its way onto the Mesh looking for a Mesh WAN. This is not what we want. Routing table 31 contains the default route to the nearest WAN over the mesh, so we prevent the LAN from accessing this table unless a default route is enabled and LAN-to-WAN is disabled.

In the future we should redo these options to make it more clear what is going on.
