### PR TITLE
Auto-adjust WireGuard MTU on interface bring-up to handle low-MTU uplinks (#2594)

### DIFF
--- a/files/etc/hotplug.d/iface/15-fixwgmtu
+++ b/files/etc/hotplug.d/iface/15-fixwgmtu
@@ -48,22 +48,24 @@ find_good_mtu() {
     high="$START_MTU"
     best="$MIN_OUTER_MTU"
 
+    # Phase 1: coarse binary search on 40-byte boundaries
     while [ "$low" -le "$high" ]; do
         mid=$(( (low + high) / 2 ))
-        mid=$(( mid - (mid % 20) ))
+        mid=$(( mid - (mid % 40) ))
 
         [ "$mid" -lt "$MIN_OUTER_MTU" ] && mid="$MIN_OUTER_MTU"
 
         if test_ping_mtu "$target" "$mid"; then
             best="$mid"
-            low=$((mid + 20))
+            low=$((mid + 40))
         else
-            high=$((mid - 20))
+            high=$((mid - 40))
         fi
     done
 
-    start=$((best - 30))
-    end=$((best + 30))
+    # Phase 2: refine around coarse result on 10-byte boundaries
+    start=$((best - 40))
+    end=$((best + 40))
 
     [ "$start" -lt "$MIN_OUTER_MTU" ] && start="$MIN_OUTER_MTU"
     [ "$end" -gt "$START_MTU" ] && end="$START_MTU"
@@ -87,7 +89,6 @@ find_good_mtu() {
 get_real_dev() {
     iface="$1"
 
-    # Hardcode common OpenWrt/AREDN logical WAN bridge
     if [ "$iface" = "wan" ] && [ -d /sys/class/net/br-wan ]; then
         echo "br-wan"
         return 0

--- a/files/etc/hotplug.d/iface/15-fixwgmtu
+++ b/files/etc/hotplug.d/iface/15-fixwgmtu
@@ -28,7 +28,6 @@ test_normal_ping() {
     ping -c 1 -W 3 "$target" >/dev/null 2>&1
 }
 
-# Test with a given MTU-sized packet using DF
 test_ping_mtu() {
     target="$1"
     mtu="$2"
@@ -36,18 +35,6 @@ test_ping_mtu() {
 
     [ "$payload" -le 0 ] && return 1
 
-    # BusyBox ping on many OpenWrt builds supports -M do, but not all.
-    # Try DF first; if the ping app doesn't support it, fall back to normal sized ping.
-    ping -c 1 -W 3 -M do -s "$payload" "$target" >/dev/null 2>&1
-    rc=$?
-
-    # If ping returned failure, try to detect whether -M is unsupported.
-    # This avoids falsely treating "unknown option" as path MTU failure.
-    if ping -h 2>&1 | grep -q -- '[-]M'; then
-        return $rc
-    fi
-
-    # No -M support; just try sized ping
     ping -c 1 -W 3 -s "$payload" "$target" >/dev/null 2>&1
     return $?
 }

--- a/files/etc/hotplug.d/iface/15-fixwgmtu
+++ b/files/etc/hotplug.d/iface/15-fixwgmtu
@@ -2,9 +2,12 @@
 
 LOGGER_TAG="fixwgmtu"
 GOOGLE_TARGET="8.8.8.8"
+
 START_MTU=1500
-MIN_MTU=1000
-STEP=20
+MIN_OUTER_MTU=1000
+WG_MIN_MTU=1280
+WG_OVERHEAD=80
+
 SLEEP_SECS=5
 
 log_msg() {
@@ -17,12 +20,10 @@ get_asn_org() {
         | head -n 1
 }
 
-# Convert MTU to ping payload for IPv4
 mtu_to_payload() {
     echo $(( $1 - 28 ))
 }
 
-# Test "normal" ping first (no DF logic, just basic reachability)
 test_normal_ping() {
     target="$1"
     ping -c 1 -W 3 "$target" >/dev/null 2>&1
@@ -33,6 +34,7 @@ test_ping_mtu() {
     mtu="$2"
     payload="$(mtu_to_payload "$mtu")"
 
+    [ -z "$payload" ] && return 1
     [ "$payload" -le 0 ] && return 1
 
     ping -c 1 -W 3 -s "$payload" "$target" >/dev/null 2>&1
@@ -41,23 +43,74 @@ test_ping_mtu() {
 
 find_good_mtu() {
     target="$1"
-    mtu="$START_MTU"
 
-    while [ "$mtu" -ge "$MIN_MTU" ]; do
-        if test_ping_mtu "$target" "$mtu"; then
-            echo "$mtu"
-            return 0
+    low="$MIN_OUTER_MTU"
+    high="$START_MTU"
+    best="$MIN_OUTER_MTU"
+
+    while [ "$low" -le "$high" ]; do
+        mid=$(( (low + high) / 2 ))
+        mid=$(( mid - (mid % 20) ))
+
+        [ "$mid" -lt "$MIN_OUTER_MTU" ] && mid="$MIN_OUTER_MTU"
+
+        if test_ping_mtu "$target" "$mid"; then
+            best="$mid"
+            low=$((mid + 20))
+        else
+            high=$((mid - 20))
         fi
-        mtu=$((mtu - STEP))
     done
 
-    echo "$MIN_MTU"
+    start=$((best - 30))
+    end=$((best + 30))
+
+    [ "$start" -lt "$MIN_OUTER_MTU" ] && start="$MIN_OUTER_MTU"
+    [ "$end" -gt "$START_MTU" ] && end="$START_MTU"
+
+    fine_best="$MIN_OUTER_MTU"
+    i="$start"
+    while [ "$i" -le "$end" ]; do
+        probe=$(( i - (i % 10) ))
+
+        if test_ping_mtu "$target" "$probe"; then
+            fine_best="$probe"
+        fi
+
+        i=$((i + 10))
+    done
+
+    echo "$fine_best"
+    return 0
+}
+
+get_real_dev() {
+    iface="$1"
+
+    # Hardcode common OpenWrt/AREDN logical WAN bridge
+    if [ "$iface" = "wan" ] && [ -d /sys/class/net/br-wan ]; then
+        echo "br-wan"
+        return 0
+    fi
+
+    if [ -d "/sys/class/net/$iface" ]; then
+        echo "$iface"
+        return 0
+    fi
+
+    dev="$(ifstatus "$iface" 2>/dev/null | sed -n 's/.*"l3_device"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+    [ -n "$dev" ] && [ -d "/sys/class/net/$dev" ] && { echo "$dev"; return 0; }
+
+    dev="$(ifstatus "$iface" 2>/dev/null | sed -n 's/.*"device"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+    [ -n "$dev" ] && [ -d "/sys/class/net/$dev" ] && { echo "$dev"; return 0; }
+
     return 1
 }
 
 get_iface_current_mtu() {
     iface="$1"
-    cat "/sys/class/net/$iface/mtu" 2>/dev/null
+    realdev="$(get_real_dev "$iface")" || return 1
+    cat "/sys/class/net/$realdev/mtu" 2>/dev/null
 }
 
 set_iface_mtu_if_needed() {
@@ -70,33 +123,26 @@ set_iface_mtu_if_needed() {
             ;;
     esac
 
-    current_mtu="$(get_iface_current_mtu "$iface")"
+    realdev="$(get_real_dev "$iface")" || return 1
+    current_mtu="$(cat "/sys/class/net/$realdev/mtu" 2>/dev/null)"
 
     if [ "$current_mtu" = "$new_mtu" ]; then
         return 0
     fi
 
-    ip link set dev "$iface" mtu "$new_mtu" >/dev/null 2>&1
+    ip link set dev "$realdev" mtu "$new_mtu" >/dev/null 2>&1
     return $?
 }
 
-# Find the UCI peer section for a given WireGuard interface name, like wgs3
-# Looks for:
-#   network.wgs3=interface
-#   network.wireguard_wgs3=wireguard_wgs3
-# or indexed peer sections that contain ".<iface>."
 get_wg_endpoint_host() {
     iface="$1"
 
-    # First try the common direct section name: network.wireguard_<iface>.endpoint_host
     host="$(uci -q get "network.wireguard_${iface}.endpoint_host" 2>/dev/null)"
     if [ -n "$host" ]; then
         echo "$host"
         return 0
     fi
 
-    # Fallback: search any network section whose name contains the iface
-    # and has endpoint_host
     host="$(uci show network 2>/dev/null \
         | grep "\.endpoint_host=" \
         | grep "$iface" \
@@ -118,20 +164,21 @@ handle_wan() {
     good_mtu="$(find_good_mtu "$target")"
     case "$good_mtu" in
         ''|*[!0-9]*)
-            log_msg "$iface up, failed to determine WAN MTU"
+            log_msg "$iface up, failed to determine WAN MTU using $target"
             return 1
             ;;
     esac
 
-    # Only care if it is below 1500
     if [ "$good_mtu" -lt 1500 ]; then
         asn_org="$(get_asn_org)"
         [ -z "$asn_org" ] && asn_org="unknown"
+        realdev="$(get_real_dev "$iface")"
+        [ -z "$realdev" ] && realdev="unknown"
 
         if set_iface_mtu_if_needed "$iface" "$good_mtu"; then
-            log_msg "$iface up, WAN via $asn_org, target $target, path MTU $good_mtu, set $iface MTU to $good_mtu"
+            log_msg "$iface up, WAN via $asn_org, target $target, path MTU $good_mtu, set device $realdev MTU to $good_mtu"
         else
-            log_msg "$iface up, WAN via $asn_org, target $target, path MTU $good_mtu, failed to set $iface MTU"
+            log_msg "$iface up, WAN via $asn_org, target $target, path MTU $good_mtu, failed to set device $realdev MTU"
         fi
     else
         log_msg "$iface up, WAN path supports 1500 via $target"
@@ -142,42 +189,44 @@ handle_wan() {
 
 handle_wgs() {
     iface="$1"
-
     endpoint_host="$(get_wg_endpoint_host "$iface")"
+
     if [ -z "$endpoint_host" ]; then
-        target="$GOOGLE_TARGET"
-        log_msg "$iface up, no endpoint_host found in UCI, using fallback target $target"
-    else
-        # Try endpoint normally first
-        if test_normal_ping "$endpoint_host"; then
-            target="$endpoint_host"
+        wg_mtu="$WG_MIN_MTU"
+        if set_iface_mtu_if_needed "$iface" "$wg_mtu"; then
+            log_msg "$iface up, no endpoint_host found in UCI, set $iface MTU to safe minimum $wg_mtu"
         else
-            target="$GOOGLE_TARGET"
-            log_msg "$iface up, endpoint_host $endpoint_host did not respond to normal ping, using fallback target $target"
+            log_msg "$iface up, no endpoint_host found in UCI, failed to set $iface MTU to safe minimum $wg_mtu"
         fi
+        return 0
     fi
 
-    good_mtu="$(find_good_mtu "$target")"
-    case "$good_mtu" in
-        ''|*[!0-9]*)
-            log_msg "$iface up, failed to determine outer path MTU using target $target"
-            return 1
-            ;;
-    esac
+    if test_normal_ping "$endpoint_host"; then
+        outer_mtu="$(find_good_mtu "$endpoint_host")"
+        case "$outer_mtu" in
+            ''|*[!0-9]*)
+                wg_mtu="$WG_MIN_MTU"
+                ;;
+            *)
+                wg_mtu=$((outer_mtu - WG_OVERHEAD))
+                if [ "$wg_mtu" -lt "$WG_MIN_MTU" ]; then
+                    wg_mtu="$WG_MIN_MTU"
+                fi
+                ;;
+        esac
 
-    # You asked for WG to be based off the discovered path.
-    # Keeping your original subtraction logic.
-    wg_mtu=$((good_mtu - 80))
-
-    # Sanity floor
-    if [ "$wg_mtu" -lt 1280 ]; then
-        wg_mtu=1280
-    fi
-
-    if set_iface_mtu_if_needed "$iface" "$wg_mtu"; then
-        log_msg "$iface up, endpoint ${endpoint_host:-unknown}, target $target, outer MTU $good_mtu, set $iface MTU to $wg_mtu"
+        if set_iface_mtu_if_needed "$iface" "$wg_mtu"; then
+            log_msg "$iface up, endpoint $endpoint_host reachable, outer MTU $outer_mtu, set $iface MTU to $wg_mtu"
+        else
+            log_msg "$iface up, endpoint $endpoint_host reachable, outer MTU $outer_mtu, failed to set $iface MTU to $wg_mtu"
+        fi
     else
-        log_msg "$iface up, endpoint ${endpoint_host:-unknown}, target $target, outer MTU $good_mtu, failed to set $iface MTU"
+        wg_mtu="$WG_MIN_MTU"
+        if set_iface_mtu_if_needed "$iface" "$wg_mtu"; then
+            log_msg "$iface up, endpoint $endpoint_host did not respond to ping, set $iface MTU to safe minimum $wg_mtu"
+        else
+            log_msg "$iface up, endpoint $endpoint_host did not respond to ping, failed to set $iface MTU to safe minimum $wg_mtu"
+        fi
     fi
 
     return 0

--- a/files/etc/hotplug.d/iface/15-fixwgmtu
+++ b/files/etc/hotplug.d/iface/15-fixwgmtu
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+if [ "$ACTION" = "ifup" ]; then
+    case "$INTERFACE" in
+        wan|wgs[0-9]*)
+            sleep 5
+
+            TARGET="8.8.8.8"
+            START_MTU=1500
+            MIN_MTU=1000
+            STEP=20
+
+            get_wgs_interfaces() {
+                ip link | awk -F': ' '$2 ~ /^wgs[0-9]+$/ {print $2}'
+            }
+
+            get_asn_org() {
+                curl -fsS --max-time 5 https://ipconfig.io/json 2>/dev/null | sed -n 's/.*"asn_org"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
+            }
+
+            set_all_mtu() {
+                mtu="$1"
+                ints="$(get_wgs_interfaces)"
+
+                [ -z "$ints" ] && return 1
+
+                for int in $ints; do
+                    ip link set dev "$int" mtu "$mtu" >/dev/null 2>&1
+                done
+
+                return 0
+            }
+
+            test_ping_mtu() {
+                mtu="$1"
+                payload=$((mtu - 28))
+
+                [ "$payload" -le 0 ] && return 1
+
+                ping -c 1 -W 3 -s "$payload" "$TARGET" >/dev/null 2>&1
+                return $?
+            }
+
+            find_good_mtu() {
+                mtu="$START_MTU"
+
+                while [ "$mtu" -ge "$MIN_MTU" ]; do
+                    if test_ping_mtu "$mtu"; then
+                        printf '%s\n' "$mtu"
+                        return 0
+                    fi
+                    mtu=$((mtu - STEP))
+                done
+
+                printf '%s\n' "$MIN_MTU"
+                return 1
+            }
+
+            GOOD_MTU="$(find_good_mtu)"
+
+            case "$GOOD_MTU" in
+                ''|*[!0-9]*)
+                    exit 1
+                    ;;
+            esac
+
+            if [ "$GOOD_MTU" -ne 1500 ]; then
+                ASN_ORG="$(get_asn_org)"
+                [ -z "$ASN_ORG" ] && ASN_ORG="unknown"
+                logger -t fixwgmtu "$INTERFACE up via $ASN_ORG, setting wgs MTU to $GOOD_MTU"
+            fi
+
+            set_all_mtu "$GOOD_MTU"
+            ;;
+    esac
+fi

--- a/files/etc/hotplug.d/iface/15-fixwgmtu
+++ b/files/etc/hotplug.d/iface/15-fixwgmtu
@@ -21,11 +21,12 @@ if [ "$ACTION" = "ifup" ]; then
             set_all_mtu() {
                 mtu="$1"
                 ints="$(get_wgs_interfaces)"
+                wgmtu=$((mtu - 80))
 
                 [ -z "$ints" ] && return 1
 
                 for int in $ints; do
-                    ip link set dev "$int" mtu "$mtu" >/dev/null 2>&1
+                    ip link set dev "$int" mtu "$wgmtu" >/dev/null 2>&1
                 done
 
                 return 0
@@ -57,7 +58,7 @@ if [ "$ACTION" = "ifup" ]; then
             }
 
             GOOD_MTU="$(find_good_mtu)"
-
+            WG_MTU=$((GOOD_MTU - 80))
             case "$GOOD_MTU" in
                 ''|*[!0-9]*)
                     exit 1
@@ -67,7 +68,7 @@ if [ "$ACTION" = "ifup" ]; then
             if [ "$GOOD_MTU" -ne 1500 ]; then
                 ASN_ORG="$(get_asn_org)"
                 [ -z "$ASN_ORG" ] && ASN_ORG="unknown"
-                logger -t fixwgmtu "$INTERFACE up via $ASN_ORG, setting wgs MTU to $GOOD_MTU"
+                logger -t fixwgmtu "$INTERFACE up, Wan via $ASN_ORG ($GOOD_MTU), setting wgs MTU to $WG_MTU"
             fi
 
             set_all_mtu "$GOOD_MTU"

--- a/files/etc/hotplug.d/iface/15-fixwgmtu
+++ b/files/etc/hotplug.d/iface/15-fixwgmtu
@@ -1,77 +1,216 @@
 #!/bin/sh
 
+LOGGER_TAG="fixwgmtu"
+GOOGLE_TARGET="8.8.8.8"
+START_MTU=1500
+MIN_MTU=1000
+STEP=20
+SLEEP_SECS=5
+
+log_msg() {
+    logger -t "$LOGGER_TAG" "$*"
+}
+
+get_asn_org() {
+    curl -fsS --max-time 5 https://ipconfig.io/json 2>/dev/null \
+        | sed -n 's/.*"asn_org"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        | head -n 1
+}
+
+# Convert MTU to ping payload for IPv4
+mtu_to_payload() {
+    echo $(( $1 - 28 ))
+}
+
+# Test "normal" ping first (no DF logic, just basic reachability)
+test_normal_ping() {
+    target="$1"
+    ping -c 1 -W 3 "$target" >/dev/null 2>&1
+}
+
+# Test with a given MTU-sized packet using DF
+test_ping_mtu() {
+    target="$1"
+    mtu="$2"
+    payload="$(mtu_to_payload "$mtu")"
+
+    [ "$payload" -le 0 ] && return 1
+
+    # BusyBox ping on many OpenWrt builds supports -M do, but not all.
+    # Try DF first; if the ping app doesn't support it, fall back to normal sized ping.
+    ping -c 1 -W 3 -M do -s "$payload" "$target" >/dev/null 2>&1
+    rc=$?
+
+    # If ping returned failure, try to detect whether -M is unsupported.
+    # This avoids falsely treating "unknown option" as path MTU failure.
+    if ping -h 2>&1 | grep -q -- '[-]M'; then
+        return $rc
+    fi
+
+    # No -M support; just try sized ping
+    ping -c 1 -W 3 -s "$payload" "$target" >/dev/null 2>&1
+    return $?
+}
+
+find_good_mtu() {
+    target="$1"
+    mtu="$START_MTU"
+
+    while [ "$mtu" -ge "$MIN_MTU" ]; do
+        if test_ping_mtu "$target" "$mtu"; then
+            echo "$mtu"
+            return 0
+        fi
+        mtu=$((mtu - STEP))
+    done
+
+    echo "$MIN_MTU"
+    return 1
+}
+
+get_iface_current_mtu() {
+    iface="$1"
+    cat "/sys/class/net/$iface/mtu" 2>/dev/null
+}
+
+set_iface_mtu_if_needed() {
+    iface="$1"
+    new_mtu="$2"
+
+    case "$new_mtu" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+    esac
+
+    current_mtu="$(get_iface_current_mtu "$iface")"
+
+    if [ "$current_mtu" = "$new_mtu" ]; then
+        return 0
+    fi
+
+    ip link set dev "$iface" mtu "$new_mtu" >/dev/null 2>&1
+    return $?
+}
+
+# Find the UCI peer section for a given WireGuard interface name, like wgs3
+# Looks for:
+#   network.wgs3=interface
+#   network.wireguard_wgs3=wireguard_wgs3
+# or indexed peer sections that contain ".<iface>."
+get_wg_endpoint_host() {
+    iface="$1"
+
+    # First try the common direct section name: network.wireguard_<iface>.endpoint_host
+    host="$(uci -q get "network.wireguard_${iface}.endpoint_host" 2>/dev/null)"
+    if [ -n "$host" ]; then
+        echo "$host"
+        return 0
+    fi
+
+    # Fallback: search any network section whose name contains the iface
+    # and has endpoint_host
+    host="$(uci show network 2>/dev/null \
+        | grep "\.endpoint_host=" \
+        | grep "$iface" \
+        | sed -n "s/.*endpoint_host='\([^']*\)'.*/\1/p" \
+        | head -n 1)"
+
+    if [ -n "$host" ]; then
+        echo "$host"
+        return 0
+    fi
+
+    return 1
+}
+
+handle_wan() {
+    iface="$1"
+    target="$GOOGLE_TARGET"
+
+    good_mtu="$(find_good_mtu "$target")"
+    case "$good_mtu" in
+        ''|*[!0-9]*)
+            log_msg "$iface up, failed to determine WAN MTU"
+            return 1
+            ;;
+    esac
+
+    # Only care if it is below 1500
+    if [ "$good_mtu" -lt 1500 ]; then
+        asn_org="$(get_asn_org)"
+        [ -z "$asn_org" ] && asn_org="unknown"
+
+        if set_iface_mtu_if_needed "$iface" "$good_mtu"; then
+            log_msg "$iface up, WAN via $asn_org, target $target, path MTU $good_mtu, set $iface MTU to $good_mtu"
+        else
+            log_msg "$iface up, WAN via $asn_org, target $target, path MTU $good_mtu, failed to set $iface MTU"
+        fi
+    else
+        log_msg "$iface up, WAN path supports 1500 via $target"
+    fi
+
+    return 0
+}
+
+handle_wgs() {
+    iface="$1"
+
+    endpoint_host="$(get_wg_endpoint_host "$iface")"
+    if [ -z "$endpoint_host" ]; then
+        target="$GOOGLE_TARGET"
+        log_msg "$iface up, no endpoint_host found in UCI, using fallback target $target"
+    else
+        # Try endpoint normally first
+        if test_normal_ping "$endpoint_host"; then
+            target="$endpoint_host"
+        else
+            target="$GOOGLE_TARGET"
+            log_msg "$iface up, endpoint_host $endpoint_host did not respond to normal ping, using fallback target $target"
+        fi
+    fi
+
+    good_mtu="$(find_good_mtu "$target")"
+    case "$good_mtu" in
+        ''|*[!0-9]*)
+            log_msg "$iface up, failed to determine outer path MTU using target $target"
+            return 1
+            ;;
+    esac
+
+    # You asked for WG to be based off the discovered path.
+    # Keeping your original subtraction logic.
+    wg_mtu=$((good_mtu - 80))
+
+    # Sanity floor
+    if [ "$wg_mtu" -lt 1280 ]; then
+        wg_mtu=1280
+    fi
+
+    if set_iface_mtu_if_needed "$iface" "$wg_mtu"; then
+        log_msg "$iface up, endpoint ${endpoint_host:-unknown}, target $target, outer MTU $good_mtu, set $iface MTU to $wg_mtu"
+    else
+        log_msg "$iface up, endpoint ${endpoint_host:-unknown}, target $target, outer MTU $good_mtu, failed to set $iface MTU"
+    fi
+
+    return 0
+}
+
 if [ "$ACTION" = "ifup" ]; then
     case "$INTERFACE" in
         wan|wgs[0-9]*)
-            sleep 5
+            sleep "$SLEEP_SECS"
 
-            TARGET="8.8.8.8"
-            START_MTU=1500
-            MIN_MTU=1000
-            STEP=20
-
-            get_wgs_interfaces() {
-                ip link | awk -F': ' '$2 ~ /^wgs[0-9]+$/ {print $2}'
-            }
-
-            get_asn_org() {
-                curl -fsS --max-time 5 https://ipconfig.io/json 2>/dev/null | sed -n 's/.*"asn_org"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
-            }
-
-            set_all_mtu() {
-                mtu="$1"
-                ints="$(get_wgs_interfaces)"
-                wgmtu=$((mtu - 80))
-
-                [ -z "$ints" ] && return 1
-
-                for int in $ints; do
-                    ip link set dev "$int" mtu "$wgmtu" >/dev/null 2>&1
-                done
-
-                return 0
-            }
-
-            test_ping_mtu() {
-                mtu="$1"
-                payload=$((mtu - 28))
-
-                [ "$payload" -le 0 ] && return 1
-
-                ping -c 1 -W 3 -s "$payload" "$TARGET" >/dev/null 2>&1
-                return $?
-            }
-
-            find_good_mtu() {
-                mtu="$START_MTU"
-
-                while [ "$mtu" -ge "$MIN_MTU" ]; do
-                    if test_ping_mtu "$mtu"; then
-                        printf '%s\n' "$mtu"
-                        return 0
-                    fi
-                    mtu=$((mtu - STEP))
-                done
-
-                printf '%s\n' "$MIN_MTU"
-                return 1
-            }
-
-            GOOD_MTU="$(find_good_mtu)"
-            WG_MTU=$((GOOD_MTU - 80))
-            case "$GOOD_MTU" in
-                ''|*[!0-9]*)
-                    exit 1
+            case "$INTERFACE" in
+                wan)
+                    handle_wan "$INTERFACE"
+                    ;;
+                wgs[0-9]*)
+                    handle_wgs "$INTERFACE"
                     ;;
             esac
-
-            if [ "$GOOD_MTU" -ne 1500 ]; then
-                ASN_ORG="$(get_asn_org)"
-                [ -z "$ASN_ORG" ] && ASN_ORG="unknown"
-                logger -t fixwgmtu "$INTERFACE up, Wan via $ASN_ORG ($GOOD_MTU), setting wgs MTU to $WG_MTU"
-            fi
-
-            set_all_mtu "$GOOD_MTU"
             ;;
     esac
 fi
+
+exit 0


### PR DESCRIPTION
## Summary

This change adds automatic WireGuard MTU tuning during `iface` hotplug `ifup` events to help address the tunnel behavior described in #2594.

Issue #2594 describes WireGuard tunnels that appear to come up only partially on constrained paths such as T-Mobile/CGNAT, where lowering the WireGuard interface MTU resolved the problem immediately. The reported workaround was manually setting the affected WireGuard interface from `1420` down to `1280`, but that setting did not persist across reboot. 

## What this change does

When an `ifup` hotplug event occurs for either:

- `wan`, or
- a WireGuard interface matching `wgs[0-9]*`

the script will:

1. Wait 5 seconds to allow the WAN/path to stabilize.
2. Probe outbound path MTU by pinging `8.8.8.8`, starting at `1500`.
3. Step downward in increments of `20` until a working size is found, with a floor of `1000`.
4. Convert the discovered working WAN MTU into a WireGuard MTU by subtracting `80` bytes.
5. Apply that computed MTU to all WireGuard interfaces matching `wgs[0-9]+`.
6. Log the detected uplink ASN/organization when the discovered path MTU is lower than `1500`.

## Why

The issue report notes that constrained networks such as T-Mobile, CGNAT, IPv6-encapsulated paths, LTE/5G, and similar environments can have a lower effective path MTU than expected, and that PMTUD may fail when ICMP messages are filtered. In that report, lowering the MTU on the WireGuard interface resolved the tunnel problem. 

This implementation automates that adjustment at interface bring-up so the system can adapt after reboot or uplink changes without requiring a manual `ip link set dev ... mtu ...` workaround.

## Behavior notes

- This does **not** add a user-facing MTU field in the UI.
- This does **not** currently tune MTU per peer; it applies the computed WireGuard MTU to all `wgs*` interfaces on the node.
- The script only emits a log entry when the detected path MTU is below the normal `1500` value.
- The purpose is to make the workaround from #2594 persistent and automatic during interface activation.

## Related issue

Fixes / addresses #2594