### PR TITLE
UI: Sort wireguard tunnels by type and numeric index

### DIFF
--- a/files/app/main/status/e/tunnels.ut
+++ b/files/app/main/status/e/tunnels.ut
@@ -176,7 +176,6 @@ uciMesh.foreach("wireguard", "client", a => {
     delete available[a.clientip];
     servercount++;
 });
-
 sort(tunnels, (a, b) => {
     const ma = match(a.index, /^([a-z]+)_(\d+)$/);
     const mb = match(b.index, /^([a-z]+)_(\d+)$/);
@@ -188,7 +187,6 @@ sort(tunnels, (a, b) => {
     }
     return int(ma[2]) - int(mb[2]);
 });
-
 function t2t(type)
 {
     switch (type) {

--- a/files/app/main/status/e/tunnels.ut
+++ b/files/app/main/status/e/tunnels.ut
@@ -176,6 +176,19 @@ uciMesh.foreach("wireguard", "client", a => {
     delete available[a.clientip];
     servercount++;
 });
+
+sort(tunnels, (a, b) => {
+    const ma = match(a.index, /^([a-z]+)_(\d+)$/);
+    const mb = match(b.index, /^([a-z]+)_(\d+)$/);
+    if (!ma || !mb) {
+        return (a.index < b.index) ? -1 : 1;
+    }
+    if (ma[1] !== mb[1]) {
+        return (ma[1] === "server") ? -1 : 1;
+    }
+    return int(ma[2]) - int(mb[2]);
+});
+
 function t2t(type)
 {
     switch (type) {


### PR DESCRIPTION
Summary:
This PR improves the Wireguard tunnels list by introducing a more consistent and user-friendly sorting mechanism.

Problem:
Previously, tunnels were displayed based on creation/UCI order, which made management difficult—especially with many tunnels. Alphabetical sorting also caused incorrect ordering (e.g., client_11 appearing before client_2).

Solution:
A natural sorting algorithm was added to tunnels.ut:

server_N entries are prioritized and shown first, followed by client_N entries
Numeric indices are sorted numerically instead of lexicographically (e.g., client_2 < client_10)

Result:

More predictable and organized list
Improved usability for nodes with many tunnels
Clearer separation between server and client entries

Test:

Navigate to /a/status/e/tunnels
Verify that server entries appear before client entries
Ensure entries with the same prefix are sorted in ascending numeric order