### PR TITLE
Improve when we display message about poor tunnel performance.

### DIFF
--- a/files/usr/local/bin/mgr/lqm.uc
+++ b/files/usr/local/bin/mgr/lqm.uc
@@ -283,7 +283,8 @@ function main()
                             device: m[2],
                             mac: mac,
                             ipv6ll: m[1],
-                            refresh: 0
+                            refresh: 0,
+                            avg_lq: 100
                         };
                         if (type === "RF") {
                             track.mode = radioMode;
@@ -298,6 +299,7 @@ function main()
                         if (rtt) {
                             track.rtt = int(rtt[1]);
                         }
+                        track.avg_lq = min(100, 0.9 * track.avg_lq + 0.1 * track.lq);
                     }
                 }
             }

--- a/files/usr/share/ucode/aredn/messages.uc
+++ b/files/usr/share/ucode/aredn/messages.uc
@@ -126,11 +126,11 @@ export function getAlerts()
         {
             const tracker = trackers[mac];
             if (tracker.type === "Wireguard" && tracker.lastseen + 120 >= now) {
-                total += tracker.lq;
+                total += tracker.avg_lq;
                 count++;
             }
         }
-        if (count > 0 && total / count < 90) {
+        if (count > 0 && total / count < 85) {
             push(alerts, "Some tunnel rx values are lower than ideal. You may need to reduce the number of tunnels hosted by this node.");
         }
     }


### PR DESCRIPTION
Use a running average so we dont display the message for momentary spikes.