### PR TITLE
Lower min_free_kbytes to 1M (from default of 16M)

### DIFF
--- a/files/etc/sysctl.d/01-vm.conf
+++ b/files/etc/sysctl.d/01-vm.conf
@@ -1,0 +1,3 @@
+# Default value is too high for our low memory devices,
+# so set this to 1M
+vm.min_free_kbytes=1024

--- a/patches/781-disable-lru-gen.patch
+++ b/patches/781-disable-lru-gen.patch
@@ -1,0 +1,13 @@
+--- a/target/linux/generic/config-6.6
++++ b/target/linux/generic/config-6.6
+@@ -3162,8 +3162,8 @@
+ # CONFIG_LPC_ICH is not set
+ # CONFIG_LPC_SCH is not set
+ # CONFIG_LP_CONSOLE is not set
+-CONFIG_LRU_GEN=y
+-CONFIG_LRU_GEN_ENABLED=y
++CONFIG_LRU_GEN=n
++CONFIG_LRU_GEN_ENABLED=n
+ # CONFIG_LRU_GEN_STATS is not set
+ # CONFIG_LSI_ET1011C_PHY is not set
+ CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity"

--- a/patches/series
+++ b/patches/series
@@ -11,7 +11,6 @@
 703-disable-ipv6-dnsmasq.patch
 704-enable-telnet.patch
 704-dnsmasq-fixes.patch
-#704-dnsmasq-mimalloc.patch
 705-aredn-banner.patch
 706-MeshNode-SSID.patch
 708-define-aredn-ath79-networks.patch


### PR DESCRIPTION
On low memory devices (<=32M) min_free_kbytes is set to 1M. On larger devices it is set to 16M. This is the memory the kernel keeps around for situations where it absolutely needs memory now or with crash. AREDN nodes are relatively stable memory wise, and this high limit is effectively reducing the memory we actually have to do work. So make it lower to improve stability.
