### PR TITLE
Enable QCA955x on-chip WMAC radio on Ubiquiti XC boards

### DIFF
--- a/patches/758-enable-wmac-spectral-scanner.patch
+++ b/patches/758-enable-wmac-spectral-scanner.patch
@@ -1,0 +1,50 @@
+--- /dev/null
++++ b/target/linux/ath79/dts/qca955x_ubnt_xc-wmac.dtsi
+@@ -0,0 +1,17 @@
++// SPDX-License-Identifier: GPL-2.0-only
++//
++// Enable on-chip WMAC radio on QCA955x Ubiquiti XC boards.
++// The QCA9558/QCA9560 SoC contains an AHB-attached 802.11n radio
++// that can be used as a dedicated spectral scanner without disrupting
++// the main ath10k PCI radio serving the AREDN mesh.
++//
++// Caldata is the AR9300 compressed EEPROM at ART partition offset 0x5000,
++// which is the same nvmem cell already defined for the ath10k radio.
++// Both drivers read different fields from the shared caldata block.
++//
++
++&wmac {
++	status = "okay";
++	nvmem-cells = <&cal_art_5000>;
++	nvmem-cell-names = "calibration";
++};
+--- a/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
++++ b/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
+@@ -1,6 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ 
+ #include "qca955x_ubnt_xc.dtsi"
++#include "qca955x_ubnt_xc-wmac.dtsi"
+ 
+ / {
+ 	compatible = "ubnt,powerbeam-5ac-500", "ubnt,xc", "qca,qca9558";
+--- a/target/linux/ath79/dts/qca9558_ubnt_rocket-5ac-lite.dts
++++ b/target/linux/ath79/dts/qca9558_ubnt_rocket-5ac-lite.dts
+@@ -1,6 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ 
+ #include "qca955x_ubnt_xc.dtsi"
++#include "qca955x_ubnt_xc-wmac.dtsi"
+ 
+ / {
+ 	compatible = "ubnt,rocket-5ac-lite", "ubnt,xc", "qca,qca9558";
+--- a/target/linux/ath79/dts/qca9558_ubnt_nanobeam-ac-xc.dts
++++ b/target/linux/ath79/dts/qca9558_ubnt_nanobeam-ac-xc.dts
+@@ -6,6 +6,7 @@
+ #include <dt-bindings/leds/common.h>
+ 
+ #include "qca955x_ubnt_xc.dtsi"
++#include "qca955x_ubnt_xc-wmac.dtsi"
+ 
+ / {
+ 	compatible = "ubnt,nanobeam-ac-xc", "ubnt,xc", "qca,qca9558";

--- a/patches/series
+++ b/patches/series
@@ -43,6 +43,7 @@
 755-ubiquiti-ac-loco.patch
 756-cudy-support.patch
 #757-txpower-mediatek.patch
+758-enable-wmac-spectral-scanner.patch
 760-uhttp-ucode.patch
 760-uhttp-redirect.patch
 761-ucode-zlib.patch


### PR DESCRIPTION
Enable the AHB-attached 802.11n radio present in the QCA9558/QCA9560 SoC on the Ubiquiti XC board family (PowerBeam 5AC 500, Rocket 5AC Lite, NanoBeam AC XC). This radio can serve as a dedicated spectral scanner for RF interference detection without disrupting the main ath10k mesh radio.

The WMAC hardware is present in the SoC and has valid AR9300 calibration data in the ART partition at offset 0x5000. The existing cal_art_5000 nvmem cell is shared - both ath10k and ath9k read different fields from the same caldata block. The ath9k driver and platform driver are already loaded in AREDN firmware; this change enables device tree probing so ath9k binds to the hardware and exposes phy1.

The patch creates a shared include (qca955x_ubnt_xc-wmac.dtsi) so all three XC boards get the change. The pattern follows 11+ existing upstream OpenWrt QCA955x devices that enable the WMAC (Archer C7 v1, Aruba AP-115, LibreRouter v1, etc.).

Tested: patch applies cleanly against OpenWrt v25.12.4 (AREDN base). Hardware verification pending - requires firmware build and flash to bench device.