### PR TITLE
Stop upstreaming .local.mesh to DNS server

### DIFF
--- a/files/etc/dnsmasq.conf
+++ b/files/etc/dnsmasq.conf
@@ -8,6 +8,10 @@ expand-hosts
 # Never send any AAAA responses
 filter-AAAA
 
+# Domain + local (will not submit .local.mesh upstream) 
+domain=local.mesh
+local=/local.mesh/
+
 # Don't cache the errors
 no-negcache
 


### PR DESCRIPTION
adding the `local` value will stop DNSMASQ to send the mesh specific DNS resolution to upstream servers. This considerably reduce the number of requests made to upstream server and also reduce resolution time when upstream server is not responding.