### PR TITLE
Dont support some wifi modes on tiny builds

### DIFF
--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -261,11 +261,13 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                     <select hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="{{prefix}}mode" {{_R("hideable-onselect")}}>
                         <option value="0" {{mode === radios.RADIO_OFF ? "selected" : ""}}>Off</option>
                         <option value="1" {{mode === radios.RADIO_MESH ? "selected" : ""}}>Mesh</option>
+                        {% if (fs.access("/usr/sbin/hostapd")) { %}
                         <option value="4" {{mode === radios.RADIO_MESHPTMP ? "selected" : ""}}>Mesh PtMP</option>
                         <option value="5" {{mode === radios.RADIO_MESHPTP ? "selected" : ""}}>Mesh PtP</option>
                         <option value="6" {{mode === radios.RADIO_MESHSTA ? "selected" : ""}}>Mesh Station</option>
                         <option value="2" {{mode === radios.RADIO_LAN ? "selected" : ""}}>LAN Hotspot</option>
                         <option value="3" {{mode === radios.RADIO_WAN ? "selected" : ""}}>WAN Client</option>
+                        {% } %}
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
hostapd is necessary for non mesh wifi modes. If this isn't found (on tiny builds unless the package is explicitly installed) then dont offer the modes.