### PR TITLE
Avoid extra reboot on halow wireless devices

### DIFF
--- a/files/usr/local/bin/aredn_init
+++ b/files/usr/local/bin/aredn_init
@@ -194,6 +194,7 @@ if (nvram.get("hsmmmesh", "settings", "configured") != "0") {
     if (fs.access("/tmp/reboot-required")) {
         if (fs.access("/etc/local/aredn_init_rebooted")) {
             print("Rebooting node requested, but would loop so ignoring\n");
+            fs.rename("/tmp/reboot-required", "/tmp/xtra-reboot-debug");
             fs.unlink("/etc/local/aredn_init_rebooted");
         }
         else {

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -1342,7 +1342,7 @@ for (let file in nfiles) {
     }
 }
 
-fs.rmdir("/tmp/new_config");
+removeAll("/tmp/new_config");
 
 nvram.set("hsmmmesh", "settings", "node", node);
 nvram.set("hsmmmesh", "settings", "tactical", tactical);


### PR DESCRIPTION
This happens because the MorseMicro software messes with out wireless config making it look like it's been changed when it hasn't.