### PR TITLE
Allow a node to opt-out of routing internet bound traffic.

### DIFF
--- a/files/app/main/status/e/network.ut
+++ b/files/app/main/status/e/network.ut
@@ -178,6 +178,9 @@ if (request.env.REQUEST_METHOD === "PUT") {
     if ("lan_dhcp_defaultroute" in request.args) {
         uciMesh.set("aredn", "@wan[0]", "lan_dhcp_defaultroute", request.args.lan_dhcp_defaultroute === "on" ? 1 : 0);
     }
+    if ("mesh_internet" in request.args) {
+        uciMesh.set("aredn", "@wan[0]", "mesh_internet", request.args.mesh_internet === "on" ? 1 : 0);
+    }
     uciMesh.commit("aredn");
     configuration.saveSettings();
     print(_R("changes"));
@@ -458,6 +461,18 @@ const gateway_altnet = dmz_mode === 1 ? dhcp.gateway : "";
             </div>
             {{_H("Provide a default route to a LAN connected device, even if our local WAN is disabled. By default this is only provided to
             devices if our local WAN is available.")}}
+            <div class="cols">
+                <div>
+                    <div class="o">Mesh Internet Router</div>
+                    <div class="m">Allow other nodes to route Internet bound traffic via this node</div>
+                </div>
+                <div style="flex:0">
+                    {{_R("switch", { name: "mesh_internet", value: uciMesh.get("aredn", "@wan[0]", "mesh_internet") !== "0" })}}
+                </div>
+            </div>
+            {{_H("By default a node will route any kind of traffic to any destination. In some circumstances you may wish to restrict
+            traffic which is bound for the Internet. Disabling this option stops Internet traffic from traversing this node.
+            It also prevents this node from accessing the Internet unless it is provided locally.")}}
         {% } %}
         </div>
     </div>

--- a/files/etc/uci-defaults/99_canonical_config
+++ b/files/etc/uci-defaults/99_canonical_config
@@ -134,6 +134,7 @@ const config = {
             web_access: 1,
             mesh_to_local_wan: shell("uci -q -c /etc/config.mesh get aredn.@wan[0].olsrd_gw") || 0,
             lan_to_remote_wan: shell("uci -q -c /etc/config.mesh get aredn.@wan[0].mesh_wan_gw") || 0,
+            mesh_internet: 1,
             monitor1: "1.1.1.1",
             monitor2: "8.8.8.8"
         },


### PR DESCRIPTION
By default a node will route any traffic it has routes for. This include traffic bound for non-mesh addresses (ie. the Internet). Some users have wanted the ability to opt-out of this for various reasons, but this wasn't possible until we switch exclusively to Babel.

The default behaviour remains the same and all traffic is routed. But if this feature is disable the node will no longer route Internet bound traffic including locally originating traffic. If you still want your node to access the Internet you must provide that locally either via the node's WAN interface or via a dtd connected node.

The actual mechanism to enforce this will be in a separate PR - this is just the UI around the feature.