### PR TITLE
Disable bss coloring

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -1001,7 +1001,7 @@ for (let dev = 0; dev < ifacecount; dev++) {
             if (macaddr) {
                 macaddr = trim(replace(macaddr, /^..:/, "fe:"));
                 isolate = 1;
-                bss_color = int(match(macaddr, /:(..)$/)[1], 16);
+                //bss_color = int(match(macaddr, /:(..)$/)[1], 16);
             }
         }
         else if (cfg[`${radio}_mode`] == "meshsta") {


### PR DESCRIPTION
BSS Coloring seems like it could be useful, but in halow I dont yet understand what effect it has on tx power like it does in wifi 6 - disable for now.