### PR TITLE
fix europe/istanbul's time zone

### DIFF
--- a/files/etc/zoneinfo
+++ b/files/etc/zoneinfo
@@ -308,7 +308,7 @@ Europe/Gibraltar	CET-1CEST,M3.5.0,M10.5.0/3
 Europe/Guernsey	GMT0BST,M3.5.0/1,M10.5.0
 Europe/Helsinki	EET-2EEST,M3.5.0/3,M10.5.0/4
 Europe/Isle_of_Man	GMT0BST,M3.5.0/1,M10.5.0
-Europe/Istanbul	EET-2EEST,M3.5.0/3,M10.5.0/4
+Europe/Istanbul	TRT-3
 Europe/Jersey	GMT0BST,M3.5.0/1,M10.5.0
 Europe/Kaliningrad	EET-2EEST,M3.5.0,M10.5.0/3
 Europe/Kiev	EET-2EEST,M3.5.0/3,M10.5.0/4


### PR DESCRIPTION
Hi, Europe/Istanbul time zone changed to UTC+3 in 2016. Daylight saving time has not been implemented for more than 10 years and is permanent. Unfortunately, some software still has old version. The official law document is [available here.](https://www.resmigazete.gov.tr/eskiler/2016/09/20160908-2.pdf) (Turkish) I arranged it this way because TRT-3 (Turkey time) is suitable according to Posix standards. Many people miss it and use it with the wrong time or have to choose a different time zone. It would be great to fix it.

Thank you in advance
Best regards