### PR TITLE
PTxP fixes for what memory saving broke.

### DIFF
--- a/patches/714-disable-wpa-supplicant.patch
+++ b/patches/714-disable-wpa-supplicant.patch
@@ -1,11 +1,22 @@
 --- a/package/network/services/hostapd/files/wpad.init
 +++ b/package/network/services/hostapd/files/wpad.init
-@@ -24,7 +24,9 @@
+@@ -7,7 +7,9 @@
+ NAME=wpad
+ 
+ start_service() {
+-	if [ -x "/usr/sbin/hostapd" ]; then
++	if [ "$(uci -q get wireless.@wifi-iface[0].mode)" == "" -o "$(uci -q get wireless.@wifi-iface[0].mode)" == "sta" ] && [ "$(uci -q get wireless.@wifi-iface[0].encryption)" == "" -o "$(uci -q get wireless.@wifi-iface[0].encryption)" = "none" ] && [ "$(uci -q get wireless.@wifi-iface[1].mode)" == "" -o "$(uci -q get wireless.@wifi-iface[1].mode)" == "sta" ] && [ "$(uci -q get wireless.@wifi-iface[1].encryption)" = "" -o "$(uci -q get wireless.@wifi-iface[1].encryption)" == "none" ]; then
++		true # Don't run hostap to save some memory
++	elif [ -x "/usr/sbin/hostapd" ]; then
+ 		mkdir -p /var/run/hostapd
+ 		chown network:network /var/run/hostapd
+ 		procd_open_instance hostapd
+@@ -24,7 +26,9 @@
  		procd_close_instance
  	fi
  
 -	if [ -x "/usr/sbin/wpa_supplicant" ]; then
-+	if [ "$(uci -q get wireless.@wifi-iface[0].encryption)" == "" -o "$(uci -q get wireless.@wifi-iface[0].encryption)" = "none" ] && [ "$(uci -q get wireless.@wifi-iface[1].encryption)" = "" -o "$(uci -q get wireless.@wifi-iface[1].encryption)" == "none" ]; then
++	if [ "$(uci -q get wireless.@wifi-iface[0].mode)" == "" -o "$(uci -q get wireless.@wifi-iface[0].mode)" == "ap" ] && [ "$(uci -q get wireless.@wifi-iface[0].encryption)" == "" -o "$(uci -q get wireless.@wifi-iface[0].encryption)" = "none" ] && [ "$(uci -q get wireless.@wifi-iface[1].mode)" == "" -o "$(uci -q get wireless.@wifi-iface[1].mode)" == "ap" ] && [ "$(uci -q get wireless.@wifi-iface[1].encryption)" = "" -o "$(uci -q get wireless.@wifi-iface[1].encryption)" == "none" ]; then
 +		true # Don't run supplicant to save some memory
 +	elif [ -x "/usr/sbin/wpa_supplicant" ]; then
  		mkdir -p /var/run/wpa_supplicant


### PR DESCRIPTION
We previous disable wpa_supplicant for PTxP modes to save memory as we dont use encryption. However, stations still need it running to function so we cannot disable it for them. We can disable hostapd for stations so do that to save memory there.