### PR TITLE
mdt: updates for the glinet a-1300

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ Paul Milazzo - K3PGM <milazzo@comcast.net>
 Jean-Michel Vien - VA2XJM <va2xjm@gmail.com>
 Jacob McSwain - KI5VMF <aredn@mcswain.dev>
 Maiyun Zhang - AK6DS/VE7ZMY <ham@maiyun.me>
+Mike Thomas - K0MDT <mdthomas.home@gmail.com>

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -141,6 +141,7 @@ Model | SKUs | Band | Target | Subtarget | Image | RAM | Stability | Status
 Shadow (16MB NOR) | GL-AR300M16 <br> GL-AR300M16-Ext | 2 | ath79 | generic | glinet_gl-ar300m16 | 64MB | stable | released
 Shadow (128MB NAND) | GL-AR300M <br> GL-AR300M-Ext | 2 | ath79 | nand | gl-ar300m | 64MB | stable | released
 Mudi | GL-E750 | 2 & 5 | ath79 | nand | gl-e750 | 128MB | stable | stable
+Slate Plus | GL-A1300 | 2 & 5 | ipq40xx | generic | gl-a1300 | 256MB | stable | nightly (6)
 Convexa-B | GL-B1300 | 2 & 5 | ipq40xx | generic | gl-b1300 | 256MB | stable | released (6)
 Beryl | GL-MT1300 | 2 & 5 | ramips | mt7621 | gl-mt1300 | 256MB | stable | released (4)
 **Sunset Devices** | | | | | | | |

--- a/configs/ipq40xx-generic.config
+++ b/configs/ipq40xx-generic.config
@@ -1,5 +1,6 @@
 CONFIG_TARGET_ipq40xx=y
 CONFIG_TARGET_ipq40xx_generic=y
+CONFIG_TARGET_DEVICE_ipq40xx_generic_DEVICE_glinet_gl-a1300=y
 CONFIG_TARGET_DEVICE_ipq40xx_generic_DEVICE_glinet_gl-b1300=y
 #
 # videoproxy

--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -48,6 +48,26 @@
   "gl.inet gl-ar750s (nor/nand)": {
     "maxpower": 23
   },
+  "gl.inet gl-a1300": {
+    "wlan0": {
+      "maxpower": 20,
+      "antenna": {
+        "description": "2.1 dBi Omni",
+        "gain": 2.1,
+        "beamwidth": 360
+      },
+      "exclude_channels": [ -4, -3, -2, -1 ]
+    },
+    "wlan1": {
+      "maxpower": 20,
+      "antenna": {
+        "description": "8.4 dBi Omni",
+        "gain": 8.4,
+        "beamwidth": 360
+      }
+    },
+    "features": [ "supernode", "xlink" ]
+  },
   "gl.inet gl-b1300": {
     "wlan0": {
       "maxpower": 20,

--- a/files/usr/share/ucode/aredn/hardware.uc
+++ b/files/usr/share/ucode/aredn/hardware.uc
@@ -868,6 +868,7 @@ export function getEthernetPorts()
         case "cudy,wr3000p-v1":
         case "cudy,wr3000s-v1":
             return default5PortLayout;
+        case "glinet,gl-a1300":
         case "glinet,gl-b1300":
             return default3PortLayout;
         case "openwrt,one":


### PR DESCRIPTION
I think I got all the required updates in, and tested. 
The channels [-4, -3, -2, -1] are excluded. 
I spot checked the other channels with a glinet ar300m16. 
