### PR TITLE
Require a perfect LQ to trigger the babel monitor restart

### DIFF
--- a/files/etc/mesh-release
+++ b/files/etc/mesh-release
@@ -1,1 +1,1 @@
-KN6PLV-babel-f721f918
+KN6PLV-babel-39df733f

--- a/files/usr/local/bin/mgr/babel_monitor.uc
+++ b/files/usr/local/bin/mgr/babel_monitor.uc
@@ -35,7 +35,7 @@ import * as math from "math";
 import * as babel from "aredn.babel";
 
 const BAD_COST = 65535;
-const MIN_LQ = 50;
+const MIN_LQ = 99;
 
 function main()
 {


### PR DESCRIPTION
Better place to start this until we have more data.