### PR TITLE
Restore user blocks for all mesh types.

### DIFF
--- a/files/app/main/neighbor-device.ut
+++ b/files/app/main/neighbor-device.ut
@@ -73,7 +73,7 @@ if (tracker) {
     }
     neighbor = { name: tracker.hostname || `|${tracker.ip}`, n: tracker, l: null };
 }
-const showblock = auth.isAdmin && (neighbor && neighbor.n && neighbor.n.type == "RF") && (configuration.getSettingAsString("radio0_mode", "") === "meshap" || configuration.getSettingAsString("radio1_mode", "") === "meshap");
+const showblock = auth.isAdmin && neighbor?.n?.type == "RF";
 const supernode = (uciMesh.get("aredn", "@supernode[0]", "enable") === "1");
 %}
 <div class="dialog">

--- a/files/app/partial/network.ut
+++ b/files/app/partial/network.ut
@@ -44,7 +44,7 @@
         let validWan = false;
         const wan_proto = uci.get("network", "wan", "proto");
         if (wan_proto === "dhcp") {
-            const ifaces = ubus.call("network.interface", "dump").interface;
+            const ifaces = ubus.call("network.interface", "dump")?.interface;
             for (let i = 0; i < length(ifaces); i++) {
                 if (ifaces[i].interface === "wan" && ifaces[i]["ipv4-address"]) {
                     const wan = ifaces[i]["ipv4-address"][0];

--- a/files/usr/local/bin/mgr/lqm.uc
+++ b/files/usr/local/bin/mgr/lqm.uc
@@ -71,7 +71,7 @@ function updateConfig()
     const max_distance = cm.get("setup", "globals", `${radio}_distance`) || default_max_distance;
     config = {
         max_distance: max_distance > 0 ? max_distance : default_max_distance,
-        user_blocks: c.get("aredn", "@lqm[0]", "user_blocks") || ""
+        user_blocks: c.get("aredn", "@lqm[0]", "user_blocks")
     };
 }
 

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -1238,6 +1238,22 @@ if (h && e && ah) {
     ah.close();
 }
 
+// Generate user blocks
+const bd = fs.open("/tmp/babel-deny.conf", "w");
+if (bd) {
+    const blocks = split(cm.get("aredn", "@lqm[0]", "user_blocks"), ",");
+    for (let i = 0; i < length(blocks); i++) {
+        const mac = replace(replace(blocks[i], /[ \t]/, ""), "-", ":");
+        const ll = network.mac2ipv6ll(mac);
+        bd.write(`in anyproto neigh ${ll} deny\n`);
+    }
+    bd.close();
+    if (filecopy("/tmp/babel-deny.conf", "/var/run/babel-deny.conf")) {
+        changes.babel = true;
+    }
+    fs.unlink("/tmp/babel-deny.conf");
+}
+
 // Reset validation state when we regenerate configs
 services.resetValidation();
 

--- a/files/usr/share/ucode/aredn/configuration.uc
+++ b/files/usr/share/ucode/aredn/configuration.uc
@@ -51,7 +51,8 @@ const configDirs = [
     "/etc/local/uci",
     "/etc/aredn_include",
     "/etc/dropbear",
-    "/tmp"
+    "/tmp",
+    "/var/run"
 ];
 const configFiles = [
     "/etc/config.mesh/aredn",
@@ -77,7 +78,8 @@ const configFiles = [
     "/etc/aredn_include/lan.network.user",
     "/etc/aredn_include/wan.network.user",
     "/etc/dropbear/authorized_keys",
-    "/tmp/newpassword"
+    "/tmp/newpassword",
+    "/var/run/babel-deny.conf"
 ];
 
 function initCursor()


### PR DESCRIPTION
Restore user ability to block specific neighbor connections on a node. This was available in meshap mode, but is now generally available again by using babel to deny incoming routes from specified neighbors.