### PR TITLE
Fix generation of dtdmac

### DIFF
--- a/files/etc/mesh-release
+++ b/files/etc/mesh-release
@@ -1,1 +1,1 @@
-KN6PLV-babel-5ba28e5b
+KN6PLV-babel-f721f918

--- a/files/usr/local/bin/aredn_init
+++ b/files/usr/local/bin/aredn_init
@@ -127,10 +127,12 @@ if (wifi_mac == "" || mac2 == "") {
 if (dtdmac == "") {
     let m = null;
     for (let i = 0; i < 5; i++) {
-        m = match(hardware.getInterfaceMAC("br-lan"), /..:..:..:(..):(..):(..)/);
-        if (m) {
+        m = match(hardware.getInterfaceMAC("eth0"), /..:..:..:(..):(..):(..)/);
+        if (m && !(m[1] == "00" && m[2] == "00" && m[3] == "00")) {
             break;
         }
+        m = null;
+        sleep(2000);
     }
     if (m) {
         dtdmac = `${hex(m[1])}.${hex(m[2])}.${hex(m[3])}`;


### PR DESCRIPTION
dtdmac was often set to 0.0.0 which is both not random and wrong.