### PR TITLE
Fix dialog close race condition

### DIFF
--- a/files/app/partial/dialog-footer.ut
+++ b/files/app/partial/dialog-footer.ut
@@ -37,5 +37,5 @@
     {% if (inner !== "nocancel" && auth.isAdmin) { %}
     <button id="dialog-cancel" hx-delete="{{request.env.REQUEST_URI}}" hx-target="#changes" onclick="setTimeout(_ => document.getElementById('ctrl-modal').close(), 10)">Cancel</button>
     {% } %}
-    <button id="dialog-done" onclick="setTimeout(_ => document.getElementById('ctrl-modal').close(), 100)">Done</button>
+    <button id="dialog-done" onclick="htmx.find('#ctrl-modal').style.display='none';const f=()=>htmx.find('body.htmx-request')?setTimeout(f,10):(m=htmx.find('#ctrl-modal'),m.close(),m.style.display='');setTimeout(f,100)">Done</button>
 </div>


### PR DESCRIPTION
If the dialog closed before any pending response was received from the node, it was discarded so the commit/revert banner might not appeared.