### PR TITLE
Restart babel when we restart the network.

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -1412,6 +1412,7 @@ for (let file in nfiles) {
             }
             case "network":
                 changes.network = true;
+                changes.babel = true;
                 changes.lqm = true; // and lqm because device assignment could change
                 break;
             case "dhcp":


### PR DESCRIPTION
We shouldnt need to do this but babel can become upset sometimes and get stuck spinning