### PR TITLE
Add two more packages from feeds to make openwrt build stop complaining along with fixes for mikrotik and tplink units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ feeds-update: stamp-clean-feeds-updated .stamp-feeds-updated
 	cd $(OPENWRT_DIR); ./scripts/feeds uninstall -a
 	cd $(OPENWRT_DIR); ./scripts/feeds update -a
 	cd $(OPENWRT_DIR); ./scripts/feeds install libpam
+	cd $(OPENWRT_DIR); ./scripts/feeds install libev
+	cd $(OPENWRT_DIR); ./scripts/feeds install libtirpc
 	cd $(OPENWRT_DIR); ./scripts/feeds install libcap
 	cd $(OPENWRT_DIR); ./scripts/feeds install jansson
 	cd $(OPENWRT_DIR); ./scripts/feeds install libidn2

--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -576,7 +576,6 @@
   },
   "mikrotik lhg 5 ac (rblhgg-5acd)": {
     "maxpower": 25,
-    "exclude_bandwidths": [ 5 ],
     "antenna": {
       "description": "24.5 dBi 7&deg; Dish",
       "gain": 24.5,
@@ -585,7 +584,6 @@
   },
   "mikrotik lhg 5 ac xl (rblhgg-5acd-xl)": {
     "maxpower": 25,
-    "exclude_bandwidths": [ 5 ],
     "antenna": {
       "description": "27 dBi 7&deg; Dish",
       "gain": 27,

--- a/files/usr/local/bin/mgr/wireless_monitor.lua
+++ b/files/usr/local/bin/mgr/wireless_monitor.lua
@@ -93,7 +93,11 @@ function M.reset_network(mode)
         elseif mikrotik_ac then
             -- Only observered on Mikrotik AC devices
             os.execute(IW .. " " .. wifi .. " ibss leave > /dev/null 2>&1")
-            os.execute(IW .. " " .. wifi .. " ibss join " .. ssid .. " " .. frequency .. " HT20 fixed-freq > /dev/null 2>&1")
+            if nixio.fs.stat("/lib/firmware/ath10k/QCA4019") then
+              os.execute(IW .. " " .. wifi .. " ibss join " .. ssid .. " " .. frequency .. " NOHT fixed-freq > /dev/null 2>&1")
+            else
+              os.execute(IW .. " " .. wifi .. " ibss join " .. ssid .. " " .. frequency .. " HT20 fixed-freq > /dev/null 2>&1")
+            end
         else
             nixio.syslog("notice", "-- ignoring (mikrotik ac only)")
         end

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -970,6 +970,9 @@ do
             if nixio.fs.stat("/lib/firmware/ath10k/QCA9888") then
               htmode="NOHT"
             end
+            if nixio.fs.stat("/lib/firmware/ath10k/QCA4019") then
+              htmode="NOHT"
+            end
        elseif cfg[radio .. "_mode"] == "meshap" or cfg[radio .. "_mode"] == "meshptp" then
             -- mesh RF access point configuration
             is_mesh_rf = true

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -906,10 +906,7 @@ do
     else
         local is_mesh_rf = false
         local htmode = "HT20"
-        if nixio.fs.stat("/lib/firmware/ath10k/QCA9888") then
-            -- This chipset is used by TPLink devices, and they work better in NOHT mode
-            htmode = "NOHT"
-        elseif nixio.fs.stat("/sys/kernel/debug/ieee80211/" .. devname .. "/ath10k") then
+        if nixio.fs.stat("/sys/kernel/debug/ieee80211/" .. devname .. "/ath10k") then
             htmode = "VHT20"
             if wlan == mesh_wifi then
                 if mesh_chanbw == 40 then
@@ -970,7 +967,10 @@ do
             mode = "adhoc"
             encryption = "none"
             network = "wifi"
-        elseif cfg[radio .. "_mode"] == "meshap" or cfg[radio .. "_mode"] == "meshptp" then
+            if nixio.fs.stat("/lib/firmware/ath10k/QCA9888") then
+              htmode="NOHT"
+            end
+       elseif cfg[radio .. "_mode"] == "meshap" or cfg[radio .. "_mode"] == "meshptp" then
             -- mesh RF access point configuration
             is_mesh_rf = true
             channel = mesh_channel


### PR DESCRIPTION
The openwrt build complains these packages are missing.
Trivial change to the makefile to add them, just makes it look cleaner while building.

Worked on this more later, added some changes for TpLink CPE710.  NOHT is only needed for adhoc, not for sta and ap modes.  Moved qca9888 detection into the stanza for setting adhoc mode,  which leaves HT20 for sta and ap modes.  Makes a big difference in performance if using those modes.

Tested here in a 5 node mesh, 2 tplink, 2 ubiquiti and one mikrotik.

Added another set of changes, this time for the Mikrotik LHG 5 ac.  It suffers the exact same issue as the tplink unit did.  This change forces NOHT on the ipq4019 chipset, similar to the way it was done for the qca9888 on the tplink.

A happy side effect of this change, 5mhz channels work correctly now as well.

These changes are all extensively tested in adhoc, ap and sta modesm each with 5, 10 and 20mhz channel widths.  I am testing on a fully interconnected mesh that consists of 2 tplink cpe710, 1 ubiquiti litebeam 5 ac gen2, 1 ubiquiti rocket ac and one mikrotik lhg 5 ac xl.  Network is stressed by running multiple iperf runs across all link.

With NOHT forced for the qca9888 and ipq4019 in adhoc mode, the ath10k driver no longer abends when under load.

These fixes are a band-aid to deal with a driver issue.  Will see if we can fix the dirver in the near future and get the performance of HT20 back.


