### PR TITLE
Fix layout of LAN type so it looks the same on all browsers

### DIFF
--- a/files/app/main/status/e/network.ut
+++ b/files/app/main/status/e/network.ut
@@ -214,8 +214,8 @@ const gateway_altnet = dmz_mode === 1 ? dhcp.gateway : "";
                     <div class="m">Type and size of LAN subnet</div>
                 </div>
                 <div style="flex:0">
-                    <select hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="dhcp_mode" {{_R("hideable-onselect")}}>
-                        <option value="0" {dmz_mode == 0 ? "selected" : ""}}>NAT</option>
+                    <select style="direction:ltr;text-align-last:right" hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="dhcp_mode" {{_R("hideable-onselect")}}>
+                        <option value="0" {{dmz_mode == 0 ? "selected" : ""}}>NAT</option>
                         <option value="1" {{dmz_mode == 1 ? "selected" : ""}}>44Net</option>
                         <option value="2" {{dmz_mode == 2 ? "selected" : ""}}>/30 (1 host)</option>
                         <option value="3" {{dmz_mode == 3 ? "selected" : ""}}>/29 (5 hosts)</option>


### PR DESCRIPTION
The layout of LAN type looked different on different browsers due to CSS incpompatibilies. Tweaked to be the same.