### PR TITLE
Make the Heltec HT-HD01 an alt name for the MorseMicro EKH03

### DIFF
--- a/patches/790-morsemicro-support.patch
+++ b/patches/790-morsemicro-support.patch
@@ -652,7 +652,7 @@
 + 
 --- a/target/linux/ramips/image/mt76x8.mk
 +++ b/target/linux/ramips/image/mt76x8.mk
-@@ -1189,3 +1189,21 @@
+@@ -1189,3 +1189,23 @@
  	check-size | zyimage -d 6162 -v "ZyXEL Keenetic Extra II"
  endef
  TARGET_DEVICES += zyxel_keenetic-extra-ii
@@ -661,6 +661,8 @@
 +  IMAGE_SIZE := 32448k
 +  DEVICE_VENDOR := MorseMicro
 +  DEVICE_MODEL := EKH03
++  DEVICE_ALT0_VENDOR := Heltec
++  DEVICE_ALT0_MODEL := HT-HD01
 +  DEVICE_VARIANT :=
 +  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
 +        kmod-mmc-mt7620 kmod-i2c-mt7628 \


### PR DESCRIPTION
This will make the device name find the correct firmware in the online firmware tool.