### PR TITLE
Revert "Panic and reboot if we run out of memory"

### DIFF
--- a/files/etc/sysctl.d/02-panic-on-oom.conf
+++ b/files/etc/sysctl.d/02-panic-on-oom.conf
@@ -1,2 +1,0 @@
-# If we run out of memory, panic and reboot in preference to killing random things.
-vm.panic_on_oom=2


### PR DESCRIPTION
Reverts aredn/aredn#2408
This is interacting badly with wireguard for unknown reasons despite the nodes having lots of free memory, so revert for now.