### PR TITLE
Dont allow new legacy tunnels

### DIFF
--- a/files/app/main/status/e/tunnels.ut
+++ b/files/app/main/status/e/tunnels.ut
@@ -288,10 +288,6 @@ function t2t(type)
                 <select style="direction:ltr">
                     <option value="wc">Wireguard Client</option>
                     <option value="ws">Wireguard Server</option>
-                    {% if (uciMesh.get("aredn", "@supernode[0]", "enable") !== "1") { %}
-                    <option value="lc">Legacy Client</option>
-                    <option value="ls">Legacy Server</option>
-                    {% } %}
                 </select>
             </div>
             <button>+</button>


### PR DESCRIPTION
Legacy tunnels cannot support Babel, so while we still support them, prevent people making new ones.