### PR TITLE
Add Mesh PtP mode (like of Mesh PtMP mode)

### DIFF
--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -38,8 +38,9 @@ if (request.env.REQUEST_METHOD === "PUT") {
     const modemap = {
         "0": radios.RADIO_OFF,
         "1": radios.RADIO_MESH,
-        "4": radios.RADIO_MESHAP,
-        "5": radios.RADIO_MESHSTA,
+        "4": radios.RADIO_MESHPTMP,
+        "5": radios.RADIO_MESHPTP,
+        "6": radios.RADIO_MESHSTA,
         "2": radios.RADIO_LAN,
         "3": radios.RADIO_WAN
     };
@@ -56,7 +57,8 @@ if (request.env.REQUEST_METHOD === "PUT") {
     }
     switch (radio0_mode) {
         case radios.RADIO_MESH:
-        case radios.RADIO_MESHAP:
+        case radios.RADIO_MESHPTMP:
+        case radios.RADIO_MESHPTP:
         case radios.RADIO_MESHSTA:
             configuration.setSetting("radio0_mode", radio0_mode);
             if ("radio0_channel" in request.args) {
@@ -64,6 +66,9 @@ if (request.env.REQUEST_METHOD === "PUT") {
             }
             else if (!configuration.getSettingAsString("radio0_channel")) {
                 configuration.setSetting("radio0_channel", wlan[0].def.channel);
+            }
+            if ("radio0_peer" in request.args) {
+                configuration.setSetting("radio0_peer", request.args.radio0_peer);
             }
             if ("radio0_ssid" in request.args) {
                 configuration.setSetting("radio0_ssid", request.args.radio0_ssid);
@@ -117,7 +122,8 @@ if (request.env.REQUEST_METHOD === "PUT") {
     }
     switch (radio1_mode) {
         case radios.RADIO_MESH:
-        case radios.RADIO_MESHAP:
+        case radios.RADIO_MESHPTMP:
+        case radios.RADIO_MESHPTP:
         case radios.RADIO_MESHSTA:
             configuration.setSetting("radio1_mode", radio1_mode);
             if ("radio1_channel" in request.args) {
@@ -125,6 +131,9 @@ if (request.env.REQUEST_METHOD === "PUT") {
             }
             else if (!configuration.getSettingAsString("radio1_channel")) {
                 configuration.setSetting("radio1_channel", wlan[0].def.channel);
+            }
+            if ("radio1_peer" in request.args) {
+                configuration.setSetting("radio1_peer", request.args.radio1_peer);
             }
             if ("radio1_ssid" in request.args) {
                 configuration.setSetting("radio1_ssid", request.args.radio1_ssid);
@@ -247,7 +256,8 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                     const modemap = {
                         "mesh": 1,
                         "meshap": 4,
-                        "meshsta": 5,
+                        "meshptp": 5,
+                        "meshsta": 6,
                         "lan": 2,
                         "wan": 3
                     };
@@ -263,8 +273,9 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                     <select hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="{{prefix}}mode" {{_R("hideable-onselect")}}>
                         <option value="0" {{wlan[w].mode.mode === radios.RADIO_OFF ? "selected" : ""}}>Off</option>
                         <option value="1" {{wlan[w].mode.mode === radios.RADIO_MESH ? "selected" : ""}}>Mesh</option>
-                        <option value="4" {{wlan[w].mode.mode === radios.RADIO_MESHAP ? "selected" : ""}}>Mesh PtMP</option>
-                        <option value="5" {{wlan[w].mode.mode === radios.RADIO_MESHSTA ? "selected" : ""}}>Mesh Station</option>
+                        <option value="4" {{wlan[w].mode.mode === radios.RADIO_MESHPTMP ? "selected" : ""}}>Mesh PtMP</option>
+                        <option value="5" {{wlan[w].mode.mode === radios.RADIO_MESHPTP ? "selected" : ""}}>Mesh PtP</option>
+                        <option value="6" {{wlan[w].mode.mode === radios.RADIO_MESHSTA ? "selected" : ""}}>Mesh Station</option>
                         <option value="2" {{wlan[w].mode.mode === radios.RADIO_LAN ? "selected" : ""}}>LAN Hotspot</option>
                         <option value="3" {{wlan[w].mode.mode === radios.RADIO_WAN ? "selected" : ""}}>WAN Client</option>
                     </select>
@@ -272,7 +283,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
             </div>
             {{_H("Select the purpose of the radio. Each radio can be assigned to a specific purpose, but devices with multiple radios
             cannot have the same purpose for multiple radios (except <b>off</b>).")}}
-            <div class="hideable1 hideable4 hideable5" {{length(wlan) > 1 ? "style='padding-left:10px'" : ""}}>
+            <div class="hideable1 hideable4 hideable5 hideable6" {{length(wlan) > 1 ? "style='padding-left:10px'" : ""}}>
                 <div class="cols">
                     <div>
                         <div class="o">Channel</div>
@@ -308,6 +319,18 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                 </div>
                 {{_H("Select the bandwidth of the radio. Be aware that larger bandwidth settings will consume more channels. Avoid overlapping
                 channels as this will impact performance.")}}
+                <div class="cols peer hideable5">
+                    <div>
+                        <div class="o">Peer Node</div>
+                        <div class="m">MAC a&zwnj;ddress of remote Mesh Station</div>
+                    </div>
+                    <div style="flex:0">
+                        <input hx-put="{{request.env.REQUEST_URI}}" name="{{prefix}}peer" type="text" required placeholder="mac a&zwnj;ddress" pattern="([0-9a-fA-F][0-9a-fA-F]:){5}[0-9a-fA-F][0-9a-fA-F]" hx-validate="true" value="{{configuration.getSettingAsString(`${prefix}peer`, "")}}">
+                    </div>
+                </div>
+                <div class="peer hideable5">
+                {{_H("Specify the MAC a&zwnj;ddress of the node which is allowed to peer with this node. The other node must be configured as a Mesh Station.")}}
+                </div>
                 <div class="cols">
                     <div>
                         <div class="o">Transmit Power</div>
@@ -341,7 +364,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                             <div class="m">Distance to farthest neighbor in {{units.distanceUnit()}}</div>
                         </div>
                         <div style="flex:0">
-                            <input hx-put="{{request.env.REQUEST_URI}}" name="{{prefix}}distance" type="text" size="3" pattern="\d+" hx-validate="true" value="{{int(0.5 + units.meters2distance(configuration.getSettingAsInt("{{prefix}}distance", 0)))}}">
+                            <input hx-put="{{request.env.REQUEST_URI}}" name="{{prefix}}distance" type="text" size="3" pattern="\d+" hx-validate="true" value="{{int(0.5 + units.meters2distance(configuration.getSettingAsInt(`${prefix}distance`, 0)))}}">
                         </div>
                     </div>
                 </div>
@@ -642,7 +665,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
         const bws{{w}} = htmx.find(`#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_bandwidth]`);
         const bwssid{{w}} = htmx.find(`#ctrl-modal .dialog.radio-and-antenna input[name=radio{{w}}_ssid] + span`);
         function change{{w}}() {
-            if (radio{{w}}.value == "4" || radio{{w}}.value == "5") {
+            if (radio{{w}}.value == "4" || radio{{w}}.value == "5" || radio{{w}}.value == "6") {
                 bwssid{{w}}.innerHTML = `-${chan{{w}}.value}-${bws{{w}}.value}-v3`;
             }
             else {

--- a/files/app/main/tools/e/wifiscan.ut
+++ b/files/app/main/tools/e/wifiscan.ut
@@ -44,7 +44,7 @@ for (let i = 0; i < length(config); i++) {
     const mode = config[i].mode.mode;
     if (mode !== radios.RADIO_OFF) {
         count++;
-        if (selected === -1 || (mode == radios.RADIO_MESH || mode == radios.RADIO_MESHAP || mode == radios.RADIO_MESHSTA)) {
+        if (selected === -1 || (mode == radios.RADIO_MESH || mode == radios.RADIO_MESHPTMP || mode == radios.RADIO_MESHPTP || mode == radios.RADIO_MESHSTA)) {
             selected = i;
         }
     }
@@ -179,7 +179,8 @@ if (request.env.REQUEST_METHOD === "PUT") {
                     s.mode = "My Ad-Hoc Mesh";
                 }
                 break;
-            case radios.RADIO_MESHAP:
+            case radios.RADIO_MESHPTMP:
+            case radios.RADIO_MESHPTP:
                 if (s.joined) {
                     s.mode = "My Mesh Station";
                 }

--- a/files/app/partial/radio-and-antenna.ut
+++ b/files/app/partial/radio-and-antenna.ut
@@ -40,7 +40,8 @@
     for (let i = 0; i < length(radio); i++) {
         switch (radio[i].mode?.mode) {
             case radios.RADIO_MESH:
-            case radios.RADIO_MESHAP:
+            case radios.RADIO_MESHPTMP:
+            case radios.RADIO_MESHPTP:
             case radios.RADIO_MESHSTA:
                 midx = i;
                 break;
@@ -61,7 +62,7 @@
     </div>
     {% if (midx !== -1) {
         const r = radio[midx].mode; %}
-    <div class="section-title">{{r.mode === "mesh" ? "Mesh" : r.mode === "meshap" ? "Mesh PTMP" : "Mesh Station"}}</div>
+    <div class="section-title">{{r.mode === "mesh" ? "Mesh" : r.mode === "meshap" ? "Mesh PTMP" : r.mode === "meshptp" ? "Mesh PTP" : "Mesh Station"}}</div>
     <div class="section">
         <div class="cols">
             <div>

--- a/files/app/partial/tools.ut
+++ b/files/app/partial/tools.ut
@@ -46,7 +46,8 @@
             <div hx-trigger="click" hx-get="tools/e/wifiscan" hx-target="#ctrl-modal"><div class="icon signal"></div>WiFi Scan</div>
             {% }
             if (mode0 === radios.RADIO_MESH || mode1 === radios.RADIO_MESH ||
-                mode0 === radios.RADIO_MESHAP || mode1 === radios.RADIO_MESHAP ||
+                mode0 === radios.RADIO_MESHPTMP || mode1 === radios.RADIO_MESHPTMP ||
+                mode0 === radios.RADIO_MESHPTP || mode1 === radios.RADIO_MESHPTP ||
                 mode0 === radios.RADIO_MESHSTA || mode1 === radios.RADIO_MESHSTA) { %}
             <div hx-trigger="click" hx-get="tools/e/wifisignal" hx-target="#ctrl-modal"><div class="icon wifi"></div>WiFi Signal</div>
             {% }

--- a/files/app/resource/css/admin.css
+++ b/files/app/resource/css/admin.css
@@ -453,6 +453,7 @@ label.switch
 #ctrl-modal .hideable[data-hideable] > .hideable3,
 #ctrl-modal .hideable[data-hideable] > .hideable4,
 #ctrl-modal .hideable[data-hideable] > .hideable5,
+#ctrl-modal .hideable[data-hideable] > .hideable6,
 #ctrl-modal .hideable-g[data-hideable] .hideable0-g,
 #ctrl-modal .hideable-g[data-hideable] .hideable1-g
 {
@@ -466,6 +467,7 @@ label.switch
 #ctrl-modal .hideable[data-hideable="3"] > .hideable3,
 #ctrl-modal .hideable[data-hideable="4"] > .hideable4,
 #ctrl-modal .hideable[data-hideable="5"] > .hideable5,
+#ctrl-modal .hideable[data-hideable="5"] > .hideable6,
 #ctrl-modal .hideable-g[data-hideable="off"] .hideable0-g,
 #ctrl-modal .hideable-g[data-hideable="on"] .hideable1-g
 {
@@ -529,6 +531,19 @@ label.switch
 }
 
 /* control add/rm end */
+
+/* radio and network start */
+
+#ctrl-modal .radio-and-antenna .peer.hideable5
+{
+    display: none;
+}
+#ctrl-modal .radio-and-antenna .hideable[data-hideable="5"] .peer.hideable5
+{
+    display: flex;
+}
+
+/* radio and network end */
 
 /* dhcp start */
 

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -208,14 +208,14 @@ local mesh_channel = ""
 local mesh_chanbw = ""
 local mesh_txpower = nil
 local mesh_distance = ""
-if cfg.radio0_mode == "mesh" or cfg.radio0_mode == "meshap" or cfg.radio0_mode == "meshsta" then
+if cfg.radio0_mode == "mesh" or cfg.radio0_mode == "meshap" or cfg.radio0_mode == "meshptp" or cfg.radio0_mode == "meshsta" then
     mesh_wifi = "wlan0"
     mesh_channel = tonumber(cfg.radio0_channel)
     mesh_chanbw = tonumber(cfg.radio0_bandwidth)
     mesh_ssid = cfg.radio0_ssid
     mesh_txpower = tonumber(cfg.radio0_txpower)
     mesh_distance = tonumber(cfg.radio0_distance)
-elseif cfg.radio1_mode == "mesh" or cfg.radio1_mode == "meshap" or cfg.radio1_mode == "meshsta" then
+elseif cfg.radio1_mode == "mesh" or cfg.radio1_mode == "meshap" or cfg.radio1_mode == "meshptp" or cfg.radio1_mode == "meshsta" then
     mesh_wifi = "wlan1"
     mesh_channel = tonumber(cfg.radio1_channel)
     mesh_chanbw = tonumber(cfg.radio1_bandwidth)
@@ -942,7 +942,7 @@ do
             mode = "adhoc"
             encryption = "none"
             network = "wifi"
-        elseif cfg[radio .. "_mode"] == "meshap" then
+        elseif cfg[radio .. "_mode"] == "meshap" or cfg[radio .. "_mode"] == "meshptp" then
             -- mesh RF access point configuration
             is_mesh_rf = true
             channel = mesh_channel
@@ -956,12 +956,16 @@ do
             network = "wifi"
             celldensity = 2
             multicasttounicast=1
-            macfilter="deny"
+            if cfg[radio .. "_mode"] == "meshptp" then
+                macfilter="allow"
+            else
+                macfilter="deny"
+            end
             snrreject = tonumber(nc:get("aredn", "@lqm[0]", "min_snr")) - tonumber(nc:get("aredn", "@lqm[0]", "margin_snr"))
             -- Make AP's the best for better arednlink performance
             macaddr = read_all("/sys/class/ieee80211/" .. devname .. "/macaddress")
             if macaddr then
-                macaddr = macaddr:gsub("^..:", "fe:")
+                macaddr = macaddr:gsub("^..:", "fe:"):match("%S+")
                 isolate=1
             end
         elseif cfg[radio .. "_mode"] == "meshsta" then
@@ -1374,6 +1378,8 @@ local config_special = {
     wifi_mode_1 = c:get("wireless", "@wifi-iface[1]", "mode"),
     wifi_channel_0 = c:get("wireless", "@wifi-device[0]", "channel"),
     wifi_channel_1 = c:get("wireless", "@wifi-device[1]", "channel"),
+    wifi_macfilter_0 = c:get("wireless", "@wifi-device[0]", "macfilter"),
+    wifi_macfilter_1 = c:get("wireless", "@wifi-device[1]", "macfilter"),
     power_eth = c:get("aredn", "@poe[0]", "passthrough"),
     power_usb = c:get("aredn", "@usb[0]", "passthrough"),
     ntp_period = c:get("aredn", "@ntp[0]", "period")
@@ -1481,11 +1487,11 @@ do
             if oc:get("wireless", "@wifi-device[0]", "channel") ~= config_special.wifi_channel_0 or oc:get("wireless", "@wifi-device[1]", "channel") ~= config_special.wifi_channel_1 then
                 changes.manager = true
             end
-            if oc:get("wireless", "@wifi-iface[0]", "mode") ~= config_special.wifi_mode_0 or oc:get("wireless", "@wifi-iface[1]", "mode") ~= config_special.wifi_mode_1 then
+            if oc:get("wireless", "@wifi-iface[0]", "mode") ~= config_special.wifi_mode_0 or oc:get("wireless", "@wifi-iface[1]", "mode") ~= config_special.wifi_mode_1 or
+               oc:get("wireless", "@wifi-iface[0]", "macfilter") ~= config_special.wifi_macfilter_0 or oc:get("wireless", "@wifi-iface[1]", "macfilter") ~= config_special.wifi_macfilter_1 then
                 -- Only start the hostapd (etc) if we need to. This doesn't change what is currently running
                 -- only what automatically runs in the future
-                if oc:get("wireless", "@wifi-iface[0]", "mode") == "ap" or oc:get("wireless", "@wifi-iface[1]", "mode") == "ap" or
-                   oc:get("wireless", "@wifi-iface[0]", "mode") == "sta" or oc:get("wireless", "@wifi-iface[1]", "mode") == "sta" then
+                if oc:get("wireless", "@wifi-iface[0]", "mode") == "ap" or oc:get("wireless", "@wifi-iface[1]", "mode") == "ap" then
                     os.execute("/etc/init.d/wpad enable > /dev/null 2>&1")
                 else
                     os.execute("/etc/init.d/wpad disable > /dev/null 2>&1")

--- a/files/usr/share/ucode/aredn/radios.uc
+++ b/files/usr/share/ucode/aredn/radios.uc
@@ -37,7 +37,8 @@ import * as uci from "uci";
 
 export const RADIO_OFF = "off";
 export const RADIO_MESH = "mesh";
-export const RADIO_MESHAP = "meshap";
+export const RADIO_MESHPTMP = "meshap";
+export const RADIO_MESHPTP = "meshptp";
 export const RADIO_MESHSTA = "meshsta";
 export const RADIO_LAN = "lan";
 export const RADIO_WAN = "wan";
@@ -103,7 +104,7 @@ export function getActiveConfiguration()
             if (s.network === "wifi") {
                 switch (s.mode) {
                     case "ap":
-                        mmode.mode = RADIO_MESHAP;
+                        mmode.mode = s.macfilter === "allow" ? RADIO_MESHPTP : RADIO_MESHPTMP;
                         mdevice = s.device;
                         mmode.ssid = s.ssid;
                         break;


### PR DESCRIPTION
Allow to mesh node radios to be configured to *only* exchange data with each other.