### PR TITLE
Allow ID beacon to be disabled.

### DIFF
--- a/files/app/main/status/e/internal-services.ut
+++ b/files/app/main/status/e/internal-services.ut
@@ -41,6 +41,9 @@ if (request.env.REQUEST_METHOD === "PUT") {
     if (request.args.iperf) {
         uciMesh.set("aredn", "@iperf[0]", "enable", request.args.iperf === "on" ? "1" : "0");
     }
+    if (request.args.beacon) {
+        uciMesh.set("aredn", "@beacon[0]", "enable", request.args.beacon === "on" ? "1" : "0");
+    }
     if (request.args.ssh_access) {
         uciMesh.set("aredn", "@wan[0]", "ssh_access", request.args.ssh_access === "on" ? "1" : "0");
     }
@@ -161,6 +164,16 @@ if (request.env.REQUEST_METHOD === "DELETE") {
             </div>
         </div>
         {{_H("Allow access to the node's web interface via the WAN network. Disabling this option will not prevent web acccess to the node from the mesh.")}}
+        <div class="cols">
+            <div>
+                <div class="o">ID Beacon</div>
+                <div class="m">Send an ID Beacon with your node's name and location</div>
+            </div>
+            <div style="flex:0">
+                {{_R("switch", { name: "beacon", value: uciMesh.get("aredn", "@beacon[0]", "enable") !== "0" })}}
+            </div>
+        </div>
+        {{_H("Allow a node to send an ID beacon containing the name and location. This is necessary in some regions to comply with local regulations.")}}
     {% if (hardware.supportsFeature("hw-watchdog")) { %}
         <div class="hideable" data-hideable='{{uciMesh.get("aredn", "@watchdog[0]", "enable") === "1" ? "on" : "off"}}'>
             <div class="cols">

--- a/files/app/partial/internal-services.ut
+++ b/files/app/partial/internal-services.ut
@@ -39,6 +39,7 @@
     const wd = uci.get("aredn", "@watchdog[0]", "enable") === "1" ? "active" : "disabled";
     const wwd = uci.get("aredn", "@wireless_watchdog[0]", "enable") === "1" ? "active" : "disabled";
     const ip = uci.get("aredn", "@iperf[0]", "enable") === "0" ? "disabled" : "active";
+    const be = uci.get("aredn", "@beacon[0]", "enable") !== "1" ? "disabled" : "active";
     const s = fs.stat("/tmp/metrics-ran");
     const mt = s && time() - s.mtime < 3600000 ? "active" : "inactive";
     const ws = "active";
@@ -74,5 +75,6 @@
         {% if (hardware.supportsFeature("usb-power")) { %}
         <div class="service"><div class="status {{pou}}"></div>USB power out</div>
         {% } %}
+        <div class="service"><div class="status {{be}}"></div>ID Beacon</div>
     </div>
 </div>

--- a/files/etc/uci-defaults/99_canonical_config
+++ b/files/etc/uci-defaults/99_canonical_config
@@ -66,6 +66,9 @@ function tunnelNetwork()
 const config = {
     aredn: {
         alerts: {},
+        beacon: {
+            enable: 1
+        },
         dmz: DELETE,
         downloads: {
             firmware_aredn: "http://downloads.arednmesh.org",

--- a/files/usr/local/bin/mgr/fccid.uc
+++ b/files/usr/local/bin/mgr/fccid.uc
@@ -32,6 +32,10 @@
  */
 
 const c = uci.cursor();
+
+if (c.get("aredn", "@beacon[0]", "enable") != "1") {
+    return exitApp();
+}
 const name = configuration.getName();
 if (!name) {
     return exitApp();

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -1313,7 +1313,8 @@ const special = {
     wifi_macfilter_1: c.get("wireless", "@wifi-device[1]", "macfilter"),
     power_eth: c.get("aredn", "@poe[0]", "passthrough"),
     power_usb: c.get("aredn", "@usb[0]", "passthrough"),
-    ntp_period: c.get("aredn", "@ntp[0]", "period")
+    ntp_period: c.get("aredn", "@ntp[0]", "period"),
+    beacon_enable: c.get("aredn", "@beacon[0]", "enable")
 };
 const nfiles = {};
 let d = fs.opendir("/tmp/new_config");
@@ -1362,6 +1363,9 @@ for (let file in nfiles) {
                 if (special.watchdog_enable != oc.get("aredn", "@watchdog[0]", "enable") ||
                     special.watchdog_pings != oc.get("aredn", "@watchdog[0]", "ping_addresses") ||
                     special.watchdog_daily != oc.get("aredn", "@watchdog[0]", "daily")) {
+                    changes.manager = true;
+                }
+                if (special.beacon_enable != oc.get("aredn", "@beacon[0]", "enable")) {
                     changes.manager = true;
                 }
                 if (special.web_access != oc.get("aredn", "@wan[0]", "web_access")) {


### PR DESCRIPTION
We beacon information about a node to comply with local regulations. You can now disable this if required.