### PR TITLE
Missing tunnel endpoint when setting up firewall

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -607,6 +607,7 @@ cm.foreach("wireguard", "server",
             wgservers, client_priv, w, abcd[0], abcd[1], abcd[2], abcd[3] + 1, ll, (s.enabled == 1 ? "0" : "1"));
         cfg.wireguard_network_config += sprintf("config wireguard_wgs%d\n\toption public_key '%s'\n\toption endpoint_host '%s'\n\toption endpoint_port '%s'\n\toption persistent_keepalive '25'\n\tlist allowed_ips '0.0.0.0/0'\n\tlist allowed_ips '::/0'\n\n",
             wgservers, server_pub, s.host, p);
+        cfg.vpn_interfaces += `\tlist network 'wgs${wgservers}'\n`;
         wgservers++;
     }
 );


### PR DESCRIPTION
node-setup was re-written for a post-lua world. Mistakes were made. Here's another - the tunnel endpoint was missing for tunnel clients so no traffic could be forwarded over these connections. Fixed.