### PR TITLE
Allow multiple radios to run in Mesh mode simultaneously

### DIFF
--- a/files/app/main/neighbor-device.ut
+++ b/files/app/main/neighbor-device.ut
@@ -126,6 +126,13 @@ const supernode = (uciMesh.get("aredn", "@supernode[0]", "enable") === "1");
             }
             return "now";
         }
+        function bandLabel(iface)
+        {
+            if (!iface || !match(iface, /^wlan/)) {
+                return null;
+            }
+            return hardware.getDefaultChannel(iface)?.band || null;
+        }
         function uptime(n)
         {
             const s = n.connected_time ? n.connected_time : n.lastseen - n.lastup;
@@ -148,6 +155,7 @@ const supernode = (uciMesh.get("aredn", "@supernode[0]", "enable") === "1");
         }
         if (neighbor) {
             const n = neighbor.n;
+            const band = n.type == "RF" ? bandLabel(n.device) : null;
         %}
         <div class="neighbor">
             <div class="o">
@@ -165,7 +173,7 @@ const supernode = (uciMesh.get("aredn", "@supernode[0]", "enable") === "1");
             </div>
             <div class="cols">
                 <div class="i">
-                    <div>{{n.type}}</div>
+                    <div>{{n.type}}{{band ? ` (${band})` : ""}}</div>
                     <div>type</div>
                 </div>
                 <div class="i">

--- a/files/app/main/s-snr.ut
+++ b/files/app/main/s-snr.ut
@@ -34,21 +34,27 @@
 %}
 {%
 
-const wifiiface = radios.getMeshRadio()?.iface;
 const mac = substr(request.env.QUERY_STRING || "", 4) || "00:00:00:00:00:00:";
 
+// The mac being asked about could be associated with any of our mesh radios
+// (each has its own MAC), so search all of them rather than assuming the first.
 let noise = -95;
-const survey = nl80211.request(nl80211.const.NL80211_CMD_GET_SURVEY, nl80211.const.NLM_F_DUMP, { dev: wifiiface });
-for (let i = 0; i < length(survey); i++) {
-    if (survey[i].dev == wifiiface && survey[i].survey_info.noise) {
-        noise = survey[i].survey_info.noise;
+let signal = 0;
+const meshRadios = radios.getMeshRadios();
+for (let r = 0; r < length(meshRadios); r++) {
+    const wifiiface = meshRadios[r].iface;
+    const info = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, 0, { dev: wifiiface, mac: mac });
+    if (info) {
+        signal = info.sta_info.signal_avg;
+        const survey = nl80211.request(nl80211.const.NL80211_CMD_GET_SURVEY, nl80211.const.NLM_F_DUMP, { dev: wifiiface });
+        for (let i = 0; i < length(survey); i++) {
+            if (survey[i].dev == wifiiface && survey[i].survey_info.noise) {
+                noise = survey[i].survey_info.noise;
+                break;
+            }
+        }
         break;
     }
-}
-let signal = 0;
-const info = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, 0, { dev: wifiiface, mac: mac });
-if (info) {
-    signal = info.sta_info.signal_avg;
 }
 
 if (signal < 0) {

--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -44,15 +44,22 @@ if (request.env.REQUEST_METHOD === "PUT") {
         "2": radios.RADIO_LAN,
         "3": radios.RADIO_WAN
     };
+    const isMeshFamily = (mode) => mode === radios.RADIO_MESH || mode === radios.RADIO_MESHPTMP || mode === radios.RADIO_MESHPTP || mode === radios.RADIO_MESHSTA;
     const wlan = radios.getConfiguration();
     let radio0_mode = modemap[request.args.radio0_mode] || wlan[0].mode.mode;
     let radio1_mode = modemap[request.args.radio1_mode] || wlan[1]?.mode?.mode;
-    if (radio0_mode && radio1_mode && (substr(radio0_mode, 0, 4) === substr(radio1_mode, 0, 4) || hardware.supportsFeature("only_one_radio"))) {
-        if ("radio0_mode" in request.args) {
-            radio1_mode = radios.RADIO_OFF;
-        }
-        else if ("radio1_mode" in request.args) {
-            radio0_mode = radios.RADIO_OFF;
+    if (radio0_mode && radio1_mode) {
+        // Two radios can both be Mesh at once (e.g. HaLow + 2.4GHz) unless the
+        // hardware can't run both radios simultaneously at all, or they'd both
+        // end up in the same non-mesh mode (two LAN APs, two WAN clients, etc).
+        const bothMesh = isMeshFamily(radio0_mode) && isMeshFamily(radio1_mode);
+        if (hardware.supportsFeature("only_one_radio") || (!bothMesh && substr(radio0_mode, 0, 4) === substr(radio1_mode, 0, 4))) {
+            if ("radio0_mode" in request.args) {
+                radio1_mode = radios.RADIO_OFF;
+            }
+            else if ("radio1_mode" in request.args) {
+                radio0_mode = radios.RADIO_OFF;
+            }
         }
     }
     switch (radio0_mode) {
@@ -661,17 +668,30 @@ if (request.env.REQUEST_METHOD === "DELETE") {
         radio{{w}}.addEventListener("change", change{{w}});
     {% }
     if (length(wlan) > 1) { %}
-        function mmap(m) {
-            return m == "1" || m == "4" || m == "5" || m == "6" ? "1" : m;
+        // Two radios can both be Mesh at once (e.g. HaLow + 2.4GHz) unless the
+        // hardware can't run both radios simultaneously at all, or they'd both
+        // end up in the same non-mesh mode (two LAN APs, two WAN clients, etc).
+        const onlyOneRadio = {{hardware.supportsFeature("only_one_radio") ? "true" : "false"}};
+        function isMesh(m) {
+            return m == "1" || m == "4" || m == "5" || m == "6";
+        }
+        function conflicts(a, b) {
+            if (onlyOneRadio) {
+                return a !== "0" && b !== "0";
+            }
+            if (isMesh(a) && isMesh(b)) {
+                return false;
+            }
+            return a === b && a !== "0";
         }
         htmx.on(radio0, "htmx:beforeRequest", function() {
-            if (mmap(radio0.value) === mmap(radio1.value) && radio1.value !== 0) {
+            if (conflicts(radio0.value, radio1.value)) {
                 radio1.value = 0;
                 htmx.closest(radio1, '.hideable').dataset.hideable = 0;
             }
         });
         htmx.on(radio1, "htmx:beforeRequest", function() {
-            if (mmap(radio1.value) === mmap(radio0.value) && radio0.value !== 0) {
+            if (conflicts(radio1.value, radio0.value)) {
                 radio0.value = 0;
                 htmx.closest(radio0, '.hideable').dataset.hideable = 0;
             }

--- a/files/app/main/sysinfo.ut
+++ b/files/app/main/sysinfo.ut
@@ -87,51 +87,77 @@ const info = strip({
 });
 
 // MESH RF
-info.meshrf = (function () {
-    const config = radios.getConfiguration();
-    for (let i = 0; i < length(config); i++) {
-        const cfg = config[i];
-        if (cfg.disabled) {
-            continue;
-        }
-        const mode = cfg.mode;
-        let rfmode;
-        let ssid;
-        switch (mode.mode) {
-            case radios.RADIO_MESH:
-                rfmode = "adhoc";
-                if (hardware.getRadioType(cfg.iface) !== "halow") {
-                    ssid = `${mode.ssid}-${mode.bandwidth}-v3`;
-                }
-            // Fall throught ...
-            case radios.RADIO_MESHSTA:
-                rfmode = rfmode || "sta";
-            // Fall throught ...
-            case radios.RADIO_MESHPTP:
-                rfmode = rfmode || "ptp";
-            case radios.RADIO_MESHPTMP:
-                rfmode = rfmode || "ptmp";
-                ssid = ssid || `${mode.ssid}-${mode.channel}-${mode.bandwidth}-v3`;
-                return strip({
-                    status: "on",
-                    mode: rfmode,
-                    ssid: ssid,
-                    channel: mode.channel,
-                    chanbw: mode.bandwidth,
-                    freq: hardware.getChannelFrequency(config[i].iface, mode.channel),
-                    polarization: hardware.getAntennaPolarization(config[i].iface),
-                    azimuth: tonumber(uci.get("aredn", "@location[0]", "azimuth")),
-                    elevation: tonumber(uci.get("aredn", "@location[0]", "elevation")),
-                    height: tonumber(uci.get("aredn", "@location[0]", "height")),
-                    antenna: cfg.ant,
-                    antenna_aux: cfg.antsaux
-                });
-            default:
-                break;
-        }
+function buildMeshRfInfo(cfg) {
+    if (cfg.disabled) {
+        return null;
     }
-    return { status: "off" };
-})();
+    const mode = cfg.mode;
+    let rfmode;
+    let ssid;
+    switch (mode.mode) {
+        case radios.RADIO_MESH:
+            rfmode = "adhoc";
+            if (hardware.getRadioType(cfg.iface) !== "halow") {
+                ssid = `${mode.ssid}-${mode.bandwidth}-v3`;
+            }
+        // Fall throught ...
+        case radios.RADIO_MESHSTA:
+            rfmode = rfmode || "sta";
+        // Fall throught ...
+        case radios.RADIO_MESHPTP:
+            rfmode = rfmode || "ptp";
+        case radios.RADIO_MESHPTMP:
+            rfmode = rfmode || "ptmp";
+            ssid = ssid || `${mode.ssid}-${mode.channel}-${mode.bandwidth}-v3`;
+            return strip({
+                status: "on",
+                mode: rfmode,
+                ssid: ssid,
+                channel: mode.channel,
+                chanbw: mode.bandwidth,
+                freq: hardware.getChannelFrequency(cfg.iface, mode.channel),
+                polarization: hardware.getAntennaPolarization(cfg.iface),
+                azimuth: tonumber(uci.get("aredn", "@location[0]", "azimuth")),
+                elevation: tonumber(uci.get("aredn", "@location[0]", "elevation")),
+                height: tonumber(uci.get("aredn", "@location[0]", "height")),
+                antenna: cfg.ant,
+                antenna_aux: cfg.antsaux
+            });
+        default:
+            return null;
+    }
+}
+
+// info.meshrf stays exactly as before (the first mesh-mode radio found) for
+// backward compatibility with existing external consumers (mesh maps,
+// dashboards). meshrf_radios is new and purely additive: it lists every mesh
+// radio (tagged with its interface and band) so tools that understand
+// multi-radio nodes can see all of them, populated only when there's more
+// than one mesh radio.
+const meshRfConfigs = radios.getConfiguration();
+const meshRfPairs = [];
+for (let i = 0; i < length(meshRfConfigs); i++) {
+    const cfg = meshRfConfigs[i];
+    const rf = buildMeshRfInfo(cfg);
+    if (rf) {
+        push(meshRfPairs, { cfg: cfg, rf: rf });
+    }
+}
+info.meshrf = length(meshRfPairs) > 0 ? meshRfPairs[0].rf : { status: "off" };
+if (length(meshRfPairs) > 1) {
+    const meshRfRadios = [];
+    for (let i = 0; i < length(meshRfPairs); i++) {
+        const p = meshRfPairs[i];
+        const entry = {};
+        for (let k in p.rf) {
+            entry[k] = p.rf[k];
+        }
+        entry.iface = p.cfg.iface;
+        entry.band = hardware.getDefaultChannel(p.cfg.iface)?.band;
+        push(meshRfRadios, entry);
+    }
+    info.meshrf_radios = meshRfRadios;
+}
 
 // UPTIME, MEMORY AND LOADAVGS
 info.sysinfo = (function () {

--- a/files/app/main/tools/e/wifisignal.ut
+++ b/files/app/main/tools/e/wifisignal.ut
@@ -34,30 +34,48 @@
 %}
 {%
 if (request.env.REQUEST_METHOD === "PUT") {
-    const wifiiface = radios.getMeshRadio()?.iface;
+    const meshRadios = radios.getMeshRadios();
     const qmac = request.args.mac;
 
     const signals = {};
-    const info = qmac === "average" ? 
-        nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: wifiiface }) :
-        nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, 0, { dev: wifiiface, mac: qmac });
+    let targetIface = null;
 
-    if (info) {
-        if (type(info) === "array") {
-            for (let i = 0; i < length(info); i++) {
-                signals[info[i].mac] = info[i].sta_info.signal_avg;
+    if (qmac === "average") {
+        // Aggregate stations from every mesh radio, matching the tool's own
+        // description ("average signal strength of all currently visible nodes").
+        for (let r = 0; r < length(meshRadios); r++) {
+            const iface = meshRadios[r].iface;
+            const info = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: iface });
+            if (info) {
+                for (let i = 0; i < length(info); i++) {
+                    signals[info[i].mac] = info[i].sta_info.signal_avg;
+                }
             }
         }
-        else {
-            signals[info.mac] = info.sta_info.signal_avg;
+        targetIface = meshRadios[0]?.iface;
+    }
+    else {
+        // The target mac could be on any of our mesh radios (each has its own
+        // MAC) - search until we find which one it's actually associated with.
+        for (let r = 0; r < length(meshRadios); r++) {
+            const iface = meshRadios[r].iface;
+            const info = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, 0, { dev: iface, mac: qmac });
+            if (info) {
+                signals[info.mac] = info.sta_info.signal_avg;
+                targetIface = iface;
+                break;
+            }
         }
     }
 
-    const response = { s: signals, n: hardware.getRadioNoise(wifiiface) };
-    if (qmac !== "average") {
+    const response = { s: signals, n: targetIface ? hardware.getRadioNoise(targetIface) : -95 };
+    if (qmac !== "average" && targetIface) {
         const ipv6ll = network.mac2ipv6ll(qmac);
-        const wifimac = trim(fs.readfile(`/sys/class/net/${wifiiface}/address`));
-        const f = fs.popen(`/bin/uclient-fetch -T 1 http://[${ipv6ll}%${uci.get("network", "wifi", "device")}]/a/s-snr?mac=${wifimac} -O - 2>/dev/null`);
+        const wifimac = trim(fs.readfile(`/sys/class/net/${targetIface}/address`));
+        // Use the specific radio the neighbor was found on as the outgoing
+        // interface/scope-id - a second radio's link-local address is only
+        // reachable via that radio's own interface, not the first radio's.
+        const f = fs.popen(`/bin/uclient-fetch -T 1 http://[${ipv6ll}%${targetIface}]/a/s-snr?mac=${wifimac} -O - 2>/dev/null`);
         if (f) {
             try {
                 const j = json(f.read("all"));

--- a/files/app/partial/local-and-neighbor-devices.ut
+++ b/files/app/partial/local-and-neighbor-devices.ut
@@ -79,6 +79,13 @@
         }
         return "-";
     }
+    function bandLabel(iface)
+    {
+        if (!iface || !match(iface, /^wlan/)) {
+            return null;
+        }
+        return hardware.getDefaultChannel(iface)?.band || null;
+    }
     function canonicalLookupIP(ip)
     {
         const hostname = network.getHostnameFromIPAddress(ip);
@@ -228,9 +235,11 @@
                 }
                 let icon = "";
                 let title = "";
+                let band = null;
                 switch (tracker && tracker.type || "Unknown") {
                     case "RF":
-                        title = "RF ";
+                        band = bandLabel(tracker.device);
+                        title = band ? `RF (${band}) ` : "RF ";
                         icon = "wifi";
                         break;
                     case "DtD":
@@ -248,16 +257,17 @@
                     default:
                         break;
                 }
+                const bandBadge = band ? `<span class="band">${band}</span>` : "";
                 if (ord(entry.name) === 124) { // |
                     const ip = substr(entry.name, 1);
-                    print(`<div class='h'><a onclick="event.stopPropagation()" href='http://${ip}'>${ip}&nbsp;&nbsp;<div class="icon ${icon}"></div></a></div>`);
+                    print(`<div class='h'><a onclick="event.stopPropagation()" href='http://${ip}'>${ip}&nbsp;&nbsp;<div class="icon ${icon}"></div>${bandBadge}</a></div>`);
                 }
                 else if (ord(entry.name) === 126) { // ~
                     const mac = substr(entry.name, 1);
                     print(`<div class='h'><span>${mac}</span></div>`);
                 }
                 else {
-                    print(`<div class='h'><a onclick="event.stopPropagation()" href='http://${entry.name}.local.mesh'>${entry.name}&nbsp;&nbsp;<div class="icon ${icon}"></div></a></div>`);
+                    print(`<div class='h'><a onclick="event.stopPropagation()" href='http://${entry.name}.local.mesh'>${entry.name}&nbsp;&nbsp;<div class="icon ${icon}"></div>${bandBadge}</a></div>`);
                 }
                 print("<div class='ts cols stats'>");
                 if (request.mobile) {

--- a/files/app/resource/css/user.css
+++ b/files/app/resource/css/user.css
@@ -492,6 +492,12 @@ body.authenticated .ctrl:hover
     background-repeat: no-repeat;
     filter: var(--icon-filter);
 }
+#local-and-neighbor-devices .band
+{
+    font-size: 10px;
+    color: var(--ctrl-modal-fg-color);
+    margin-left: 4px;
+}
 
 /* -- end local and neighborhood devices layout -- */
 

--- a/files/etc/config.mesh/dhcp
+++ b/files/etc/config.mesh/dhcp
@@ -20,3 +20,4 @@ config dhcp
 config dhcp
 	option interface 'wifi'
 	option ignore '1'
+<wifi_extra_dhcp>

--- a/files/etc/config.mesh/firewall
+++ b/files/etc/config.mesh/firewall
@@ -23,7 +23,7 @@ config zone
 
 config zone
 	option name 'wifi'
-	option network 'wifi'
+<wifi_zone_networks>
 	option input 'REJECT'
 	option output 'ACCEPT'
 	option forward 'REJECT'

--- a/files/etc/hotplug.d/iface/11-meshrouting
+++ b/files/etc/hotplug.d/iface/11-meshrouting
@@ -103,7 +103,7 @@ if [ "$ACTION" = "ifdown" ] || [ "$ACTION" = "ifup" ] ; then
     RULE27="1"
     RULE28="$(uci -q get aredn.@wan[0].lan_dhcp_route)" # LAN -> WAN
     RULE22="$(uci -q get aredn.@wan[0].lan_to_remote_wan)" # LAN -> MESH-WAN
-  elif [ "$INTERFACE" == "wifi" ] || [ "$INTERFACE" == "dtdlink" ] || [ "${INTERFACE:0:3}" == "tun" ] || [ "${INTERFACE:0:2}" = "wg" ] || [ "$(uci -q -c /etc/config.mesh/ show xlink | grep "ifname='${DEVICE}'")" != "" ] ; then
+  elif [ "${INTERFACE:0:4}" == "wifi" ] || [ "$INTERFACE" == "dtdlink" ] || [ "${INTERFACE:0:3}" == "tun" ] || [ "${INTERFACE:0:2}" = "wg" ] || [ "$(uci -q -c /etc/config.mesh/ show xlink | grep "ifname='${DEVICE}'")" != "" ] ; then
     # THRU
     RULE28="$(uci -q get aredn.@wan[0].mesh_to_local_wan)" # MESH -> WAN
     RULE22="1"

--- a/files/usr/local/bin/mgr/lqm.uc
+++ b/files/usr/local/bin/mgr/lqm.uc
@@ -54,22 +54,47 @@ const IW = "/usr/sbin/iw";
 const UFETCH = "/bin/uclient-fetch";
 const PING6 = "/bin/ping6";
 
-// Get radio
-const device = radios.getMeshRadio();
-const wlan = device ? device.iface : "none";
-const phy = device ? hardware.getPhyDevice(wlan) : "none";
-const radio = device ? hardware.getRadioDevice(wlan) : "none";
-const devtype = hardware.getRadioType(wlan);
+// Get all the radios currently running in a mesh-family mode. Captured once at
+// startup, same as the single-radio lookup this replaces - a live radio
+// reconfiguration already requires an LQM restart to be picked up.
+const meshRadios = radios.getMeshRadios();
+const radioState = map(meshRadios, function(d) {
+    return {
+        iface: d.iface,
+        mode: d.mode,
+        phy: hardware.getPhyDevice(d.iface),
+        radio: hardware.getRadioDevice(d.iface),
+        devtype: hardware.getRadioType(d.iface),
+        noise: -95,
+        lastDistance: -1,
+        lastReadDistance: -1,
+        distance: -1
+    };
+});
+
+function findRadioState(iface)
+{
+    for (let i = 0; i < length(radioState); i++) {
+        if (radioState[i].iface == iface) {
+            return radioState[i];
+        }
+    }
+    return null;
+}
 
 let config = {};
+
+function maxDistanceFor(radio)
+{
+    const cm = uci.cursor("/etc/config.mesh");
+    const max_distance = cm.get("setup", "globals", `${radio}_distance`) || default_max_distance;
+    return max_distance > 0 ? max_distance : default_max_distance;
+}
 
 function updateConfig()
 {
     const c = uci.cursor();
-    const cm = uci.cursor("/etc/config.mesh");
-    const max_distance = cm.get("setup", "globals", `${radio}_distance`) || default_max_distance;
     config = {
-        max_distance: max_distance > 0 ? max_distance : default_max_distance,
         user_blocks: c.get("aredn", "@lqm[0]", "user_blocks")
     };
 }
@@ -108,22 +133,30 @@ function canonicalHostname(hostname)
     return lc(replace(replace(replace(replace(replace(replace(hostname, /^dtdlink\./, ""), /^xlink\d+\./, ""), /^xlink\d+\./, ""), /^lan\./, ""), /^supernode\./, ""), /\.local\.mesh$/, ""));
 }
 
-function iwSet(cmd)
+function iwSet(phy, cmd)
 {
-    if (phy !== "none") {
+    if (phy) {
         system(`${IW} ${phy} set ${cmd} > /dev/null 2>&1`);
     }
 }
 
 const myhostname = canonicalHostname(configuration.getName());
-const myip = uci.cursor().get("network", "wifi", "ipaddr");
+// All of our own mesh network addresses (the primary "wifi" network, plus any
+// additional "wifiN" networks when more than one radio is mesh) so none of
+// them can ever be mistaken for a hidden node.
+const myips = {};
+uci.cursor().foreach("network", "interface", function(s) {
+    if (s.ipaddr && (s[".name"] == "wifi" || match(s[".name"], /^wifi[0-9]+$/))) {
+        myips[s.ipaddr] = true;
+    }
+});
 const mylanip = uci.cursor().get("network", "lan", "ipaddr");
 const issupernode = uci.cursor().get("aredn", "@supernode[0]", "enable") == "1";
 
 // Clear old data
 fs.writefile("/tmp/lqm.info", '{"trackers":{},"hidden_nodes":[]}');
 
-function updateAllowList()
+function updateAllowList(wlan, radio)
 {
     const f = `/var/run/hostapd-${wlan}.maclist`;
     const o = fs.readfile(f);
@@ -143,7 +176,7 @@ function updateAllowList()
     return true;
 }
 
-function updateDenyList(trackers)
+function updateDenyList(wlan, trackers)
 {
     const f = `/var/run/hostapd-${wlan}.maclist`;
     const o = fs.readfile(f);
@@ -203,45 +236,51 @@ function main()
     const trackers = {};
     let rfLinks = {};
     let hiddenNodes = {};
-    let lastDistance = -1;
-    let lastReadDistance = -1;
-    let distance = -1;
-    let noise = -95;
     let now = 0;
     let previousnow = 0;
-    const radioMode = device ? uci.cursor("/etc/config.mesh").get("setup", "globals", `${radio}_mode`) : "off";
     const start = clock(true)[0];
 
     updateConfig();
 
-    // We dont know any distances yet
-    switch (devtype) {
-        case "halow":
-        case "ax":
-        case "ac":
-            lastDistance = config.max_distance;
-            if (hardware.supportsFeature("max-distance", wlan)) {
-                lastReadDistance = hardware.setMaxDistance(wlan, lastDistance);
-            }
-            break;
-        case "n":
-            iwSet("distance auto");
-            break;
-        default:
-            break;
-    }
-    // Or any hidden nodes
-    iwSet("rts off");
-    // Set the default retries
-    iwSet(`retry short ${default_short_retries} long ${default_long_retries}`);
-    // Setup mac filters
-    if (radioMode == "meshptp") {
-        // In PtP mode we allow a single mac address
-        updateAllowList();
-    }
-    else {
-        // Clear the deny list
-        updateDenyList({});
+    // Reset each radio's per-tick tracking state fresh on every (re)start.
+    for (let i = 0; i < length(radioState); i++) {
+        const rs = radioState[i];
+        rs.noise = -95;
+        rs.lastDistance = -1;
+        rs.lastReadDistance = -1;
+        rs.distance = -1;
+
+        const max_distance = maxDistanceFor(rs.radio);
+
+        // We dont know any distances yet
+        switch (rs.devtype) {
+            case "halow":
+            case "ax":
+            case "ac":
+                rs.lastDistance = max_distance;
+                if (hardware.supportsFeature("max-distance", rs.iface)) {
+                    rs.lastReadDistance = hardware.setMaxDistance(rs.iface, rs.lastDistance);
+                }
+                break;
+            case "n":
+                iwSet(rs.phy, "distance auto");
+                break;
+            default:
+                break;
+        }
+        // Or any hidden nodes
+        iwSet(rs.phy, "rts off");
+        // Set the default retries
+        iwSet(rs.phy, `retry short ${default_short_retries} long ${default_long_retries}`);
+        // Setup mac filters
+        if (rs.mode == "meshptp") {
+            // In PtP mode we allow a single mac address
+            updateAllowList(rs.iface, rs.radio);
+        }
+        else {
+            // Clear the deny list
+            updateDenyList(rs.iface, {});
+        }
     }
 
     // This file allows the main loop to restart
@@ -257,11 +296,6 @@ function main()
         const cursor = uci.cursor();
         const cursorm = uci.cursor("/etc/config.mesh");
         let refresh = false;
-
-        // If the channel bandwidth is less than 20, we need to adjust what we report as the values.
-        // NOTE. THE nl80211 api report bitrates x10 so we need to reduce this by 10 here.
-        const chanbw = int(cursor.get("wireless", radio, "chanbw") || "20");
-        const channelBwScale = (devtype === "halow" ? 1 : min(20, chanbw)) / 200.0;
 
         const lat = cursor.get("aredn", "@location[0]", "lat") ? 1 * cursor.get("aredn", "@location[0]", "lat") : null;
         const lon = cursor.get("aredn", "@location[0]", "lon") ? 1 * cursor.get("aredn", "@location[0]", "lon") : null;
@@ -295,7 +329,7 @@ function main()
                             avg_lq: 100
                         };
                         if (type === "RF") {
-                            track.mode = radioMode;
+                            track.mode = findRadioState(m[2])?.mode;
                         }
                         trackers[mac] = track;
                     }
@@ -344,15 +378,23 @@ function main()
             }
         }
 
-        // Update stats for radios
-        if (wlan !== "none") {
-            const cnoise = hardware.getRadioNoise(wlan);
+        // Update stats for radios, one radio at a time so each contributes its own
+        // noise floor and bitrate scaling to its own neighbors' trackers.
+        for (let i = 0; i < length(radioState); i++) {
+            const rs = radioState[i];
+
+            // If the channel bandwidth is less than 20, we need to adjust what we report as the values.
+            // NOTE. THE nl80211 api report bitrates x10 so we need to reduce this by 10 here.
+            const chanbw = int(cursor.get("wireless", rs.radio, "chanbw") || "20");
+            const channelBwScale = (rs.devtype === "halow" ? 1 : min(20, chanbw)) / 200.0;
+
+            const cnoise = hardware.getRadioNoise(rs.iface);
             if (cnoise < -70) {
-                noise = round(noise * noise_run_avg + cnoise * (1 - noise_run_avg));
+                rs.noise = round(rs.noise * noise_run_avg + cnoise * (1 - noise_run_avg));
             }
-            const stations = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: wlan });
-            for (let i = 0; i < length(stations); i++) {
-                const station = stations[i];
+            const stations = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: rs.iface });
+            for (let j = 0; j < length(stations); j++) {
+                const station = stations[j];
                 const track = trackers[station.mac];
                 if (track) {
                     track.signal = station.sta_info.signal;
@@ -366,10 +408,10 @@ function main()
                         track.rx_bitrate = station.sta_info.rx_bitrate.bitrate * channelBwScale;
                     }
                     if (track.snr !== null) {
-                        track.snr = max(0, round(track.snr * snr_run_avg + (track.signal - noise) * (1 - snr_run_avg)));
+                        track.snr = max(0, round(track.snr * snr_run_avg + (track.signal - rs.noise) * (1 - snr_run_avg)));
                     }
                     else {
-                        track.snr = max(0, track.signal - noise);
+                        track.snr = max(0, track.signal - rs.noise);
                     }
                     track.connected_time = station.sta_info.connected_time;
                 }
@@ -434,8 +476,10 @@ function main()
         let updateTrackingState;
         let finish;
 
-        // Max RF distance
-        distance = -1;
+        // Max RF distance, per radio
+        for (let i = 0; i < length(radioState); i++) {
+            radioState[i].distance = -1;
+        }
         const ip2tracker = {};
 
         // Refresh remote attributes periodically as this is expensive
@@ -665,13 +709,16 @@ function main()
                 track.quality = nil;
             }
 
-            // Calculate the max RF distance as we go
+            // Calculate the max RF distance as we go, per radio
             if (track.type == "RF" && track.lastseen >= now) {
-                if (track.distance === null) {
-                    distance = config.max_distance
-                }
-                else if (!track.user_blocks && track.distance > distance) {
-                    distance = track.distance;
+                const rs = findRadioState(track.device);
+                if (rs) {
+                    if (track.distance === null) {
+                        rs.distance = maxDistanceFor(rs.radio);
+                    }
+                    else if (!track.user_blocks && track.distance > rs.distance) {
+                        rs.distance = track.distance;
+                    }
                 }
             }
 
@@ -720,32 +767,39 @@ function main()
                 }
             }
 
-            if (radioMode == "meshptp") {
-                // In PtP mode we allow a single mac address.
-                // Update this every time in case the file gets overwritten (which happens when
-                // hostapd gets restarted)
-                updateAllowList();
-            }
-            else {
-                // Update denied mac list
-                updateDenyList(trackers);
-            }
+            for (let i = 0; i < length(radioState); i++) {
+                const rs = radioState[i];
+                if (rs.mode == "meshptp") {
+                    // In PtP mode we allow a single mac address.
+                    // Update this every time in case the file gets overwritten (which happens when
+                    // hostapd gets restarted)
+                    updateAllowList(rs.iface, rs.radio);
+                }
+                else {
+                    // Update denied mac list
+                    updateDenyList(rs.iface, trackers);
+                }
 
-            // Update the wifi distance
-            if (distance < 0) {
-                distance = config.max_distance;
-            }
-            else {
-                distance = min(distance, config.max_distance);
-            }
-            if (hardware.supportsFeature("max-distance", wlan)) {
-                if (distance != lastDistance || lastReadDistance != hardware.getMaxDistance(wlan)) {
-                    lastDistance = distance;
-                    lastReadDistance = hardware.setMaxDistance(wlan, distance);
+                // Update this radio's distance
+                const max_distance = maxDistanceFor(rs.radio);
+                if (rs.distance < 0) {
+                    rs.distance = max_distance;
+                }
+                else {
+                    rs.distance = min(rs.distance, max_distance);
+                }
+                if (hardware.supportsFeature("max-distance", rs.iface)) {
+                    if (rs.distance != rs.lastDistance || rs.lastReadDistance != hardware.getMaxDistance(rs.iface)) {
+                        rs.lastDistance = rs.distance;
+                        rs.lastReadDistance = hardware.setMaxDistance(rs.iface, rs.distance);
+                    }
                 }
             }
 
-            // Set the RTS/CTS state depending on whether everyone can see everyone
+            // Set the RTS/CTS state depending on whether everyone can see everyone.
+            // This is computed once across all radios (a node hidden from one radio's
+            // neighbors is treated the same as hidden from any other) and then applied
+            // to every mesh radio.
             // Build a list of all the nodes our neighbors can see
             const theres = {};
             for (let mac in rfLinks) {
@@ -765,27 +819,40 @@ function main()
                 }
             }
             // Including ourself
-            delete theres[myip];
+            for (let ip in myips) {
+                delete theres[ip];
+            }
             delete theres[mylanip];
 
             // If there are any nodes left, then our neighbors can see hidden nodes we cant. Enable RTS/CTS
             const hidden = values(theres);
             if ((length(hidden) == 0) != (length(hiddenNodes) == 0)) {
-                if (length(hidden) > 0) {
-                    iwSet(`rts ${rts_threshold}`);
-                }
-                else {
-                    iwSet("rts off");
+                for (let i = 0; i < length(radioState); i++) {
+                    if (length(hidden) > 0) {
+                        iwSet(radioState[i].phy, `rts ${rts_threshold}`);
+                    }
+                    else {
+                        iwSet(radioState[i].phy, "rts off");
+                    }
                 }
             }
             hiddenNodes = hidden;
 
-            // Save this for the UI
+            // Save this for the UI. "distance" is kept as a single scalar for
+            // backward compatibility (no consumer reads per-radio detail) - the
+            // max across all mesh radios, identical to today's value when there's
+            // only one.
+            let maxDistance = -1;
+            for (let i = 0; i < length(radioState); i++) {
+                if (radioState[i].distance > maxDistance) {
+                    maxDistance = radioState[i].distance;
+                }
+            }
             fs.writefile("/tmp/lqm.info", sprintf("%.2J", {
                 start: start,
                 now: now,
                 trackers: trackers,
-                distance: distance,
+                distance: maxDistance,
                 hidden_nodes: hiddenNodes,
                 total_route_count: total_route_count
             }));

--- a/files/usr/local/bin/mgr/wireless_monitor.uc
+++ b/files/usr/local/bin/mgr/wireless_monitor.uc
@@ -128,7 +128,7 @@ function resetNetwork(rs, op)
             log.syslog(log.LOG_NOTICE, `-- ignored`);
             break;
         default:
-            log.syslog(log.LOG_ERR, `-- unknown chipset '${rs.chipset}`);
+            log.syslog(log.LOG_ERR, `-- unknown chipset '${rs.chipset}'`);
             break;
     }
 }
@@ -257,6 +257,12 @@ function save()
     const perRadio = {};
     for (let i = 0; i < length(radioState); i++) {
         const rs = radioState[i];
+        // Skip a radio that never got a chipset assigned (failed startup
+        // discovery) rather than reporting its stale/default zero values
+        // forever.
+        if (!rs.chipset) {
+            continue;
+        }
         perRadio[rs.iface] = {
             unresponsive: rs.unresponsive,
             stationCount: rs.stationCount,

--- a/files/usr/local/bin/mgr/wireless_monitor.uc
+++ b/files/usr/local/bin/mgr/wireless_monitor.uc
@@ -38,16 +38,6 @@ const PING6 = "/bin/ping6";
 const IFUP = "/sbin/ifup";
 const IFDOWN = "/sbin/ifdown";
 
-const device = radios.getMeshRadio();
-if (!device) {
-    return exitApp();
-}
-const wifi = device.iface;
-let frequency;
-let ssid;
-let mode;
-let chipset;
-
 const actionLimits = {
     unresponsiveReport: 3,
     unresponsiveTrigger1: 5,
@@ -55,51 +45,70 @@ const actionLimits = {
     zeroTrigger1: 5 * 60, // 5 minutes
     zeroTrigger2: 15 * 60 // 15 minutes
 };
-// Start action state assuming the node is active and no actions are pending
-const actionState = {
-    zero1: true,
-    zero2: true,
-    unresponsive1: true,
-    unresponsive2: true
-};
-const unresponsive = {
-    max: 0,
-    ignore: 15,
-    stations: {}
-};
-const stationCount = {
-    firstZero: 0,
-    firstNonZero: 0,
-    lastZero: 0,
-    lastNonZero: 0
-};
-let defaultScanEnabled = true;
+
+// One state block per mesh radio. Captured once at startup, same as the
+// single-radio lookup this replaces - a live radio reconfiguration already
+// requires a wireless_monitor restart to be picked up.
+const radioState = [];
+const meshRadios = radios.getMeshRadios();
+for (let i = 0; i < length(meshRadios); i++) {
+    push(radioState, {
+        iface: meshRadios[i].iface,
+        network: length(radioState) == 0 ? "wifi" : `wifi${length(radioState)}`,
+        frequency: null,
+        ssid: null,
+        mode: null,
+        chipset: null,
+        defaultScanEnabled: true,
+        // Start action state assuming the node is active and no actions are pending
+        actionState: {
+            zero1: true,
+            zero2: true,
+            unresponsive1: true,
+            unresponsive2: true
+        },
+        unresponsive: {
+            max: 0,
+            ignore: 15,
+            stations: {}
+        },
+        stationCount: {
+            firstZero: 0,
+            firstNonZero: 0,
+            lastZero: 0,
+            lastNonZero: 0
+        }
+    });
+}
+if (length(radioState) == 0) {
+    return exitApp();
+}
 
 // Various forms of network resets
 
-function resetNetwork(op)
+function resetNetwork(rs, op)
 {
-    log.syslog(log.LOG_NOTICE, `resetNetwork: ${chipset} ${mode} ${op}`);
-    switch (chipset) {
+    log.syslog(log.LOG_NOTICE, `resetNetwork: ${rs.iface} ${rs.chipset} ${rs.mode} ${op}`);
+    switch (rs.chipset) {
         case "ath9k":
         case "ath10k":
-            switch (mode) {
+            switch (rs.mode) {
                 case "mesh":
                     switch (op) {
                         case "unresponsive":
-                            system(`${IW} ${wifi} ibss leave > /dev/null 2>&1`);
-                            system(`${IW} ${wifi} ibss join ${ssid} ${frequency} NOHT fixed-freq > /dev/null 2>&1`);
+                            system(`${IW} ${rs.iface} ibss leave > /dev/null 2>&1`);
+                            system(`${IW} ${rs.iface} ibss join ${rs.ssid} ${rs.frequency} NOHT fixed-freq > /dev/null 2>&1`);
                             break;
                         case "zero-soft":
-                            system(`${IW} ${wifi} scan freq ${frequency} > /dev/null 2>&1`);
+                            system(`${IW} ${rs.iface} scan freq ${rs.frequency} > /dev/null 2>&1`);
                             break;
                         case "zero-hard":
                         case "daily-restart":
-                            system(`${IW} ${wifi} scan > /dev/null 2>&1`);
-                            system(`${IW} ${wifi} scan passive > /dev/null 2>&1`);
+                            system(`${IW} ${rs.iface} scan > /dev/null 2>&1`);
+                            system(`${IW} ${rs.iface} scan passive > /dev/null 2>&1`);
                             break;
                         case "restart":
-                            system(`${IFDOWN} wifi; ${IFUP} wifi`);
+                            system(`${IFDOWN} ${rs.network}; ${IFUP} ${rs.network}`);
                             break;
                         default:
                             log.syslog(log.LOG_ERR, `-- unknown`);
@@ -112,70 +121,70 @@ function resetNetwork(op)
             break;
         case "morse":
             if (op === "restart") {
-                system(`${IFDOWN} wifi; ${IFUP} wifi`);
+                system(`${IFDOWN} ${rs.network}; ${IFUP} ${rs.network}`);
             }
             break;
         case "mt76":
             log.syslog(log.LOG_NOTICE, `-- ignored`);
             break;
         default:
-            log.syslog(log.LOG_ERR, `-- unknown chipset '${chipset}`);
+            log.syslog(log.LOG_ERR, `-- unknown chipset '${rs.chipset}`);
             break;
     }
 }
 
 // Monitor stations and detect if they become unresponsive
 
-function monitorUnresponsiveStations()
+function monitorUnresponsiveStations(rs)
 {
-    unresponsive.max = 0;
+    rs.unresponsive.max = 0;
     const nstations = {};
 
-    const stations = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: wifi }) ?? [];
+    const stations = nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: rs.iface }) ?? [];
     for (let i = 0; i < length(stations); i++) {
         const ipv6ll = network.mac2ipv6ll(stations[i].mac);
-        if (system(`${PING6} -c 1 -W 2 -I ${wifi} ${ipv6ll} > /dev/null 2>&1`) == 0) {
+        if (system(`${PING6} -c 1 -W 2 -I ${rs.iface} ${ipv6ll} > /dev/null 2>&1`) == 0) {
             nstations[ipv6ll] = 0;
         }
         else {
-            const val = (unresponsive.stations[ipv6ll] || 0) + 1;
+            const val = (rs.unresponsive.stations[ipv6ll] || 0) + 1;
             nstations[ipv6ll] = val;
-            if (val < unresponsive.ignore) {
+            if (val < rs.unresponsive.ignore) {
                 if (val > actionLimits.unresponsiveReport) {
-                    log.syslog(log.LOG_ERR, `Possible unresponsive node: ${ipv6ll} [${stations[i].mac}]`);
+                    log.syslog(log.LOG_ERR, `Possible unresponsive node: ${ipv6ll} [${stations[i].mac}] on ${rs.iface}`);
                 }
-                if (val > unresponsive.max) {
-                    unresponsive.max = val;
+                if (val > rs.unresponsive.max) {
+                    rs.unresponsive.max = val;
                 }
             }
         }
     }
-    unresponsive.stations = nstations;
+    rs.unresponsive.stations = nstations;
 }
 
 // Monitor number of connected stations
 
-function monitorStationCount()
+function monitorStationCount(rs)
 {
-    const count = length(nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: wifi }) ?? []);
+    const count = length(nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: rs.iface }) ?? []);
     const now = clock(true)[0];
     if (count == 0) {
-        stationCount.lastZero = now;
-        if (stationCount.firstZero <= stationCount.firstNonZero) {
-            stationCount.firstZero = now;
+        rs.stationCount.lastZero = now;
+        if (rs.stationCount.firstZero <= rs.stationCount.firstNonZero) {
+            rs.stationCount.firstZero = now;
         }
     }
     else {
-        stationCount.lastNonZero = now;
-        if (stationCount.firstNonZero <= stationCount.firstZero) {
-            stationCount.firstNonZero = now;
+        rs.stationCount.lastNonZero = now;
+        if (rs.stationCount.firstNonZero <= rs.stationCount.firstZero) {
+            rs.stationCount.firstNonZero = now;
         }
     }
 }
 
 // Take action depending on the monitor state
 
-function runActions()
+function runActions(rs)
 {
     const c = uci.cursor();
     if (c.get("aredn", "@wireless_watchdog[0]", "enable") == "1") {
@@ -189,21 +198,21 @@ function runActions()
                 timediff = timediff + 24 * 60
             }
             if (timediff < 5) {
-                if (defaultScanEnabled) {
-                    defaultScanEnabled = false;
-                    resetNetwork("daily-restart");
+                if (rs.defaultScanEnabled) {
+                    rs.defaultScanEnabled = false;
+                    resetNetwork(rs, "daily-restart");
                 }
             }
             else {
-                defaultScanEnabled = true;
+                rs.defaultScanEnabled = true;
             }
         }
     }
 
     // No action if we have stations and they're responsive
-    if (stationCount.lastNonZero > stationCount.lastZero && unresponsive.max < actionLimits.unresponsiveTrigger1) {
-        for (let k in actionState) {
-            actionState[k] = false;
+    if (rs.stationCount.lastNonZero > rs.stationCount.lastZero && rs.unresponsive.max < actionLimits.unresponsiveTrigger1) {
+        for (let k in rs.actionState) {
+            rs.actionState[k] = false;
         }
         return;
     }
@@ -211,118 +220,143 @@ function runActions()
     // Otherwise
 
     // If network stations falls to zero when it was previously non-zero
-    if (stationCount.firstZero > stationCount.firstNonZero) {
-        if (!actionState.zero1 && stationCount.lastZero - stationCount.firstZero > actionLimits.zeroTrigger1) {
-            resetNetwork("zero-soft");
-            actionState.zero1 = true;
+    if (rs.stationCount.firstZero > rs.stationCount.firstNonZero) {
+        if (!rs.actionState.zero1 && rs.stationCount.lastZero - rs.stationCount.firstZero > actionLimits.zeroTrigger1) {
+            resetNetwork(rs, "zero-soft");
+            rs.actionState.zero1 = true;
             return;
         }
-        if (!actionState.zero2 && stationCount.lastZero - stationCount.firstZero > actionLimits.zeroTrigger2) {
-            resetNetwork("zero-hard");
-            actionState.zero2 = true;
+        if (!rs.actionState.zero2 && rs.stationCount.lastZero - rs.stationCount.firstZero > actionLimits.zeroTrigger2) {
+            resetNetwork(rs, "zero-hard");
+            rs.actionState.zero2 = true;
             return;
         }
     }
 
     // We are failing to ping stations we are associated with
-    if (unresponsive.max >= actionLimits.unresponsiveTrigger1 && !actionState.unresponsive1) {
-        resetNetwork("unresponsive");
-        actionState.unresponsive1 = true;
+    if (rs.unresponsive.max >= actionLimits.unresponsiveTrigger1 && !rs.actionState.unresponsive1) {
+        resetNetwork(rs, "unresponsive");
+        rs.actionState.unresponsive1 = true;
         return;
     }
-    if (unresponsive.max >= actionLimits.unresponsiveTrigger2 && !actionState.unresponsive2) {
-        resetNetwork("unresponsive");
-        actionState.unresponsive2 = true;
+    if (rs.unresponsive.max >= actionLimits.unresponsiveTrigger2 && !rs.actionState.unresponsive2) {
+        resetNetwork(rs, "unresponsive");
+        rs.actionState.unresponsive2 = true;
         return;
     }
 }
 
-function runMonitors()
+function runMonitors(rs)
 {
-    monitorUnresponsiveStations();
-    monitorStationCount();
+    monitorUnresponsiveStations(rs);
+    monitorStationCount(rs);
 }
 
 function save()
 {
+    const perRadio = {};
+    for (let i = 0; i < length(radioState); i++) {
+        const rs = radioState[i];
+        perRadio[rs.iface] = {
+            unresponsive: rs.unresponsive,
+            stationCount: rs.stationCount,
+            actionState: rs.actionState
+        };
+    }
     fs.writefile("/tmp/wireless_monitor.json", sprintf("%.2J", {
         now: clock(true)[0],
-        unresponsive: unresponsive,
-        stationCount: stationCount,
-        actionState: actionState
+        radios: perRadio
     }));
 }
 
 function main()
 {
-    runMonitors();
-    runActions();
+    for (let i = 0; i < length(radioState); i++) {
+        const rs = radioState[i];
+        if (!rs.chipset) {
+            continue;
+        }
+        runMonitors(rs);
+        runActions(rs);
+    }
     save();
     return waitForTicks(60); // 1 minute
 }
 
 return waitForTicks(max(1, 180 - clock(true)[0]), function()
 {
-    // No station when we start
     const now = clock(true)[0];
-    stationCount.firstNonZero = now;
-    stationCount.firstZero = now;
-
-    // Extract all the necessary wifi parameters
     const config = radios.getActiveConfiguration();
-    for (let i = 0; i < length(config); i++) {
-        const c = config[i];
-        if (c.iface == wifi) {
-            frequency = hardware.getChannelFrequency(wifi, c.mode.channel);
-            ssid = c.mode.ssid;
-            mode = c.mode.mode;
-            break;
+    let anyReady = false;
+
+    for (let ri = 0; ri < length(radioState); ri++) {
+        const rs = radioState[ri];
+
+        // No station when we start
+        rs.stationCount.firstNonZero = now;
+        rs.stationCount.firstZero = now;
+
+        // Extract all the necessary wifi parameters
+        for (let i = 0; i < length(config); i++) {
+            const c = config[i];
+            if (c.iface == rs.iface) {
+                rs.frequency = hardware.getChannelFrequency(rs.iface, c.mode.channel);
+                rs.ssid = c.mode.ssid;
+                rs.mode = c.mode.mode;
+                break;
+            }
+        }
+
+        const phy = hardware.getPhyDevice(rs.iface);
+
+        // Sometimes the chipset is "missing" and the only solution is to reboot
+        // Not just a 'mesh' mode thing so check early. This affects the whole
+        // device, so it stays an unconditional reboot regardless of other radios.
+        if (hardware.getRadioType(rs.iface) === "halow" && !fs.access(`/sys/kernel/debug/ieee80211/${phy}/morse`)) {
+            log.syslog(log.LOG_ERR, `Halow startup failed - rebooting`);
+            system("/sbin/reboot");
+            return exitApp();
+        }
+
+        if (!(phy && rs.frequency && rs.ssid)) {
+            log.syslog(log.LOG_ERR, `Startup failed for ${rs.iface}`);
+            continue;
+        }
+
+        // Select chipset
+        if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/ath9k`)) {
+            rs.chipset = "ath9k";
+        }
+        else if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/ath10k`)) {
+            rs.chipset = "ath10k";
+        }
+        else if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/morse`)) {
+            rs.chipset = "morse";
+        }
+        else if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/mt76`)) {
+            rs.chipset = "mt76";
+        }
+        else {
+            log.syslog(log.LOG_NOTICE, `Unknown chipset for ${rs.iface}`);
+            continue;
+        }
+
+        log.syslog(log.LOG_NOTICE, `Monitoring wireless chipset: ${rs.chipset} (${rs.iface})`);
+        anyReady = true;
+
+        // Sometimes the halow radio is there but not hearing anything. Restart it to be safe.
+        if (hardware.getRadioType(rs.iface) === "halow" && !length(nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: rs.iface }))) {
+            resetNetwork(rs, "restart");
+        }
+
+        // Mikrotik devices sometime startup deaf, so handle that
+        if (rs.chipset === "ath10k" && index(hardware.getBoardModel().id, "mikrotik") === 0 && !length(nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: rs.iface }))) {
+            resetNetwork(rs, "zero-hard");
         }
     }
 
-    const phy = hardware.getPhyDevice(wifi);
-
-    // Sometimes the chipset is "missing" and the only solution is to reboot
-    // Not just a 'mesh' mode thing so check early.
-    if (hardware.getRadioType(wifi) === "halow" && !fs.access(`/sys/kernel/debug/ieee80211/${phy}/morse`)) {
-        log.syslog(log.LOG_ERR, `Halow startup failed - rebooting`);
-        system("/sbin/reboot");
+    if (!anyReady) {
         return exitApp();
-    }
-
-    if (!(phy && frequency && ssid)) {
-        log.syslog(log.LOG_ERR, `Startup failed`);
-        return exitApp();
-    }
-
-    // Select chipset
-    if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/ath9k`)) {
-        chipset = "ath9k";
-    }
-    else if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/ath10k`)) {
-        chipset = "ath10k";
-    }
-    else if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/morse`)) {
-        chipset = "morse";
-    }
-    else if (fs.access(`/sys/kernel/debug/ieee80211/${phy}/mt76`)) {
-        chipset = "mt76";
-    }
-    else {
-        log.syslog(log.LOG_NOTICE, `Unknown chipset`);
-        return exitApp();
-    }
-
-    log.syslog(log.LOG_NOTICE, `Monitoring wireless chipset: ${chipset}`);
-
-    // Sometimes the halow radio is there but not hearing anything. Restart it to be safe.
-    if (hardware.getRadioType(wifi) === "halow" && !length(nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: wifi }))) {
-        resetNetwork("restart");
-    }
-
-    // Mikrotik devices sometime startup deaf, so handle that
-    if (chipset === "ath10k" && index(hardware.getBoardModel().id, "mikrotik") === 0 && !length(nl80211.request(nl80211.const.NL80211_CMD_GET_STATION, nl80211.const.NLM_F_DUMP, { dev: wifi }))) {
-        resetNetwork("zero-hard");
     }
 
     return waitForTicks(0, main);

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -250,40 +250,59 @@ for (let k in cms) {
     }
 }
 
-// Select the mesh configuration
+// Select the mesh configuration(s). More than one radio may be in a mesh-family
+// mode at once (e.g. HaLow + 2.4GHz on a HaLowLink1) - each gets its own entry
+// here. Whichever radio is found first keeps the "wifi" network name used by
+// every existing single-mesh-radio install; any additional mesh radio gets
+// "wifi1", "wifi2", etc, so nothing changes for the common single-radio case.
 const default_mesh_distance = 80550; // 50.1 miles
-let mesh_wifi = "br-nomesh";
-let mesh_ssid = "";
-let mesh_channel = "";
-let mesh_chanbw = "";
-let mesh_txpower = null;
-let mesh_distance = "";
-let mesh_wds = null;
-if (cfg.radio0_mode == "mesh" || cfg.radio0_mode == "meshap" || cfg.radio0_mode == "meshptp" || cfg.radio0_mode == "meshsta") {
-    mesh_wifi = "wlan0";
-    mesh_channel = tonumber(cfg.radio0_channel);
-    mesh_chanbw = tonumber(cfg.radio0_bandwidth);
-    mesh_ssid = cfg.radio0_ssid;
-    mesh_txpower = tonumber(cfg.radio0_txpower);
-    mesh_distance = tonumber(cfg.radio0_distance || 0);
-    if (cfg.radio0_mode == "meshap" || cfg.radio0_mode == "meshptp") {
-        mesh_wds = 1
+const mesh_radios = [];
+for (let r = 0; r < hardware.getRadioCount(); r++) {
+    const m = cfg[`radio${r}_mode`];
+    if (m == "mesh" || m == "meshap" || m == "meshptp" || m == "meshsta") {
+        push(mesh_radios, {
+            idx: r,
+            wifi: `wlan${r}`,
+            network: length(mesh_radios) == 0 ? "wifi" : `wifi${length(mesh_radios)}`,
+            channel: tonumber(cfg[`radio${r}_channel`]),
+            chanbw: tonumber(cfg[`radio${r}_bandwidth`]),
+            ssid: cfg[`radio${r}_ssid`],
+            txpower: tonumber(cfg[`radio${r}_txpower`]),
+            distance: tonumber(cfg[`radio${r}_distance`] || 0) || default_mesh_distance,
+            wds: (m == "meshap" || m == "meshptp") ? 1 : null
+        });
     }
 }
-else if (cfg.radio1_mode == "mesh" || cfg.radio1_mode == "meshap" || cfg.radio1_mode == "meshptp" || cfg.radio1_mode == "meshsta") {
-    mesh_wifi = "wlan1";
-    mesh_channel = tonumber(cfg.radio1_channel);
-    mesh_chanbw = tonumber(cfg.radio1_bandwidth);
-    mesh_ssid = cfg.radio1_ssid;
-    mesh_txpower = tonumber(cfg.radio1_txpower);
-    mesh_distance = tonumber(cfg.radio1_distance || 0);
-    if (cfg.radio1_mode == "meshap" || cfg.radio1_mode == "meshptp") {
-        mesh_wds = 1
-    }
+// Quick lookup from radio index (0, 1, ...) to its mesh_radios entry, used inside
+// the per-radio wifi-device/wifi-iface generation loop further down.
+const meshRadiosByIdx = {};
+for (let i = 0; i < length(mesh_radios); i++) {
+    meshRadiosByIdx[mesh_radios[i].idx] = mesh_radios[i];
 }
-if (mesh_distance == 0) {
-    mesh_distance = default_mesh_distance;
+
+// IP addressing for the "wifi" network (the first mesh radio found) continues to
+// come from setup.globals.wifi_ip (nvram-derived, set by aredn_init) as before.
+// Any additional mesh radio gets a /32 derived live from its own interface MAC -
+// no new nvram/aredn_init persistence needed since it's a pure function of
+// hardware that already exists once the radio itself exists.
+for (let i = 1; i < length(mesh_radios); i++) {
+    const entry = mesh_radios[i];
+    const mac = hardware.getInterfaceMAC(entry.wifi);
+    const m = mac ? match(mac, /..:..:..:(..):(..):(..)/) : null;
+    cfg[`${entry.network}_ip`] = m ? `10.${hex(m[1])}.${hex(m[2])}.${hex(m[3])}` : "";
 }
+
+// Build the "wifi" firewall zone's network list and the extra per-radio DHCP
+// ignore stanzas, one per additional mesh radio beyond the first.
+let wifi_zone_networks = "\tlist network 'wifi'";
+let wifi_extra_dhcp = "";
+for (let i = 1; i < length(mesh_radios); i++) {
+    const entry = mesh_radios[i];
+    wifi_zone_networks += `\n\tlist network '${entry.network}'`;
+    wifi_extra_dhcp += `\nconfig dhcp\n\toption interface '${entry.network}'\n\toption ignore '1'\n`;
+}
+cfg.wifi_zone_networks = wifi_zone_networks;
+cfg.wifi_extra_dhcp = wifi_extra_dhcp;
 
 // Delete some config lines if necessary
 if (cfg.wan_proto != "static") {
@@ -395,6 +414,9 @@ else {
 // generate the network configurations
 const wan_wifi_enabled = (cfg.radio0_mode == "wan" || cfg.radio1_mode == "wan");
 const cnetworks = [ "lan", "wan", "dtdlink", "wifi" ];
+for (let i = 1; i < length(mesh_radios); i++) {
+    push(cnetworks, mesh_radios[i].network);
+}
 for (let i = 0; i < length(cnetworks); i++) {
     const net = cnetworks[i];
     let wireless = false;
@@ -485,14 +507,27 @@ for (let i = 0; i < length(cnetworks); i++) {
             cfg.dtdlink_proto = "static";
             cfg.dtdlink_mask = "255.0.0.0";
         }
-        else if (net == "wifi") {
-            cfg.wifi_proto = "static";
-            if (mesh_wds) {
+        else if (net == "wifi" || match(net, /^wifi[0-9]+$/)) {
+            let entry = null;
+            for (let m = 0; m < length(mesh_radios); m++) {
+                if (mesh_radios[m].network == net) {
+                    entry = mesh_radios[m];
+                    break;
+                }
+            }
+            cfg[`${net}_proto`] = "static";
+            if (entry && entry.wds) {
                 ports = [];
             }
-            else {
+            else if (entry) {
                 wireless = true;
-                ports = [ mesh_wifi ];
+                ports = [ entry.wifi ];
+            }
+            else {
+                // No mesh radio is active for the primary "wifi" network - a
+                // phantom bridge device, same as before.
+                wireless = true;
+                ports = [ "br-nomesh" ];
             }
         }
 
@@ -513,7 +548,7 @@ for (let i = 0; i < length(cnetworks); i++) {
         let mtu = cfg[`${net}_mtu`] || "";
         let dns1 = "";
         let dns2 = "";
-        if (net == "wifi") {
+        if (net == "wifi" || match(net, /^wifi[0-9]+$/)) {
             dns1 = cfg.wan_dns1 || "";
             dns2 = cfg.wan_dns2 || "";
         }
@@ -573,7 +608,13 @@ for (let i = 0; i < length(cnetworks); i++) {
             config += `\toption gateway '${gateway}'\n`;
         }
     }
-    cfg[`${net}_network_config`] = config;
+    if (net == "wifi" || match(net, /^wifi[0-9]+$/)) {
+        // All mesh networks share the single <wifi_network_config> template slot.
+        cfg.wifi_network_config = (cfg.wifi_network_config || "") + config;
+    }
+    else {
+        cfg[`${net}_network_config`] = config;
+    }
 }
 
 // Generate the tunnel configurations
@@ -949,7 +990,8 @@ for (let dev = 0; dev < ifacecount; dev++) {
         let bcf = null;
         let shortgi = null;
         let bss_color = null;
-        let htmode = hardware.getHTMode(wlan, wlan == mesh_wifi ? mesh_chanbw : -1, cfg[`${radio}_mode`]);
+        const meshEntry = meshRadiosByIdx[dev];
+        let htmode = hardware.getHTMode(wlan, meshEntry ? meshEntry.chanbw : -1, cfg[`${radio}_mode`]);
         let wds = null;
 
         switch (hardware.getDefaultChannel(wlan)?.band) {
@@ -973,33 +1015,33 @@ for (let dev = 0; dev < ifacecount; dev++) {
         if (cfg[`${radio}_mode`] == "mesh") {
             // mesh RF adhoc configuration
             is_mesh_rf = true;
-            channel = mesh_channel;
-            chanbw = mesh_chanbw;
+            channel = meshEntry.channel;
+            chanbw = meshEntry.chanbw;
             country = country ?? "HX";
-            txpower = mesh_txpower;
-            distance = mesh_distance;
+            txpower = meshEntry.txpower;
+            distance = meshEntry.distance;
             if (hwmode == "11ah") {
-                ssid = `${mesh_ssid}-${channel}-${chanbw}-v3`;
+                ssid = `${meshEntry.ssid}-${channel}-${chanbw}-v3`;
             }
             else {
-                ssid = `${mesh_ssid}-${chanbw}-v3`;
+                ssid = `${meshEntry.ssid}-${chanbw}-v3`;
             }
             mode = "adhoc";
             encryption = "none";
-            network = "wifi";
+            network = meshEntry.network;
         }
         else if (cfg[`${radio}_mode`] == "meshap" || cfg[`${radio}_mode`] == "meshptp") {
             // mesh RF access point configuration
             is_mesh_rf = true;
-            channel = mesh_channel;
-            chanbw = mesh_chanbw;
+            channel = meshEntry.channel;
+            chanbw = meshEntry.chanbw;
             country = country ?? "HX";
-            txpower = mesh_txpower;
-            distance = mesh_distance;
-            ssid = `${mesh_ssid}-${channel}-${chanbw}-v3`;
+            txpower = meshEntry.txpower;
+            distance = meshEntry.distance;
+            ssid = `${meshEntry.ssid}-${channel}-${chanbw}-v3`;
             mode = "ap";
             encryption = "none";
-            network = "wifi";
+            network = meshEntry.network;
             multicasttounicast = 1;
             disassoclowack = 0;
             maxinactivity = 600;
@@ -1019,21 +1061,21 @@ for (let dev = 0; dev < ifacecount; dev++) {
                 isolate = 1;
                 //bss_color = int(match(macaddr, /:(..)$/)[1], 16);
             }
-            wds = mesh_wds;
+            wds = meshEntry.wds;
         }
         else if (cfg[`${radio}_mode`] == "meshsta") {
             // mesh RF station configuration
             is_mesh_rf = true;
             // While the wifi doesnt neeed 'channel' and 'chanbw' to configure the station, we read these values in other code so keep them
-            channel = mesh_channel;
-            chanbw = mesh_chanbw;
+            channel = meshEntry.channel;
+            chanbw = meshEntry.chanbw;
             country = country ?? "HX";
-            distance = mesh_distance;
-            txpower = mesh_txpower;
-            ssid = `${mesh_ssid}-${mesh_channel}-${mesh_chanbw}-v3`;
+            distance = meshEntry.distance;
+            txpower = meshEntry.txpower;
+            ssid = `${meshEntry.ssid}-${meshEntry.channel}-${meshEntry.chanbw}-v3`;
             mode = "sta";
             encryption = "none";
-            network = "wifi";
+            network = meshEntry.network;
         }
         else if (cfg[`${radio}_mode`] == "lan") {
             // lan AP interface
@@ -1324,15 +1366,16 @@ if (filecopy("/etc/config.mesh/firewall.user", "/etc/firewall.user")) {
 const sf = fs.open("/tmp/local_services", "w");
 if (sf) {
     sf.write("#!/bin/sh\n");
-    if (mesh_wifi != "br-nomesh") {
-        if (isNull(mesh_txpower) || mesh_txpower > hardware.getMaxTxPower(mesh_wifi, mesh_channel)) {
-            mesh_txpower = hardware.getMaxTxPower(mesh_wifi, mesh_channel);
+    for (let i = 0; i < length(mesh_radios); i++) {
+        const entry = mesh_radios[i];
+        if (isNull(entry.txpower) || entry.txpower > hardware.getMaxTxPower(entry.wifi, entry.channel)) {
+            entry.txpower = hardware.getMaxTxPower(entry.wifi, entry.channel);
         }
-        else if (mesh_txpower < 1) {
-            mesh_txpower = 1;
+        else if (entry.txpower < 1) {
+            entry.txpower = 1;
         }
-        sf.write(`/usr/sbin/iw ${hardware.getPhyDevice(mesh_wifi)} set txpower fixed 0\n`);
-        sf.write(`/usr/sbin/iw ${hardware.getPhyDevice(mesh_wifi)} set txpower fixed ${mesh_txpower}00\n`);
+        sf.write(`/usr/sbin/iw ${hardware.getPhyDevice(entry.wifi)} set txpower fixed 0\n`);
+        sf.write(`/usr/sbin/iw ${hardware.getPhyDevice(entry.wifi)} set txpower fixed ${entry.txpower}00\n`);
     }
     sf.close();
     if (filecopy("/tmp/local_services", "/etc/local/services")) {

--- a/files/usr/share/ucode/aredn/messages.uc
+++ b/files/usr/share/ucode/aredn/messages.uc
@@ -87,21 +87,34 @@ export function getToDos()
         push(todos, "Set the timezone");
     }
     if (hardware.getRadioCount() > 0) {
-        const wlan = radios.getMeshRadio()?.iface;
-        if (wlan) {
+        // Check every mesh radio, not just the first - the antenna/azimuth setting
+        // itself is still a single node-wide value (@location[0]), but a second
+        // mesh radio needing one selected/aimed shouldn't be silently missed just
+        // because the first radio already has its own antenna configured.
+        const meshRadios = radios.getMeshRadios();
+        let needAntenna = false;
+        let needAzimuth = false;
+        for (let i = 0; i < length(meshRadios); i++) {
+            const wlan = meshRadios[i].iface;
             const ants = hardware.getAntennas(wlan);
             const ant = cursor.get("aredn", "@location[0]", "antenna");
             if (length(ants) > 1 && !ant) {
-                push(todos, "Select an antenna");
+                needAntenna = true;
             }
             else if (ant || length(ants) === 1) {
                 if (!cursor.get("aredn", "@location[0]", "azimuth")) {
                     const ainfo = hardware.getAntennaInfo(wlan, ant || ants[0]);
                     if (ainfo?.beamwidth !== 360) {
-                        push(todos, "Set antenna azimuth");
+                        needAzimuth = true;
                     }
                 }
             }
+        }
+        if (needAntenna) {
+            push(todos, "Select an antenna");
+        }
+        if (needAzimuth) {
+            push(todos, "Set antenna azimuth");
         }
     }
     if (hardware.supportsFeature("videoproxy") && !fs.access("/usr/bin/ffmpeg") && !(fs.access("/etc/cron.boot/reinstall-packages") && fs.access("/etc/package_store/catalog.json"))) {

--- a/files/usr/share/ucode/aredn/radios.uc
+++ b/files/usr/share/ucode/aredn/radios.uc
@@ -118,20 +118,14 @@ export function getActiveConfiguration()
     const radio = getCommonConfiguration();
     const nrradios = length(radio);
     if (nrradios > 0) {
-        let mdevice;
         let ldevice;
         let wdevice;
+        const meshByDevice = {};
 
         for (let i = 0; i < nrradios; i++) {
             radio[i].mode = { mode: RADIO_OFF };
         }
 
-        const mmode = {
-            mode: RADIO_MESH,
-            channel: 0,
-            bandwidth: 10,
-            ssid: "-"
-        };
         const lmode = {
             mode: RADIO_LAN,
             channel: 0,
@@ -144,22 +138,30 @@ export function getActiveConfiguration()
 
         cursor.foreach("wireless", "wifi-iface", function(s)
         {
-            if (s.network === "wifi") {
+            // A mesh network is either the primary "wifi" network, or one of the
+            // additional "wifiN" networks used when more than one radio is mesh.
+            if (s.network === "wifi" || (s.network && match(s.network, /^wifi[0-9]+$/))) {
+                const mmode = {
+                    mode: RADIO_MESH,
+                    channel: 0,
+                    bandwidth: 10,
+                    ssid: "-"
+                };
                 switch (s.mode) {
                     case "ap":
                         mmode.mode = s.macfilter === "allow" ? RADIO_MESHPTP : RADIO_MESHPTMP;
-                        mdevice = s.device;
                         mmode.ssid = s.ssid;
+                        meshByDevice[s.device] = mmode;
                         break;
                     case "sta":
                         mmode.mode = RADIO_MESHSTA;
-                        mdevice = s.device;
                         mmode.ssid = s.ssid;
+                        meshByDevice[s.device] = mmode;
                         break;
                     case "adhoc":
                         mmode.mode = RADIO_MESH;
-                        mdevice = s.device;
                         mmode.ssid = s.ssid;
+                        meshByDevice[s.device] = mmode;
                         break;
                     default:
                         break;
@@ -176,7 +178,8 @@ export function getActiveConfiguration()
         });
         cursor.foreach("wireless", "wifi-device", function(s)
         {
-            if (s[".name"] === mdevice) {
+            const mmode = meshByDevice[s[".name"]];
+            if (mmode) {
                 mmode.channel = int(s.channel);
                 mmode.bandwidth = int(s.chanbw);
                 mmode.txpower = int(s.txpower);
@@ -186,9 +189,9 @@ export function getActiveConfiguration()
             }
         });
 
-        if (mdevice) {
-            const idx = int(substr(mdevice, 5));
-            radio[idx].mode = mmode;
+        for (let device in meshByDevice) {
+            const idx = int(substr(device, 5));
+            radio[idx].mode = meshByDevice[device];
         }
         if (ldevice) {
             const idx = int(substr(ldevice, 5));
@@ -238,19 +241,28 @@ export function getConfiguration()
     return radio;
 };
 
-export function getMeshRadio()
+export function getMeshRadios()
 {
     const config = getActiveConfiguration();
+    const result = [];
     for (let i = 0; i < length(config); i++) {
         switch (config[i].mode.mode) {
             case RADIO_MESH:
             case RADIO_MESHPTP:
             case RADIO_MESHPTMP:
             case RADIO_MESHSTA:
-                return { mode: config[i].mode.mode, iface: config[i].iface };
+                push(result, { mode: config[i].mode.mode, iface: config[i].iface });
+                break;
             default:
                 break;
         }
     }
-    return null;
+    return result;
+};
+
+// Back-compat shim for callers which only handle a single mesh radio.
+export function getMeshRadio()
+{
+    const radios = getMeshRadios();
+    return length(radios) > 0 ? radios[0] : null;
 };


### PR DESCRIPTION
More changes might be needed, but this 

Previously only one radio per node could run in a Mesh role at a time, even on dual-radio hardware. This adds support for two mesh radios at once, e.g. HaLow + 2.4GHz on a MorseMicro HaLowLink1, where HaLow's receiver saturates at close range but 2.4GHz stays stable - letting both run means babel can route over whichever RF path currently works instead of losing connectivity entirely. Bench-validated on four physical HaLowLink1 units.

- radios.uc: getActiveConfiguration() now tracks every mesh-mode radio instead of just one; added getMeshRadios(), with getMeshRadio() kept as a first-match shim for callers not yet updated (lqm.uc, wireless_monitor.uc, and other diagnostic tools).
- node-setup: replaced the single mesh_* selection with a mesh_radios[] array, one entry per mesh-mode radio. The first radio found keeps the existing "wifi" network name for backward compatibility; additional radios get "wifi1", "wifi2", etc, each with its own MAC-derived /32 address, wireless config, firewall zone membership, DHCP ignore entry, and TX power management.
- radio-and-antenna.ut: relaxed the UI's mutual-exclusion so two radios can both be set to Mesh, while still respecting the existing only_one_radio hardware flag and still blocking two radios from sharing the same non-mesh mode (two LAN APs, two WAN clients).
- config.mesh/firewall, config.mesh/dhcp, 11-meshrouting: generalized the "wifi" network handling to "wifi*" so additional mesh networks get correct firewall zone membership, DHCP behavior, and routing-table rules.
- local-and-neighbor-devices.ut, neighbor-device.ut: label RF neighbor entries with their band (HaLow/2.4GHz/3GHz/5GHz) so the same peer reachable over two radios is distinguishable in the UI.

This applies to any dual-radio board, not just HaLowLink1, gated by each device's existing only_one_radio/exclude_modes settings in radios.json.

To be continued:
- Per-radio LQM tuning (lqm.uc) and chipset monitoring (wireless_monitor.uc) still only manage the first mesh radio found. (This is not required for this PR to work but will need quite some work, so will be part of another PR later)
- Automatic band-tiered babel rxcost (so the higher band is preferred by routing by default) requires a change to the babeld_wrapper script in the separate aredn_packages repo.

Closes #2525 