### PR TITLE
Disable setting of the halow distance.

### DIFF
--- a/files/usr/share/ucode/aredn/hardware.uc
+++ b/files/usr/share/ucode/aredn/hardware.uc
@@ -690,7 +690,7 @@ export function setMaxDistance(wifiIface, distance)
             break;
         case "halow":
             const ack = max(2, 2 * int(distance / 300));
-            system(`/sbin/morse_cli set ack_timeout_adjust ${ack} > /dev/null 2>&1`);
+            // system(`/sbin/morse_cli set ack_timeout_adjust ${ack} > /dev/null 2>&1`);
             break;
         default:
             const coverage = min(255, int(distance / 450));


### PR DESCRIPTION
The math to set this value appears incorrect and tanks performance. Better to leave the default for now until how to calculate this value is better understood.