### PR TITLE
Disable mANTBox 19s builds for now

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -3,6 +3,7 @@
 **Stability**
 * *untested* - this image has not been tested on hardware. It may or may not work.
 * *stable* - this image has been tested on hardware. There may still be bugs.
+* *broken* - this image is known to be broken or buggy in some way.
 
 **Status**
 * *released* - this image is in a production release of the AREDN® firmware.
@@ -10,6 +11,7 @@
 * *sunset* - this device is supported but no longer recommended for new purchases or installs.
 * *not supported* - this image is not supported and not available for download.
 * *frozen* - this device has been previously sunsetted, and is now frozen. Old images are still available but there will be no future updates.
+* *unavailable* - this image is not currently available.
 
 The 'target' and 'subtarget' identify the directory in which to find the image on at http://downloads.arednmesh.org
 
@@ -39,7 +41,7 @@ RB912UAG-2HPnD <br> BaseBox 2 | RB912UAG-2HPnD <br> RB912UAG-2HPnD-OUT | 2 | ath
 RB912UAG-5HPnD <br> BaseBox 5 | RB912UAG-5HPnD <br> RB912UAG-5HPnD-OUT | 5 | ath79 | mikrotik | mikrotik-912uag-5hpnd | 64MB | stable | released
 RB922UAGS-5HPacD <br> NetMetal 5 | 922UAGS-5HPacD-NM <br> 922UAGS-5HPacD-NM-US | 5 | ath79 | mikrotik |  mikrotik_routerboard-922uags-5hpacd | 128MB | stable | released
 mANTBox 15s | RB921GS-5HPacD-15S | 5 | ath79 | mikrotik | mikrotik-921gs-5hpacd-15s | 128MB | stable | released
-mANTBox 19s | RB921GS-5HPacD-19S | 5 | ath79 | mikrotik | mikrotik-921gs-5hpacd-19s | 128MB | stable | released
+mANTBox 19s | RB921GS-5HPacD-19S | 5 | ath79 | mikrotik | mikrotik-921gs-5hpacd-19s | 128MB | broken | unavailable
 mANTBox 2 12s | RB911G-2HPnD-12S | 2 | ath79 | mikrotik | mikrotik-911g-2hpnd-12s | 64MB | stable | released
 **Sunset Devices** | | | | | | | |
 hAP ac lite <br> hAP ac lite TC | RB952Ui-5ac2nD <br> RB952Ui-5ac2nD-TC | 2 & 5 | ath79 | mikrotik | mikrotik-952ui-5ac2nd | 64MB | stable | sunset

--- a/configs/ath79-mikrotik-ath10k.config
+++ b/configs/ath79-mikrotik-ath10k.config
@@ -1,7 +1,7 @@
 CONFIG_TARGET_ath79=y
 CONFIG_TARGET_ath79_mikrotik=y
 CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-921gs-5hpacd-15s=y
-CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-921gs-5hpacd-19s=y
+#CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-921gs-5hpacd-19s=y
 CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-922uags-5hpacd=y
 
 #


### PR DESCRIPTION
It looks like the mANTBox 19s build has more problem than originally thought. Disable new builds for the moment.