### PR TITLE
add total ram

### DIFF
--- a/files/app/partial/health.ut
+++ b/files/app/partial/health.ut
@@ -43,8 +43,9 @@
         uptime = "1 day, " + uptime;
     }
     const ld = split(fs.readfile("/proc/loadavg"), " ");
-    const ram = int(match(fs.readfile("/proc/meminfo"), /MemFree: +(\d+) kB/)[1]) / 1000.0;
-    const totram = int(match(fs.readfile("/proc/meminfo"), /MemTotal: +(\d+) kB/)[1]) / 1000;
+    const meminfo = fs.readfile("/proc/meminfo");
+    const ram = int(match(meminfo, /MemFree: +(\d+) kB/)[1]) / 1000.0;
+    const totram = int(match(meminfo, /MemTotal: +(\d+) kB/)[1]) / 1000;
     const f = fs.popen("exec /bin/df /");
     let flash = "-";
     if (f) {

--- a/files/app/partial/health.ut
+++ b/files/app/partial/health.ut
@@ -44,6 +44,7 @@
     }
     const ld = split(fs.readfile("/proc/loadavg"), " ");
     const ram = int(match(fs.readfile("/proc/meminfo"), /MemFree: +(\d+) kB/)[1]) / 1000.0;
+    const totram = int(match(fs.readfile("/proc/meminfo"), /MemTotal: +(\d+) kB/)[1]) / 1000;
     const f = fs.popen("exec /bin/df /");
     let flash = "-";
     if (f) {
@@ -81,6 +82,9 @@
             <div class="t">{{ram}} MB</div>
             <div class="s">free ram</div>
         </div>
-        <div></div>
+        <div>
+            <div class="t">{{totram}} MB</div>
+            <div class="s">total ram</div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
What would you think of the idea to add "total ram" to the health display?
Memory varies a lot across the supported devices, and I often forget how much ram a node has available.
**This just prints the estimated total ram as an integer at the end of the list.**

<img width="340" height="156" alt="Screenshot 2026-08-16 at 1 54 50 PM" src="https://github.com/user-attachments/assets/cbf05b92-81ed-43cf-8673-cbb69cabb461" />
