### PR TITLE
Remove multicast_querier property.

### DIFF
--- a/files/app/main/status/e/ports-and-xlinks.ut
+++ b/files/app/main/status/e/ports-and-xlinks.ut
@@ -180,7 +180,6 @@ ${join("\n", map(keys(c.ports), p => "\tlist ports '" + p + (c.vlan ? ":t'" : ":
 config device
 	option name 'br-${type}'
 	option type 'bridge'
-	option multicast_querier '1'
 	option macaddr '<${type}_mac>'
 	list ports 'br0.${c.vlan ? c.vlan : type == "lan" ? 3 : 1}'
 

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -396,7 +396,7 @@ else {
             }
         }
     }
-    let config = "config device\n\toption name 'br0'\n\toption type 'bridge'\n\toption vlan_filtering '1'\n\toption multicast_querier '1'\n";
+    let config = "config device\n\toption name 'br0'\n\toption type 'bridge'\n\toption vlan_filtering '1'\n";
     for (let port in list) {
         config += `\tlist ports '${port}'\n`;
     }
@@ -509,7 +509,7 @@ for (let i = 0; i < length(cnetworks); i++) {
         
         config += "config device\n";
         if (!wireless) {
-            config += `\toption name 'br-${net}'\n\toption type 'bridge'\n\toption multicast_querier '1'\n`;
+            config += `\toption name 'br-${net}'\n\toption type 'bridge'\n`;
         }
         else {
             netmask = "255.255.255.255";


### PR DESCRIPTION
This was added when it looks like Babel needed it. It doesn't.