### PR TITLE
Allow mesh for HaLowLink1 2.4ghz

### DIFF
--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -1295,7 +1295,7 @@
     },
     "wlan1": {
       "exclude_bandwidths": [ 5, 10 ],
-      "exclude_modes": [ "mesh", "meshap", "meshptp", "meshsta" ],
+      "exclude_modes": [ "meshap", "meshptp", "meshsta" ],
       "maxpower": 20,
       "antenna": {
         "description": "3.5 dBi Omni",


### PR DESCRIPTION
Allow mesh mode on the HaLowLink 1's 2.4Ghz Interface.

Tested for 24hrs with 2 nodes works perfectly for VoIP.