### PR TITLE
We no longer allow access to port 9090 from the mesh.

### DIFF
--- a/files/etc/config.mesh/firewall
+++ b/files/etc/config.mesh/firewall
@@ -244,21 +244,3 @@ config rule
 	option dest_port '161'
 	option proto 'udp'
 	option target 'ACCEPT'
-
-config rule
-	option src 'wifi'
-	option dest_port '9090'
-	option proto 'tcp'
-	option target 'ACCEPT'
-
-config rule
-	option src 'dtdlink'
-	option dest_port '9090'
-	option proto 'tcp'
-	option target 'ACCEPT'
-
-config rule
-	option src 'vpn'
-	option dest_port '9090'
-	option proto 'tcp'
-	option target 'ACCEPT'


### PR DESCRIPTION
This port goes straight to OLSR and has a habit of crashing it causing mesh instability.
Access to this data is provided via the sysinfo.json api.