### PR TITLE
Older patch for Rocket 5AC Lite dts

### DIFF
--- a/patches/731-ag71xx-updates-and-fixes.patch
+++ b/patches/731-ag71xx-updates-and-fixes.patch
@@ -1,3 +1,19 @@
+--- a/target/linux/ath79/dts/qca9558_ubnt_rocket-5ac-lite.dts
++++ b/target/linux/ath79/dts/qca9558_ubnt_rocket-5ac-lite.dts
+@@ -35,4 +35,12 @@
+ 	nvmem-cell-names = "mac-address";
+ 	phy-mode = "sgmii";
+ 	phy-handle = <&phy4>;
++	pll-reg = <0 0x48 0>;
++	pll-data = <0x03000000 0x00000101 0x00001313>;
++
++	qca955x-sgmii-fixup;
++
++	gmac-config {
++		device = <&gmac>;
++	};
+ };
+
 --- a/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
 +++ b/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
 @@ -36,6 +35,14 @@


### PR DESCRIPTION
There was an old rocket 5ac patch in previous kernels what help the network work at full speed. Experiment with bringing it into this kernel to see if it fixes what may be ethernet issue with some rocket 5ac lite hardware.

Experimental.
