### PR TITLE
Only run wireless monitor in adhoc mode.

### DIFF
--- a/files/usr/local/bin/mgr/wireless_monitor.lua
+++ b/files/usr/local/bin/mgr/wireless_monitor.lua
@@ -298,6 +298,12 @@ function M.start_monitor()
         wifi_mode = c:get("wireless", "@wifi-iface[1]", "mode")
     end
 
+    if wifi_mode ~= "adhoc" then
+        nixio.syslog("err", "Only runs in adhoc mode")
+        exit_app()
+        return
+    end
+
     -- Select chipset
     if nixio.fs.stat("/sys/kernel/debug/ieee80211/" .. phy .. "/ath9k") then
         chipset = "ath9k"


### PR DESCRIPTION
The wireless monitor uses wifi scans to repair broken networks, but if the node is managed (not adhoc) this seems to actually break operational connections. So disable this feature in non-adhoc modes.