### PR TITLE
Reduce the files we keep in the backups.

### DIFF
--- a/files/etc/arednsysupgrade.conf
+++ b/files/etc/arednsysupgrade.conf
@@ -1,15 +1,5 @@
 # This file contains a list of files to retain over a sysupgrade with "Keep Settings" in the GUI.
 # This list will be used instead of the list normally used by sysupgrade.
-/etc/config/aredn
-/etc/config/dhcp
-/etc/config/dropbear
-/etc/config/firewall
-/etc/config/network
-/etc/config/snmpd
-/etc/config/system
-/etc/config/uhttpd
-/etc/config/vtun
-/etc/config/wireless
 /etc/config.mesh/setup
 /etc/config.mesh/vtun
 /etc/config.mesh/wireguard

--- a/files/usr/share/ucode/aredn/configuration.uc
+++ b/files/usr/share/ucode/aredn/configuration.uc
@@ -422,7 +422,7 @@ export function backup()
         return null;
     }
     for (let l = fi.read("line"); length(l); l = fi.read("line")) {
-        if (!match(l, "^#") && !match(l, /^\/etc\/config\//) && fs.access(trim(l))) {
+        if (!match(l, "^#") && fs.access(trim(l))) {
             fo.write(l);
         }
     }


### PR DESCRIPTION
We added /etc/config file into the backup in an attempt to speed up the update process by reducing the number of reboots. However, this rarely works as there's always some change during an update which makes the second reboot necessary. So, remove the /etc/config files as they serve no purpose.