### PR TITLE
Do not forward AAAA requests upstream

### DIFF
--- a/patches/703-disable-ipv6-dnsmasq.patch
+++ b/patches/703-disable-ipv6-dnsmasq.patch
@@ -25,3 +25,19 @@
  
  ifeq ($(BUILD_VARIANT),nodhcpv6)
  	COPTS += -DNO_DHCP6
+--- /dev/null
++++ b/package/network/services/dnsmasq/patches/111.disable-ipv6-forwarding.patch
+@@ -0,0 +1,13 @@
++--- a/src/forward.c
+++++ b/src/forward.c
++@@ -302,6 +302,10 @@
++ 	  !strchr(daemon->namebuff, '.') &&
++ 	  strlen(daemon->namebuff) != 0)
++ 	flags = check_for_local_domain(daemon->namebuff, now) ? F_NOERR : F_NXDOMAIN;
+++
+++      /* Never forward AAAA */
+++      if (!flags && (gotname & F_IPV6) && !(gotname &= ~F_IPV6))
+++        flags = F_NOERR;
++       
++       /* Configured answer. */
++       if (flags || ede == EDE_NOT_READY)


### PR DESCRIPTION
AREDN doesnt use IPv6 addresses, and so forwarding AAAA DNS requests upstream can fail if the upstream doesn't handle them correctly. As we don't want these responses anyway, dont forward them and return an NOERROR response to the requester.

NOTES:

DNS clients should issue A and AAAA requests in parallel, but in reality many issue AAAA, wait for a response, then send an A request. If the AAAA response never arrives we end up with a delay until the client times out. This default timeout for many clients is 5 seconds. AREDN correctly handles AAAA so the lost responses are probably due to some upstream issues.

This *might* be why some people are seeing DNS delays on AREDN and some don't.