### PR TITLE
Crude way to set the MTU of all wireguard tunnels.

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -566,6 +566,10 @@ if (is_supernode && wg_begin && match(wg_begin, /^172\.31\./)) {
     cm.set("wireguard", "@network[0]", "begin", wg_begin);
     cm.commit("wireguard");
 }
+let wg_mtu_override = cm.get("wireguard", "@network[0]", "mtu") ?? "";
+if (wg_mtu_override) {
+    wg_mtu_override = `\toption mtu '${wg_mtu_override}'\n`;
+}
 const def_tun_cost = tonumber(cm.get("babel", "tunnel", "rxcost") || 1) || 0;
 let wgclients = 0;
 cm.foreach("wireguard", "client",
@@ -580,8 +584,8 @@ cm.foreach("wireguard", "client",
             const abcd = iptoarr(addr);
             const ll = network.mac2ipv6ll(sprintf("00:00:%02x:%02x:%02x:%02x", abcd[0], abcd[1], abcd[2], abcd[3])) + "/64";
             const w = s.cost || def_tun_cost;
-            cfg.wireguard_network_config += sprintf("config interface 'wgc%d'\n\toption proto 'wireguard'\n\toption private_key '%s'\n\toption nohostroute '1'\n\toption cost '%s'\n\toption listen_port '%s'\n\tlist addresses '%s'\n\tlist addresses '%s'\n\toption disabled '%s'\n\n",
-                wgclients, server_priv, w, port, addr, ll, (s.enabled == 1 ? "0" : "1"));
+            cfg.wireguard_network_config += sprintf("config interface 'wgc%d'\n\toption proto 'wireguard'\n\toption private_key '%s'\n\toption nohostroute '1'\n\toption cost '%s'\n\toption listen_port '%s'\n\tlist addresses '%s'\n\tlist addresses '%s'\n\toption disabled '%s'\n%s\n",
+                wgclients, server_priv, w, port, addr, ll, (s.enabled == 1 ? "0" : "1"), wg_mtu_override);
             cfg.wireguard_network_config += sprintf("config wireguard_wgc%d 'wireguard_wgc%d'\n\toption public_key '%s'\n\toption persistent_keepalive '25'\n\tlist allowed_ips '0.0.0.0/0'\n\tlist allowed_ips '::/0'\n\n",
                 wgclients, wgclients, client_pub);
             cfg.vpn_interfaces += `\tlist network 'wgc${wgclients}'\n`;
@@ -603,8 +607,8 @@ cm.foreach("wireguard", "server",
             const p = m2[2];
             const ll = network.mac2ipv6ll(sprintf("00:00:%02x:%02x:%02x:%02x", abcd[0], abcd[1], abcd[2], abcd[3] + 1)) + "/64";
             const w = s.cost || def_tun_cost;
-            cfg.wireguard_network_config += sprintf("config interface 'wgs%d'\n\toption proto 'wireguard'\n\toption private_key '%s'\n\toption nohostroute '1'\n\toption cost '%s'\n\tlist addresses '%d.%d.%d.%d'\n\tlist addresses '%s'\n\toption disabled '%s'\n\n",
-                wgservers, client_priv, w, abcd[0], abcd[1], abcd[2], abcd[3] + 1, ll, (s.enabled == 1 ? "0" : "1"));
+            cfg.wireguard_network_config += sprintf("config interface 'wgs%d'\n\toption proto 'wireguard'\n\toption private_key '%s'\n\toption nohostroute '1'\n\toption cost '%s'\n\tlist addresses '%d.%d.%d.%d'\n\tlist addresses '%s'\n\toption disabled '%s'\n%s\n",
+                wgservers, client_priv, w, abcd[0], abcd[1], abcd[2], abcd[3] + 1, ll, (s.enabled == 1 ? "0" : "1"), wg_mtu_override);
             cfg.wireguard_network_config += sprintf("config wireguard_wgs%d 'wireguard_wgs%d'\n\toption public_key '%s'\n\toption endpoint_host '%s'\n\toption endpoint_port '%s'\n\toption persistent_keepalive '25'\n\tlist allowed_ips '0.0.0.0/0'\n\tlist allowed_ips '::/0'\n\n",
                 wgservers, wgservers, server_pub, s.host, p);
             cfg.vpn_interfaces += `\tlist network 'wgs${wgservers}'\n`;


### PR DESCRIPTION
Provide a simple, if crude, way to override the mtu of all wireguard tunnels.

Edit the file `/etc/config.mesh/wireguard` and find the section `config network`. Add an option setting your new mtu value, for example `option mtu '1400'`. Reboot the node for this to take effect.

On my node, the whole `config network` section might look like this:
```
config network 
        option begin '172.31.64.76' 
        option dns 'aredn.xojs.org' 
        option mtu '1400'
```