### PR TITLE
Refix the LZ77 decompression for Mikrotik

### DIFF
--- a/patches/010-lz77-decompression-fix.patch
+++ b/patches/010-lz77-decompression-fix.patch
@@ -1,0 +1,16 @@
+--- a/target/linux/generic/files/drivers/platform/mikrotik/rb_hardconfig.c
++++ b/target/linux/generic/files/drivers/platform/mikrotik/rb_hardconfig.c
+@@ -592,12 +592,6 @@
+ 	ret = -ENODATA;
+ 	switch (magic) {
+ 	case RB_MAGIC_LZ77:
+-		/* no known instances of lz77 without 8001/8201 data, skip SOLO */
+-		if (tag_id == RB_WLAN_ERD_ID_SOLO) {
+-			pr_debug(RB_HC_PR_PFX "skipped LZ77 decompress in search for SOLO tag\n");
+-			break;
+-		}
+-		fallthrough;
+ 	case RB_MAGIC_LZOR:
+ 		/* Skip magic */
+ 		lbuf += sizeof(magic);
+

--- a/patches/series
+++ b/patches/series
@@ -1,6 +1,7 @@
 001-ath79-cpe220v3-sysupgrade-supported.patch
 001-wpad-changes.patch
 006-flash-fixes.patch
+010-lz77-decompression-fix.patch
 011-fix-e750-reset-5g-crash.patch
 100-remove-rcbutton-reset.patch
 101-opkg-useragent.patch


### PR DESCRIPTION
OpenWRT almost got it right, but made one bad assumption about what some devices need compared to the original code which didnt.