### PR TITLE
Move DNS servers to the "wifi" network (wlanX or br-nomesh) so they're always active.

### DIFF
--- a/files/app/main/status/e/ports-and-xlinks.ut
+++ b/files/app/main/status/e/ports-and-xlinks.ut
@@ -189,7 +189,7 @@ config interface '${type}'
 ${type === "dtdlink" ? "\toption proto 'static'" : "\toption proto '<" + type + "_proto>'"}
 	option ipaddr '<${type}_ip>'
 ${type === "dtdlink" ? "\toption netmask '255.0.0.0'" : "\toption netmask '<" + type + "_mask>'"}
-${type === "wan" ? "\toption gateway '<wan_gw>'" : ""}${type === "lan" ? "\toption dns '<wan_dns1> <wan_dns2>'" : ""}
+${type === "wan" ? "\toption gateway '<wan_gw>'" : ""}
 `);
                     f.close();
                 }

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -499,7 +499,7 @@ for (let i = 0; i < length(cnetworks); i++) {
         let mtu = cfg[`${net}_mtu`] || "";
         let dns1 = "";
         let dns2 = "";
-        if (net == "lan") {
+        if (net == "wifi") {
             dns1 = cfg.wan_dns1 || "";
             dns2 = cfg.wan_dns2 || "";
         }


### PR DESCRIPTION
DNS servers are only made available on active networks. The default network had been "lan" but on some radios there might only be power. So move them to the "wifi" network, which is *always* up.