### PR TITLE
Handle Old UI wifi migration.

### DIFF
--- a/files/etc/uci-defaults/21_wifi_options
+++ b/files/etc/uci-defaults/21_wifi_options
@@ -97,8 +97,8 @@ else
         radio0_mode="off"
         radio1_mode="off"
         radio0_band=$(/sbin/uci -q get wireless.radio0.band)
-        if [ "${wifi_enable}" = "1" ]; then
-            wifi_intf=$(${UCIGET} setup.globals.wifi_intf)
+        wifi_intf=$(${UCIGET} setup.globals.wifi_intf)
+        if [ "${wifi_enable}" = "1" -a "${wifi_intf}" != "" ]; then
             if [ "${wifi_intf}" = "wlan0" ]; then
                 radio0_mode="mesh"
                 radio0_ssid="$(${UCIGET} setup.globals.wifi_ssid)"


### PR DESCRIPTION
The Old UI would sometimes disable the wifi mesh by setting the wifi_intf property to "" rather than setting the wifi_enable property to non-null. Handle this case.