### PR TITLE
Fixup the wifi address when missing

### DIFF
--- a/files/etc/hotplug.d/iface/01-wifi-fixup
+++ b/files/etc/hotplug.d/iface/01-wifi-fixup
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Wifi does not always get an IPv4 address. Until the root cause is identified, we will
+# fixup here.
+if [ "$ACTION" = "ifup" -a "$INTERFACE" = "wifi" -a "${DEVICE:0:4}" = "wlan" ] ; then
+  ip addr add $(uci get network.wifi.ipaddr)/32 broadcast 255.255.255.255 dev ${DEVICE}
+fi


### PR DESCRIPTION
For yet unknown reasons, the ipv4 wifi address can go missing when a node starts up. Until the root cause is determined, this script will make sure it is set.