### PR TITLE
Fix exclusion of files in backup which are unnecessary.

### DIFF
--- a/files/usr/share/ucode/aredn/configuration.uc
+++ b/files/usr/share/ucode/aredn/configuration.uc
@@ -435,7 +435,7 @@ export function backup()
         return null;
     }
     for (let l = fi.read("line"); length(l); l = fi.read("line")) {
-        if (!match(l, "^#") && !match(l, "^/etc/config/") && fs.access(trim(l))) {
+        if (!match(l, "^#") && !match(l, /^\/etc\/config\//) && fs.access(trim(l))) {
             fo.write(l);
         }
     }


### PR DESCRIPTION
Backup included files from /etc/config which are just overwritten by files in /etc/config.mesh. It was harmless to include them but also pointless.