### PR TITLE
Disable wifi scan option for some mesh modes.

### DIFF
--- a/files/app/main/tools/e/wifiscan.ut
+++ b/files/app/main/tools/e/wifiscan.ut
@@ -42,9 +42,9 @@ let count = 0;
 let selected = -1;
 for (let i = 0; i < length(config); i++) {
     const mode = config[i].mode.mode;
-    if (mode !== radios.RADIO_OFF) {
+    if (mode === radios.RADIO_MESH || mode === radios.RADIO_LAN || mode === radios.RADIO_WAN) {
         count++;
-        if (selected === -1 || (mode == radios.RADIO_MESH || mode == radios.RADIO_MESHPTMP || mode == radios.RADIO_MESHPTP || mode == radios.RADIO_MESHSTA)) {
+        if (selected === -1 || mode == radios.RADIO_MESH) {
             selected = i;
         }
     }

--- a/files/app/partial/tools.ut
+++ b/files/app/partial/tools.ut
@@ -42,7 +42,9 @@
             {% const config = radios.getActiveConfiguration();
             const mode0 = config[0]?.mode?.mode;
             const mode1 = config[1]?.mode?.mode;
-            if (mode0 !== radios.RADIO_OFF || mode1 !== radios.RADIO_OFF) { %}
+            if (mode0 === radios.RADIO_MESH || mode1 === radios.RADIO_MESH ||
+                mode0 === radios.RADIO_LAN || mode1 === radios.RADIO_LAN || 
+                mode0 === radios.RADIO_WAN || mode1 === radios.RADIO_WAN) { %}
             <div hx-trigger="click" hx-get="tools/e/wifiscan" hx-target="#ctrl-modal"><div class="icon signal"></div>WiFi Scan</div>
             {% }
             if (mode0 === radios.RADIO_MESH || mode1 === radios.RADIO_MESH ||


### PR DESCRIPTION
It breaks some connections and requires a reboot to repair them.