### PR TITLE
Halow radios sometimes dont restart correctly. Make UI handle this.

### DIFF
--- a/files/usr/share/ucode/aredn/hardware.uc
+++ b/files/usr/share/ucode/aredn/hardware.uc
@@ -139,7 +139,7 @@ export function getRadioCount()
         return 1;
     }
     else {
-        return length(fs.lsdir("/sys/class/ieee80211") || []);
+        return fs.stat("/sys/class/ieee80211/phy0") ? length(fs.lsdir("/sys/class/ieee80211") || []) : 0;
     }
 };
 


### PR DESCRIPTION
Sometimes, particularly after an upgrade, the Halow radio doesnt restart correctly. Make sure the UI handles this.