### PR TITLE
Watchdog uses the default timeout rather than setting its own.

### DIFF
--- a/files/usr/local/bin/mgr/hw_watchdog.uc
+++ b/files/usr/local/bin/mgr/hw_watchdog.uc
@@ -43,7 +43,7 @@ let tick = 60;
 const pingTimeout = 3;
 const startupDelay = 600;
 const maxLastPing = 300;
-const maxWatchdogTimeout = 300;
+const minWatchdogTimeout = 15;
 
 // Set of daemons to monitor
 const defaultDaemons = "dnsmasq telnetd dropbear uhttpd babeld";
@@ -217,15 +217,17 @@ return waitForTicks(max(0, startupDelay - clock(true)[0]), function() {
         return exitApp();
     }
 
-    // Try to set the watchdog timeout, then make sure we tick no less than twice per timeout period
-    // PROBLEMS: The problem here is that some watchdogs dont honor the time we set but dont error either.
-    // To make it worse when we read the time back, they will read back the time we set even if they're not
-    // using it. There's not much we can do except use a conservative 'maxWatchdogTimeout' and do the right
-    // thing here in the hope that *some* driver do this correctly.
-    const settime = struct.pack("I", maxWatchdogTimeout);
-    wd.ioctl(fs.IOC_DIR_RW, WATCHDOG_IOCTL_BASE, WDIOC_SETTIMEOUT, settime);
+    // We cannot reliably set the timeout so we are forced to work with whatever the default value is.
+    // If the value is too small we disable the watchdog.
     const gettime = struct.unpack("I", wd.ioctl(fs.IOC_DIR_READ, WATCHDOG_IOCTL_BASE, WDIOC_GETTIMEOUT, 4))[0];
     tick = min(tick, int(gettime / 2));
+    if (tick < minWatchdogTimeout) {
+        log.syslog(log.LOG_ERROR, `tick ${tick} < ${minWatchdogTimeout}, disabling watchdog`);
+        wd.write("V");
+        wd.flush();
+        wd.close();
+        return exitApp();
+    }
     log.syslog(log.LOG_DEBUG, `tick set to ${tick}`);
 
     return main;


### PR DESCRIPTION
There seems to be no reliable way to set the watchdog timeout despite there being an API for this. Too many hardware implementations simply use the value passed unchecked resulting in unexpected behavior. Worse, the timeout read api will report back the set value even when its wrongly set or ignored.

So, the only portable solution is to use the default value, but disable the watchdog if that's so low it'd be unworkable for us. This is what the old lua code did but for different reasons.

Maybe we can revisit this with custom known working values on specific hardware - but not now.