### PR TITLE
Modify modes available on halow secondary radios.

### DIFF
--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -1376,7 +1376,7 @@
     },
     "wlan1": {
       "exclude_bandwidths": [ 5, 10 ],
-      "exclude_modes": [ "meshap", "meshptp", "meshsta" ],
+      "exclude_modes": [ "mesh" ],
       "maxpower": 20,
       "antenna": {
         "description": "3.5 dBi Omni",
@@ -1397,7 +1397,7 @@
     },
     "wlan1": {
       "exclude_bandwidths": [ 5, 10 ],
-      "exclude_modes": [ "meshap", "meshptp", "meshsta" ],
+      "exclude_modes": [ "mesh" ],
       "maxpower": 20,
       "antenna": {
         "description": "3.5 dBi Omni",
@@ -1418,7 +1418,7 @@
     },
     "wlan1": {
       "exclude_bandwidths": [ 5, 10 ],
-      "exclude_modes": [ "mesh", "meshap", "meshptp", "meshsta" ],
+      "exclude_modes": [ "mesh" ],
       "maxpower": 20,
       "antenna": {
         "description": "Omni",
@@ -1443,7 +1443,7 @@
     },
     "wlan1": {
       "exclude_bandwidths": [ 5, 10 ],
-      "exclude_modes": [ "mesh", "meshap", "meshptp", "meshsta" ],
+      "exclude_modes": [ "mesh" ],
       "maxpower": 20,
       "antenna": {
         "description": "Omni",
@@ -1468,7 +1468,7 @@
     },
     "wlan1": {
       "exclude_bandwidths": [ 5, 10 ],
-      "exclude_modes": [ "mesh", "meshap", "meshptp", "meshsta" ],
+      "exclude_modes": [ "mesh" ],
       "maxpower": 20,
       "antenna": {
         "description": "Omni",


### PR DESCRIPTION
Experience with the mt76 chipsets on other non-halow radios has show which mesh options will work (sta + ap) and wont (adhoc) so make these modes available. This is the 2.4GHz radio on these devices not the 900MHz.