### PR TITLE
Make sure DNS is always active on the node.

### DIFF
--- a/files/app/partial/network.ut
+++ b/files/app/partial/network.ut
@@ -64,17 +64,15 @@
             print("<div class='s'>wan gateway</div>");
             valueWan = true;
         }
-        if (validWan) {
-            let v = "-";
-            const dns = split(uci.get("network", "lan", "dns"), " ");
-            if (dns && dns[0]) {
-                v = dns[0];
-                if (dns[1]) {
-                    v += "&nbsp;&nbsp;&nbsp;" + dns[1];
-                }
+        let v = "-";
+        const dns = split(uci.get("network", "wifi", "dns"), " ");
+        if (dns && dns[0]) {
+            v = dns[0];
+            if (dns[1]) {
+                v += "&nbsp;&nbsp;&nbsp;" + dns[1];
             }
-            print("<div class='t'>" + v + "</div>");
-            print("<div class='s'>wan dns</div>")
         }
+        print("<div class='t'>" + v + "</div>");
+        print("<div class='s'>dns</div>")
     %}
 </div>

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -421,7 +421,7 @@ do
         local mtu = cfg[net .. "_mtu"] or ""
         local dns1 = ""
         local dns2 = ""
-        if net == "lan" then
+        if net == "wifi" then
             dns1 = cfg.wan_dns1 or ""
             dns2 = cfg.wan_dns2 or ""
         end


### PR DESCRIPTION
If the node was wifi-only (no network cable attached) then DNS would not come up correctly and non-AREDN names didnt resolve. Fix this by moving the dns names onto the wifi network (which is always up, even if we're using br-nomesh).
Already fixed in Babel version.