### PR TITLE
Add a TODO to migrate legacy tunnels

### DIFF
--- a/files/usr/share/ucode/aredn/messages.uc
+++ b/files/usr/share/ucode/aredn/messages.uc
@@ -105,6 +105,19 @@ export function haveToDos()
             }
         }
     }
+    const mcursor = uci.cursor("/etc/config.mesh");
+    if (mcursor.get("vtun", "@client[0]")) {
+        return true;
+    }
+    let legacy = false;
+    cursor.foreach("vtun", "server", s => {
+        if (index(s.netip, ":") === -1) {
+            legacy = true;
+        }
+    });
+    if (legacy) {
+        return true;
+    }
     return false;
 };
 
@@ -114,6 +127,23 @@ export function getToDos()
     const todos = [];
     if (hardware.isLowMemNode()) {
         push(todos, "AREDN® is migrating to a new routing protocol called Babel. Unfortunately this node is too old to support this. We recommend you upgrade the hardware in the near future.");
+    }
+    else {
+        let legacy = false;
+        const cursor = uci.cursor("/etc/config.mesh");
+        if (cursor.get("vtun", "@client[0]")) {
+            legacy = true;
+        }
+        else {
+            cursor.foreach("vtun", "server", s => {
+                if (index(s.netip, ":") === -1) {
+                    legacy = true;
+                }
+            });
+        }
+        if (legacy) {
+            push(todos, "AREDN® is migrating to a new routing protocol called Babel. Unfortuntely this protocol cannot support old legacy tunnels. We recommend migrating these tunnels to Wireguard.");
+        }
     }
     if (!cursor.get("aredn", "@location[0]", "lat") || !cursor.get("aredn", "@location[0]", "lon")) {
         push(todos, "Set the latitude and longitude");


### PR DESCRIPTION
Legacy tunnels cannot support Babel, so add a TODO item on a node still using them encouraging the owner to migrate to Wireguard.