### PR TITLE
Revert "Re-enable secondary wifi on Alfa AHM"

### DIFF
--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -1343,14 +1343,7 @@
       "bcf": "bcf_mf08551.bin"
     },
     "wlan1": {
-      "exclude_bandwidths": [ 5, 10 ],
-      "exclude_modes": [ "mesh", "meshap", "meshptp", "meshsta" ],
-      "maxpower": 20,
-      "antenna": {
-        "description": "Omni",
-        "gain": 0,
-        "beamwidth": 360
-      }
+      "disabled": true
     },
     "timeouts": {
       "reboot": [ 60, 240 ],


### PR DESCRIPTION
Reverts aredn/aredn#2377
The hardware exists, but the signal cannot seen outside the device, so there's probably no antenna.