### PR TITLE
Babel Mesh Page: Improve grouping

### DIFF
--- a/files/app/partial/mesh-datab.ut
+++ b/files/app/partial/mesh-datab.ut
@@ -106,7 +106,7 @@ if (f) {
     for (let l = f.read("line"); length(l); l = f.read("line")) {
         const m = match(l, reRoute);
         if (m) {
-            print(`["${m[1]}",${sprintf("%.1f", m[2] / 200.0)}],`);
+            print(`["${m[1]}",${m[2]}],`);
         }
     }
     f.close();

--- a/files/app/partial/mesh.ut
+++ b/files/app/partial/mesh.ut
@@ -53,6 +53,7 @@
     </div>
 </div>
 <script>
+window.meshBlocks = [ 1, 2, 3, 5, 10, 1000 ];
 if (location.search) {
     const q = location.search.match(/^\?q=(.+)/);
     if (q) {

--- a/files/app/partial/meshb.ut
+++ b/files/app/partial/meshb.ut
@@ -53,6 +53,7 @@
     </div>
 </div>
 <script>
+window.meshBlocks = [ 500, 1000, 2000, 4000, 8000, 1000000 ];
 if (location.search) {
     const q = location.search.match(/^\?q=(.+)/);
     if (q) {

--- a/files/app/resource/css/user.css
+++ b/files/app/resource/css/user.css
@@ -926,51 +926,51 @@ body.authenticated .ctrl:hover
     color: var(--ctrl-modal-fg-help-color);
     font-size: calc(var(--font-base-size) - 4px);
 }
-.block1
+.block-excellent
 {
     border-color: var(--meshpage-block1-border-color);
 }
-.block2
+.block-good
 {
     border-color: var(--meshpage-block2-border-color);
 }
-.block3
+.block-fair
 {
     border-color: var(--meshpage-block3-border-color);
 }
-.block5
+.block-slow
 {
     border-color: var(--meshpage-block5-border-color);
 }
-.block10
+.block-poor
 {
     border-color: var(--meshpage-block10-border-color);
 }
-.block1000
+.block-improbable
 {
     border-color: var(--meshpage-block1000-border-color);
 }
-.block1 .label
+.block-excellent .label
 {
     background-color: var(--meshpage-block1-border-color);
 }
-.block2 .label
+.block-good .label
 {
     background-color: var(--meshpage-block2-border-color);
 }
-.block3 .label
+.block-fair .label
 {
     background-color: var(--meshpage-block3-border-color);
 }
-.block5 .label
+.block-slow .label
 {
     background-color: var(--meshpage-block5-border-color);
 }
-.block10 .label
+.block-poor .label
 {
     background-color: var(--meshpage-block10-border-color);
 }
-.block1000 .label
+.block-improbable .label
 {
     background-color: var(--meshpage-block1000-border-color);
 }

--- a/files/app/resource/js/meshpage.js
+++ b/files/app/resource/js/meshpage.js
@@ -91,12 +91,12 @@ function serv(ip, hostname)
 
 window.meshRender = function(first)
 {
-    const blocks = [ 1, 2, 3, 5, 10, 1000 ];
+    const blocks = [].concat(window.meshBlocks);
     const labels = [ "Excellent", "Good", "Fair", "Slow", "Poor", "Improbable" ];
     const etx = mesh.etx;
     const hosts = mesh.hosts;
 
-    let data = `<div class="block block1"><div class="label">${labels[0]}</div>`;
+    let data = `<div class="block block-excellent"><div class="label">${labels[0]}</div>`;
     for (let i = 0; i < etx.length; i++) {
         const item = etx[i];
         const ip = item[0];
@@ -109,7 +109,7 @@ window.meshRender = function(first)
                         blocks.shift();
                         labels.shift();
                     }
-                    data += `</div><div class="block block${blocks[0]}"><div class="label">${labels[0]}</div>`;
+                    data += `</div><div class="block block-${labels[0].toLowerCase()}"><div class="label">${labels[0]}</div>`;
                 }
                 let lanview = "";
                 for (let j = 0; j < hostlist.length; j++) {

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -1173,15 +1173,15 @@ if h and e then
     do
         local ip, host = line:match("(%S+)%s+(%S+)")
         if ip then
-            if not host:match("%.") then
-                host = host .. ".local.mesh"
-            end
-            h:write(ip .. "\t" .. host .. " #ALIAS\n")
             if is_nat_mode() then
                 ah:write(cfg.wifi_ip .. "\t" .. host .. "\n")
             else
                 ah:write(ip .. "\t" .. host .. "\n")
             end
+            if not host:match("%.") then
+                host = host .. ".local.mesh"
+            end
+            h:write(ip .. "\t" .. host .. " #ALIAS\n")
         end
     end
 


### PR DESCRIPTION
OLSR used ETX as a measurement of distance/availability for nodes and services. Babel doesnt do this because it uses different mechanisms for different link types when determining routing. All this information is reduced to a routing metric; the larger the more distance a resource is. We use this to order resources and include that information in the page.

Work in progress as we dont have a good handle comparing large this metric is and how likely and fast we can access a resource.