### PR TITLE
Disable resource hashes when using direct LAN access.

### DIFF
--- a/files/app/main/app.ut
+++ b/files/app/main/app.ut
@@ -37,7 +37,7 @@
 <html lang="en" translate="no">
 <head>
     <meta charset="utf-8">
-    {% if (!config.resourcehash) { %}
+    {% if (!config.resourcehash || auth.isLAN) { %}
     <link href="/a/css/theme.css" rel="stylesheet">
     <link href="/a/css/user.css" rel="stylesheet">
     {% if (request.mobile) { %}

--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -326,6 +326,7 @@ const uciMeshMethods =
 
 const auth = {
     isAdmin: false,
+    isLAN: false,
     key: null,
     age: 315360000, // 10 years
 
@@ -369,6 +370,14 @@ const auth = {
         }
         if (config.forceauth) {
             this.isAdmin = true;
+        }
+        const ra = iptoarr(env.REMOTE_ADDR);
+        const ln = iptoarr(uciMeshMethods.get("setup", "globals", "dmz_lan_ip"));
+        if (ra[0] === ln[0] && ra[1] === ln[1] && ra[2] === ln[2]) {
+            const mask = iptoarr(uciMeshMethods.get("setup", "globals", "dmz_lan_mask"));
+            if ((ra[3] & mask[3]) === (ln[3] & mask[3])) {
+                this.isLAN = true;
+            }
         }
     },
 


### PR DESCRIPTION
Using resource hashes during direct LAN access can cause browser problems if the browser thinks localnode is somewhere different and cannot access it. This can happen during initial node setup and makes loading pages very slow.