### PR TITLE
Restart arednlink when we restart babel.

### DIFF
--- a/files/usr/local/bin/restart-services.sh
+++ b/files/usr/local/bin/restart-services.sh
@@ -87,6 +87,11 @@ do
       fi
     elif [ $srv = "lqm" ]; then
       touch /tmp/lqm.reset
+    elif [ $srv = "babel" ]; then
+      if [ -x /etc/init.d/babel ]; then
+        /etc/init.d/babel restart > /dev/null 2>&1
+        /etc/init.d/arednlink restart > /dev/null 2>&1
+      fi
     elif [ $srv = "arednlink" ]; then
       if [ -x /usr/local/bin/arednlink ]; then
         /usr/local/bin/arednlink-update


### PR DESCRIPTION
Babel is restarted when the network is reconfigured. This can involved wireguard devices being reassigned to new connections and new address. This will confuse arednlink so just restart it (for the same reasons we restart babel).