### PR TITLE
Add missing gpsd packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ feeds-update: stamp-clean-feeds-updated .stamp-feeds-updated
 	cd $(OPENWRT_DIR); ./scripts/feeds install rpcapd
 	cd $(OPENWRT_DIR); ./scripts/feeds install usbutils
 	cd $(OPENWRT_DIR); ./scripts/feeds install ffmpeg
+	cd $(OPENWRT_DIR); ./scripts/feeds install gpsd
 	cd $(OPENWRT_DIR); ./scripts/feeds install -a -p morse
 	cd $(OPENWRT_DIR); ./scripts/feeds install -f -p morse iwinfo
 	cd $(OPENWRT_DIR); ./scripts/feeds install -f -p morse libiwinfo


### PR DESCRIPTION
OLSR pulled these in automatically, but now we need to do this explicitly.