### PR TITLE
Revert "Add video proxy packags to MorseMicro HaLowLink 1"

### DIFF
--- a/configs/ramips-mt7621-morse.config
+++ b/configs/ramips-mt7621-morse.config
@@ -17,8 +17,3 @@ CONFIG_PACKAGE_morse-led-artini=y
 CONFIG_PACKAGE_morse-regdb=y
 CONFIG_PACKAGE_mt7603e-txpat-artini=y
 CONFIG_PACKAGE_netifd-morse=y
-#
-# videoproxy
-#
-CONFIG_PACKAGE_ffmpeg=m
-CONFIG_PACKAGE_libx264=m


### PR DESCRIPTION
Reverts aredn/aredn#2381
ffmpeg generates assembly language incompatible with the target processor. Revert this until OpenWRT updates their ffmpeg implementation.