### PR TITLE
Make sure to run wpa_supplicant for open stations.

### DIFF
--- a/patches/714-disable-wpa-supplicant.patch
+++ b/patches/714-disable-wpa-supplicant.patch
@@ -1,6 +1,6 @@
 --- a/package/network/services/hostapd/files/wpad.init
 +++ b/package/network/services/hostapd/files/wpad.init
-@@ -7,7 +7,28 @@
+@@ -7,7 +7,21 @@
  NAME=wpad
  
  start_service() {
@@ -13,15 +13,8 @@
 +		fi
 +	fi
 +	if [ -x "/usr/sbin/wpa_supplicant" ]; then
-+		if [ "$(uci -q get wireless.@wifi-iface[0].mode)" = "sta" ]; then
-+			if [ "$(uci -q get wireless.@wifi-iface[0].encryption)" != "" ] && [ "$(uci -q get wireless.@wifi-iface[0].encryption)" != "none" ]; then
-+				run_wpa="yes"
-+			fi
-+		fi
-+		if [ "$(uci -q get wireless.@wifi-iface[1].mode)" = "sta" ]; then
-+			if [ "$(uci -q get wireless.@wifi-iface[1].encryption)" != "" ] && [ "$(uci -q get wireless.@wifi-iface[1].encryption)" != "none" ]; then
-+				run_wpa="yes"
-+			fi
++		if [ "$(uci -q get wireless.@wifi-iface[0].mode)" = "sta" ] || [ "$(uci -q get wireless.@wifi-iface[1].mode)" = "sta" ]; then
++			run_wpa="yes"
 +		fi
 +	fi
 +


### PR DESCRIPTION
Despite what the documenation claims, you still need to run wpa_supplicant for stations even with open security.