### PR TITLE
Panic and reboot if we run out of memory

### DIFF
--- a/files/etc/sysctl.d/02-panic-on-oom.conf
+++ b/files/etc/sysctl.d/02-panic-on-oom.conf
@@ -1,0 +1,2 @@
+# If we run out of memory, panic and reboot in preference to killing random things.
+vm.panic_on_oom=2


### PR DESCRIPTION
Currently the Linux default is to kill random things when we run out of memory. This tends to result in partially working, partially broken nodes. Better to just reboot.