### PR TITLE
Drop babel monitor LQ requirement to 50%

### DIFF
--- a/files/usr/local/bin/mgr/babel_monitor.lua
+++ b/files/usr/local/bin/mgr/babel_monitor.lua
@@ -33,7 +33,7 @@
 --]]
 
 local BAD_COST = 65535
-local MIN_LQ = 100
+local MIN_LQ = 50
 
 local M = {};
 


### PR DESCRIPTION
Link local ping is doing most of the protection work here, so LQ can be lower.