### PR TITLE
Backport free memory changes from babel-only

### DIFF
--- a/files/app/main/status/e/firmware.ut
+++ b/files/app/main/status/e/firmware.ut
@@ -118,6 +118,10 @@
             const force = fs.access("/tmp/force-upgrade-this-is-dangerous") ? "--force" : "";
             return { upgrade: `/usr/local/bin/aredn_sysupgrade ${firstuse} ${force} ${firmwarefile}` };
         }
+        else {
+            fs.writefile("/proc/sys/vm/min_free_kbytes", fs.readfile("/tmp/min_free_kbytes"));
+            fs.unlink("/tmp/min_free_kbytes");
+        }
         return { error: error };
     };
     function shutdownServices()
@@ -170,7 +174,12 @@
         return;
     }
     else if (request.env.REQUEST_METHOD === "POST") {
-        if (request.args.sideload) {
+        if (request.args.updating) {
+            fs.writefile("/tmp/min_free_kbytes", fs.readfile("/proc/sys/vm/min_free_kbytes"));
+            fs.writefile("/proc/sys/vm/min_free_kbytes", "512");
+            fs.writefile("/proc/sys/vm/drop_caches", "3");
+        }
+        else if (request.args.sideload) {
             const upgrade = prepareUpgrade("/tmp/local_firmware");
             if (upgrade.error) {
                 print(`<div id="dialog-messages-error" hx-swap-oob="true">ERROR: ${upgrade.error}</div>`);
@@ -697,6 +706,12 @@
             const upload = htmx.find("#upload-firmware").files[0];
             const download = htmx.find("#download-firmware").value;
             const restore = htmx.find("#restore-config").files[0];
+            htmx.ajax("POST", "{{request.env.REQUEST_URI}}", {
+                values: {
+                    updating: 1
+                },
+                swap: "none"
+            });
             if ({{sideload || false}}) {
                 htmx.ajax("POST", "{{request.env.REQUEST_URI}}", {
                     values: {

--- a/files/etc/sysctl.d/01-vm.conf
+++ b/files/etc/sysctl.d/01-vm.conf
@@ -1,2 +1,0 @@
-# Default value is too high for our low memory devices, so set this to 512K
-vm.min_free_kbytes=512


### PR DESCRIPTION
Better balance memory needed when the node is operating vs upgrading.