### PR TITLE
Switch hidden dialog element to button.

### DIFF
--- a/files/app/partial/dialog-header.ut
+++ b/files/app/partial/dialog-header.ut
@@ -38,7 +38,7 @@ if (request.env.REQUEST_METHOD === "GET" && request.headers["hx-target"] === "ct
 }
 %}
 <div>
-    <input style="position:absolute;top:-10000px">
+    <button style="position:absolute;top:-10000px"></button>
     <button id="dialog-help" class="{{request.headers["include-help"] === "1" ? "enabled" : ""}}" hx-get="{{request.env.REQUEST_URI}}" hx-trigger="click delay:10ms" hx-target="#ctrl-modal" hx-headers='{"Include-Help":"{{includeHelp ? "0" : "1"}}","Include-Advanced":"{{request.headers['include-advanced'] === "1" ? "1" : "0"}}"}'>Help</button>
     <div class="t">{{inner}}</div>
     <hr/>


### PR DESCRIPTION
To avoid popping open the keyboard on a tablet by default.