### PR TITLE
Provide hooks to enable the spectrum radio on specific Ubiquiti AC radios.

### DIFF
--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -851,9 +851,14 @@
   },
   "0xe1f5": {
     "name": "Ubiquiti Rocket 5AC Lite",
-    "maxpower": 23,
-    "pwroffset": 4,
-    "antenna": "external",
+    "wlan0": {
+      "maxpower": 23,
+      "pwroffset": 4,
+      "antenna": "external"
+    },
+    "wlan1": {
+      "disabled": true
+    },
     "features": [ "xlink" ]
   },
   "0xe202": {
@@ -964,12 +969,17 @@
   },
   "0xe3d5": {
     "name": "Ubiquiti PowerBeam 5AC 500",
-    "maxpower": 24,
-    "pwroffset": 1,
-    "antenna": {
-      "description": "27 dBi 8&deg; Dish",
-      "gain": 27,
-      "beamwidth": 10
+    "wlan0": {
+      "maxpower": 24,
+      "pwroffset": 1,
+      "antenna": {
+        "description": "27 dBi 8&deg; Dish",
+        "gain": 27,
+        "beamwidth": 10
+      }
+    },
+    "wlan1": {
+      "disabled": true
     }
   },
   "0xe3d6": {

--- a/patches/758-ubiquiti-enable-spectrum-radios.patch
+++ b/patches/758-ubiquiti-enable-spectrum-radios.patch
@@ -1,0 +1,22 @@
+--- a/target/linux/ath79/dts/qca9558_ubnt_rocket-5ac-lite.dts
++++ b/target/linux/ath79/dts/qca9558_ubnt_rocket-5ac-lite.dts
+@@ -44,3 +44,8 @@
+ 		device = <&gmac>;
+ 	};
+ };
++
++&wmac {
++	status = "okay";
++	qca,no-eeprom;
++};
+--- a/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
++++ b/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
+@@ -44,3 +44,8 @@
+ 		device = <&gmac>;
+ 	};
+ };
++
++&wmac {
++	status = "okay";
++	qca,no-eeprom;
++};

--- a/patches/series
+++ b/patches/series
@@ -43,6 +43,7 @@
 755-ubiquiti-ac-loco.patch
 756-cudy-support.patch
 #757-txpower-mediatek.patch
+758-ubiquiti-enable-spectrum-radios.patch
 760-uhttp-ucode.patch
 760-uhttp-redirect.patch
 761-ucode-zlib.patch


### PR DESCRIPTION
This change will enable the spectrum radio on the Rocket 5AC Lite and the PowerBeam 5AC 500 which are the designated test devices. However this change does *not* include the calibration data to bring these radios up, so they will not initialize. The job of providing this data is left to the app which operates the spectrum analyzer.

See the original proposal here https://github.com/aredn/aredn/pull/2725