### PR TITLE
[BREAKING CHANGE] New format for SSID adhoc halow radios.

### DIFF
--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -250,6 +250,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                 const key_lan = mode == "lan" && key_decoded ? key_decoded : "AREDNmesh";
                 const key_wan = mode == "wan" && key_decoded ? key_decoded : "wifipassword";
                 const macaddress = wlan[w].macaddress;
+                const nochan = mode === radios.RADIO_MESH && hardware.getRadioType(wlan[w].iface) !== "halow";
     %}
         <div id="radio{{w}}" class="hideable compact" data-hideable="{{modemap[mode] || 0}}">
             <div class="cols">
@@ -367,7 +368,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                         <div class="m">AREDN mesh identifier</div>
                     </div>
                     <div style="flex:0;white-space:nowrap">
-                        <input hx-put="{{request.env.REQUEST_URI}}" name="{{prefix}}ssid" type="text" size="10" maxlength="20" pattern="[^!#;+\]\/"\t\-][^+\]\/"\t\-]{0,18}[^ !#;+\]\/"\t\-]$|^[^ !#;+\]\/"\t\-]" hx-validate="true" value="{{ssid_mesh}}"><span style="color:var(--ctrl-modal-fg-color)">{{mode === radios.RADIO_MESH ? "" : `-${channel}`}}-{{bandwidth}}-v3</span>
+                        <input hx-put="{{request.env.REQUEST_URI}}" name="{{prefix}}ssid" type="text" size="10" maxlength="20" pattern="[^!#;+\]\/"\t\-][^+\]\/"\t\-]{0,18}[^ !#;+\]\/"\t\-]$|^[^ !#;+\]\/"\t\-]" hx-validate="true" value="{{ssid_mesh}}"><span style="color:var(--ctrl-modal-fg-color)">{{nochan ? "" : `-${channel}`}}-{{bandwidth}}-v3</span>
                     </div>
                 </div>
                 {% if (hardware.supportsFeature("max-distance", wlan[w].iface)) { %}
@@ -549,6 +550,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
         const chan{{w}} = htmx.find("#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_channel]");
         const bws{{w}} = htmx.find(`#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_bandwidth]`);
         const bwssid{{w}} = htmx.find(`#ctrl-modal .dialog.radio-and-antenna input[name=radio{{w}}_ssid] + span`);
+        const halow{{w}} = {{hardware.getRadioType(wlan[w].iface) === "halow"}};
         function change{{w}}() {
             const bandwidth = parseInt(bws{{w}}.value);
             const channel = parseInt(chan{{w}}.value);
@@ -569,7 +571,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
             }
             chan{{w}}.value = nchannel;
             chan{{w}}.innerHTML = options;
-            if (radio{{w}}.value == "4" || radio{{w}}.value == "5" || radio{{w}}.value == "6") {
+            if (radio{{w}}.value == "4" || radio{{w}}.value == "5" || radio{{w}}.value == "6" || halow{{w}}) {
                 bwssid{{w}}.innerHTML = `-${nchannel}-${bandwidth}-v3`;
             }
             else {

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -961,7 +961,12 @@ for (let dev = 0; dev < ifacecount; dev++) {
             country = country ?? "HX";
             txpower = mesh_txpower;
             distance = mesh_distance;
-            ssid = `${mesh_ssid}-${chanbw}-v3`;
+            if (hwmode == "11ah") {
+                ssid = `${mesh_ssid}-${channel}-${chanbw}-v3`;
+            }
+            else {
+                ssid = `${mesh_ssid}-${chanbw}-v3`;
+            }
             mode = "adhoc";
             encryption = "none";
             network = "wifi";


### PR DESCRIPTION
Regardless of what channel is set in on halow radios in adhoc mode, they will attempt to join any SSID which matches. This is not what we want. Include the channel number in the SSID to prevent this. This is the same thing we do in AP/STA mode for non-halow radios.