### PR TITLE
Fix watchdog out-of-bound array access

### DIFF
--- a/files/usr/local/bin/mgr/hw_watchdog.uc
+++ b/files/usr/local/bin/mgr/hw_watchdog.uc
@@ -153,7 +153,7 @@ function main()
         // Check we can reach any of the ping addresses
         // We cycle over them one per iteration so as not to consume too much time
         pingIndex++;
-        if (pingIndex > length(config.pings)) {
+        if (pingIndex >= length(config.pings)) {
             pingIndex = 0;
         }
         const target = config.pings[pingIndex];


### PR DESCRIPTION
This was crashing two KK6UC nodes :(

Original log (reformatted)
```
Oct  9 15:36:07 KK6UC-SANDIEGO-SUPERNODE manager.hw_watchdog.uc[1799]: tick set to 60
Oct  9 15:36:08 KK6UC-SANDIEGO-SUPERNODE manager.hw_watchdog.uc[1799]: Exception: left-hand side expression is null -- [ { "filename": "/usr/local/bin/mgr/hw_watchdog.uc", "line": 161, "byte": 67, "function": "main", "context": "In main(), file /usr/local/bin/mgr/hw_watchdog.uc, line 161, byte 67:
  called from function call ([C])
  called from function [anonymous function] (/usr/local/bin/manager:130:69)
  called from function run ([C])
  called from anonymous function (/usr/local/bin/manager:168:11)

 `        if (system(`${PING} -c 1 -A -q -W ${pingTimeout} ${target.address} > /dev/null 2>&1`) == 0) {`
  Near here --------------------------------------------------------^
" }, { "function": "call" }, { "filename": "/usr/local/bin/manager", "line": 130, "byte": 69, "function": "[anonymous function]" }, { "function": "run" }, { "filename": "/usr/local/bin/manager", "line": 168, "byte": 11 } ]
```