### PR TITLE
Also omit the mANTBox 15.

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -11,7 +11,7 @@
 * *sunset* - this device is supported but no longer recommended for new purchases or installs.
 * *not supported* - this image is not supported and not available for download.
 * *frozen* - this device has been previously sunsetted, and is now frozen. Old images are still available but there will be no future updates.
-* *unavailable* - this image is not currently available.
+* *unavailable* - this image is not currently available. It should be restored in a later build.
 
 The 'target' and 'subtarget' identify the directory in which to find the image on at http://downloads.arednmesh.org
 
@@ -40,7 +40,7 @@ QRT 5 | RB911G-5HPnD-QRT | 5 | ath79 | mikrotik | mikrotik-911g-5hpnd-qrt | 64MB
 RB912UAG-2HPnD <br> BaseBox 2 | RB912UAG-2HPnD <br> RB912UAG-2HPnD-OUT | 2 | ath79 | mikrotik | mikrotik-912uag-2hpnd | 64MB | untested | released
 RB912UAG-5HPnD <br> BaseBox 5 | RB912UAG-5HPnD <br> RB912UAG-5HPnD-OUT | 5 | ath79 | mikrotik | mikrotik-912uag-5hpnd | 64MB | stable | released
 RB922UAGS-5HPacD <br> NetMetal 5 | 922UAGS-5HPacD-NM <br> 922UAGS-5HPacD-NM-US | 5 | ath79 | mikrotik |  mikrotik_routerboard-922uags-5hpacd | 128MB | stable | released
-mANTBox 15s | RB921GS-5HPacD-15S | 5 | ath79 | mikrotik | mikrotik-921gs-5hpacd-15s | 128MB | stable | released
+mANTBox 15s | RB921GS-5HPacD-15S | 5 | ath79 | mikrotik | mikrotik-921gs-5hpacd-15s | 128MB | broken | unavailable
 mANTBox 19s | RB921GS-5HPacD-19S | 5 | ath79 | mikrotik | mikrotik-921gs-5hpacd-19s | 128MB | broken | unavailable
 mANTBox 2 12s | RB911G-2HPnD-12S | 2 | ath79 | mikrotik | mikrotik-911g-2hpnd-12s | 64MB | stable | released
 **Sunset Devices** | | | | | | | |

--- a/configs/ath79-mikrotik-ath10k.config
+++ b/configs/ath79-mikrotik-ath10k.config
@@ -1,6 +1,6 @@
 CONFIG_TARGET_ath79=y
 CONFIG_TARGET_ath79_mikrotik=y
-CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-921gs-5hpacd-15s=y
+#CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-921gs-5hpacd-15s=y
 #CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-921gs-5hpacd-19s=y
 CONFIG_TARGET_DEVICE_ath79_mikrotik_DEVICE_mikrotik_routerboard-922uags-5hpacd=y
 


### PR DESCRIPTION
Like the 19, the 15 can no longer be upgraded reliably so omit the build to avoid people breaking their devices.
Hopefully we can restore these once the root cause is identified.