### PR TITLE
Drop babel monitor LQ requirement to 50%

### DIFF
--- a/files/usr/local/bin/mgr/babel_monitor.uc
+++ b/files/usr/local/bin/mgr/babel_monitor.uc
@@ -35,7 +35,7 @@ import * as fs from "fs";
 import * as babel from "aredn.babel";
 
 const BAD_COST = 65535;
-const MIN_LQ = 100;
+const MIN_LQ = 50;
 
 function ping(n)
 {


### PR DESCRIPTION
Link local ping is doing most of the protection work here, so LQ can be lower.