### PR TITLE
Add support for the Bullet AC.

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -48,7 +48,7 @@ hAP ac lite <br> hAP ac lite TC | RB952Ui-5ac2nD <br> RB952Ui-5ac2nD-TC | 2 & 5 
 Model | SKUs | Band | Target | Subtarget | Image | RAM | Stability | Status
 :------ | :----: | :----: | :------: | :---------: | :-----: | :---: | :---------: | :------
 Bullet M2 XW || 2 | ath79 | generic | ubnt_bullet-m-xw | 64MB | untested | released
-Bullet AC (2WA) || 5 | ath79 | generic | ubnt_bullet-ac | 64MB | stable | nightly
+Bullet AC (2WA) | B-DB-AC | 2 & 5 | ath79 | generic | ubnt_bullet-ac | 64MB | stable | nightly
 LiteAP 5AC | LAP-120 <br> LAP-120-US <br> LBE-5AC-16-120 <br> LBE-5AC-16-120-US | 5 | ath79 | generic | ubnt_lap-120 | 64MB | stable | released
 LiteBeam 5AC Gen2 | LBE-5AC <br> LBE-5AC-US | 5 | ath79 | generic | ubnt_litebeam-ac-gen2 | 64MB | stable | released
 LiteBeam 5AC LR | LBE-5AC-LR <br> LBE-5AC-LR-US | 5 | ath79 | generic | ubnt_litebeam-ac-lr | 64MB | stable | released

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -48,7 +48,7 @@ hAP ac lite <br> hAP ac lite TC | RB952Ui-5ac2nD <br> RB952Ui-5ac2nD-TC | 2 & 5 
 Model | SKUs | Band | Target | Subtarget | Image | RAM | Stability | Status
 :------ | :----: | :----: | :------: | :---------: | :-----: | :---: | :---------: | :------
 Bullet M2 XW || 2 | ath79 | generic | ubnt_bullet-m-xw | 64MB | untested | released
-Bullet AC (2WA) | B-DB-AC | 2 & 5 | ath79 | generic | ubnt_bullet-ac | 64MB | stable | nightly
+Bullet AC (2WA) | B-DB-AC | 2 & 5 | ath79 | generic | ubnt_bullet-ac | 64MB | stable | nightly (10)
 LiteAP 5AC | LAP-120 <br> LAP-120-US <br> LBE-5AC-16-120 <br> LBE-5AC-16-120-US | 5 | ath79 | generic | ubnt_lap-120 | 64MB | stable | released
 LiteBeam 5AC Gen2 | LBE-5AC <br> LBE-5AC-US | 5 | ath79 | generic | ubnt_litebeam-ac-gen2 | 64MB | stable | released
 LiteBeam 5AC LR | LBE-5AC-LR <br> LBE-5AC-LR-US | 5 | ath79 | generic | ubnt_litebeam-ac-lr | 64MB | stable | released
@@ -210,5 +210,6 @@ Vultr | x86 | 64 | x86-64-generic-ext4 | 64mb+ | stable | released (5)
  7. Mikrotik devices come with either a v6 bootloader or a v7 bootloader. See [here](https://openwrt.org/toh/mikrotik/common) for more details. If you are using a v7 bootloader use the v7 sysupgrade instead of the plain one.
  8. There is currently no way to recover if a firmware update fails and it could brick your device.
  9. Devices with AX radios do not support negative channels or channels with less then 20MHz bandwidth.
+ 10. Devices with SIMO radios only provide half the bandwidth.
 
 Latest installation instructions are found at: https://docs.arednmesh.org/en/latest/

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -48,6 +48,7 @@ hAP ac lite <br> hAP ac lite TC | RB952Ui-5ac2nD <br> RB952Ui-5ac2nD-TC | 2 & 5 
 Model | SKUs | Band | Target | Subtarget | Image | RAM | Stability | Status
 :------ | :----: | :----: | :------: | :---------: | :-----: | :---: | :---------: | :------
 Bullet M2 XW || 2 | ath79 | generic | ubnt_bullet-m-xw | 64MB | untested | released
+Bullet AC (2WA) || 5 | ath79 | generic | ubnt_bullet-ac | 64MB | stable | nightly
 LiteAP 5AC | LAP-120 <br> LAP-120-US <br> LBE-5AC-16-120 <br> LBE-5AC-16-120-US | 5 | ath79 | generic | ubnt_lap-120 | 64MB | stable | released
 LiteBeam 5AC Gen2 | LBE-5AC <br> LBE-5AC-US | 5 | ath79 | generic | ubnt_litebeam-ac-gen2 | 64MB | stable | released
 LiteBeam 5AC LR | LBE-5AC-LR <br> LBE-5AC-LR-US | 5 | ath79 | generic | ubnt_litebeam-ac-lr | 64MB | stable | released

--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -248,6 +248,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
 <div class="dialog radio-and-antenna">
     {{_R("dialog-header", "Radios &amp; Antennas")}}
     <div>
+    {{_R("dialog-messages")}}
     {%
         const hasradios = length(wlan) > 0;
         if (hasradios) {
@@ -635,6 +636,9 @@ if (request.env.REQUEST_METHOD === "DELETE") {
     <script>
     (function(){
         {{_R("open")}}
+    {% if (hardware.getRadioIntf("wlan0")?.simo) { %}
+        dialogMessage.success("<center>This is a SIMO radio. You will only get half the expected bandwidth.</center>");
+    {% } %}
     {%
     for (let w = 0; w < length(wlan); w++) { %}
         const radio{{w}} = htmx.find("#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_mode]");

--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -976,22 +976,25 @@
   },
   "0xe2c5": {
     "name": "Ubiquiti Bullet AC (2WA)",
-    "changes": {
-      "wireless": "reboot"
-    },
     "wlan0": {
       "maxpower": 22,
       "simo": true,
       "antenna": "external"
     },
     "wlan1": {
-      "disabled": true,
       "maxpower": 14,
       "antenna": {
         "description": "4 dBi Omni",
         "gain": 4,
         "beamwidth": 360
       }
+    },
+    "timeouts": {
+      "reboot": [ 20, 180 ],
+      "upgrade": [ 120, 360 ]
+    },
+    "changes": {
+      "wireless": "reboot"
     }
   },
   "0xe2d2": {

--- a/files/etc/radios.json
+++ b/files/etc/radios.json
@@ -974,6 +974,26 @@
     "pwroffset": 6,
     "antenna": "external"
   },
+  "0xe2c5": {
+    "name": "Ubiquiti Bullet AC (2WA)",
+    "changes": {
+      "wireless": "reboot"
+    },
+    "wlan0": {
+      "maxpower": 22,
+      "simo": true,
+      "antenna": "external"
+    },
+    "wlan1": {
+      "disabled": true,
+      "maxpower": 14,
+      "antenna": {
+        "description": "4 dBi Omni",
+        "gain": 4,
+        "beamwidth": 360
+      }
+    }
+  },
   "0xe2d2": {
     "name": "Ubiquiti Bullet M2 Titanium HP",
     "maxpower": 16,
@@ -1643,7 +1663,7 @@
   },
   "qemu": {
     "name": "QEMU PC",
-    "features": [ "supernode", "videoproxy", "xlink", "remoterf" ]
+    "features": [ "supernode", "videoproxy", "xlink" ]
   },
   "vmware": {
     "name": "VMware PC",

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -351,7 +351,7 @@ const cnetworks = [ "lan", "wan", "dtdlink", "wifi0", "wifi1" ];
 for (let i = 0; i < length(cnetworks); i++) {
     const net = cnetworks[i];
     let usebridge = true;
-    let config = "";
+    config = "";
 
     // generate a complete config
     let vlan = null;
@@ -788,7 +788,7 @@ nc.commit("dhcp");
 
 // Generate the wireless config file
 const default_mesh_distance = 80550; // 50.1 miles
-let config = "";
+config = "";
 const txpowers = [];
 const ifacecount = hardware.getRadioCount();
 const devpaths = {};
@@ -1273,7 +1273,12 @@ const restarters = {
     },
     "system": [ "log", "system", "ntp" ],
     "wireless": {
-        "any": "wireless",
+        "any": () => {
+            if (hardware.getRadio()?.changes?.wireless === "reboot") {
+                return "reboot";
+            }
+            return "wireless";
+        },
         "wireless.@wifi-iface[0].mode": "reboot",
         "wireless.@wifi-device[0].channel": "lqm",
         "wireless.@wifi-device[0].macfilter": "reboot",
@@ -1335,11 +1340,9 @@ for (let file in nfiles) {
                         map(c, k => changes[k] = true);
                         break;
                     case "function":
-                        if (p === "any") {
-                            c();
-                        }
-                        else {
-                            c(specials[p], oc.get(p3[0], p3[1], p3[2]));
+                        const r = p === "any" ? c() : c(specials[p], oc.get(p3[0], p3[1], p3[2]));;
+                        if (r) {
+                            changes[r] = true;
                         }
                         break;
                     default:

--- a/files/usr/share/ucode/aredn/hardware.uc
+++ b/files/usr/share/ucode/aredn/hardware.uc
@@ -113,7 +113,7 @@ export function getBoardId()
     return trim(name);
 };
 
-function getRadio()
+export function getRadio()
 {
     if (!radioJson) {
         const f = fs.open("/etc/radios.json");
@@ -132,7 +132,7 @@ function getRadio()
         }
     }
     return radioJson;
-}
+};
 
 export function getRadioName()
 {

--- a/patches/701-extended-spectrum.patch
+++ b/patches/701-extended-spectrum.patch
@@ -305,7 +305,7 @@
 + #define ATH10K_CONNECTION_LOSS_HZ (3 * HZ)
 +-#define ATH10K_NUM_CHANS 42
 +-#define ATH10K_MAX_5G_CHAN 177
-++#define ATH10K_NUM_CHANS 88 
+++#define ATH10K_NUM_CHANS 88
 ++#define ATH10K_MAX_5G_CHAN 184
 + 
 + /* Antenna noise floor */
@@ -419,3 +419,35 @@
 + 		dev_kfree_skb(skb);
 + 		return 0;
 + 	}
+--- /dev/null
++++ b/package/kernel/ath10k-ct/patches/999-0002-ath10k-chan-remove.patch
+@@ -0,0 +1,29 @@
++--- a/ath10k-6.18/core.h
+++++ b/ath10k-6.18/core.h
++@@ -40,7 +40,7 @@
++ #define WMI_READY_TIMEOUT (5 * HZ)
++ #define ATH10K_FLUSH_TIMEOUT_HZ (5 * HZ)
++ #define ATH10K_CONNECTION_LOSS_HZ (3 * HZ)
++-#define ATH10K_NUM_CHANS 88
+++#define ATH10K_NUM_CHANS 84
++ #define ATH10K_MAX_5G_CHAN 184
++ 
++ /* Antenna noise floor */
++--- a/ath10k-6.18/mac.c
+++++ b/ath10k-6.18/mac.c
++@@ -10766,11 +10766,11 @@
++ 	CHAN5G(36, 5180, 0),
++ 	CHAN5G(40, 5200, 0),
++ 	CHAN5G(44, 5220, 0),
++-	CHAN5G(48, 5240, 0),
++-	CHAN5G(52, 5260, 0),
++-	CHAN5G(56, 5280, 0),
+++	/*CHAN5G(48, 5240, 0),*/
+++	/*CHAN5G(52, 5260, 0),*/
+++	/*CHAN5G(56, 5280, 0),*/
++ 	CHAN5G(60, 5300, 0),
++-	CHAN5G(64, 5320, 0),
+++	/*CHAN5G(64, 5320, 0),*/
++ 	CHAN5G(100, 5500, 0),
++ 	CHAN5G(104, 5520, 0),
++ 	CHAN5G(108, 5540, 0),

--- a/patches/707-ath9k-chain0-cal.patch
+++ b/patches/707-ath9k-chain0-cal.patch
@@ -1,0 +1,38 @@
+--- /dev/null
++++ b/package/kernel/mac80211/patches/ath/530-ath9k-ar9003-include-chain0-in-cal-chainmask.patch
+@@ -0,0 +1,35 @@
++--- a/drivers/net/wireless/ath/ath9k/ar9003_calib.c
+++++ b/drivers/net/wireless/ath/ath9k/ar9003_calib.c
++@@ -1582,10 +1582,21 @@
++ 	bool txiqcal_done = false;
++ 	bool status = true;
++ 	bool run_agc_cal = false, sep_iq_cal = false;
+++	u8 rx_cal_mask, tx_cal_mask;
++ 	int i = 0;
++ 
++-	/* Use chip chainmask only for calibration */
++-	ar9003_hw_set_chain_masks(ah, ah->caps.rx_chainmask, ah->caps.tx_chainmask);
+++	/*
+++	 * Use chip chainmask only for calibration.  Chain 0 must be
+++	 * included: the AGC and Tx IQ calibration engines hang if it
+++	 * is excluded from the calibration chainmask, as seen on
+++	 * AR9342 boards with a chain-1-only (0x2) EEPROM chainmask,
+++	 * e.g. the 2.4 GHz management radio of the Ubiquiti Bullet AC.
+++	 * The runtime chainmask is restored below.
+++	 */
+++	rx_cal_mask = ah->caps.rx_chainmask | BIT(0);
+++	tx_cal_mask = ah->caps.tx_chainmask | BIT(0);
+++
+++	ar9003_hw_set_chain_masks(ah, rx_cal_mask, tx_cal_mask);
++ 
++ 	if (ah->enabled_cals & TX_CL_CAL) {
++ 		REG_SET_BIT(ah, AR_PHY_CL_CAL_CTL, AR_PHY_CL_CAL_ENABLE);
++@@ -1635,7 +1646,7 @@
++ skip_tx_iqcal:
++ 	if (run_agc_cal || !(ah->ah_flags & AH_FASTCC)) {
++ 		for (i = 0; i < AR9300_MAX_CHAINS; i++) {
++-			if (!(ah->rxchainmask & (1 << i)))
+++			if (!(rx_cal_mask & (1 << i)))
++ 				continue;
++ 
++ 			ar9003_hw_manual_peak_cal(ah, i,

--- a/patches/series
+++ b/patches/series
@@ -15,6 +15,7 @@
 704-dnsmasq-have-nftset.patch
 705-aredn-banner.patch
 706-MeshNode-SSID.patch
+707-ath9k-chain0-cal.patch
 708-define-aredn-ath79-networks.patch
 708-define-aredn-ipq40xx-networks.patch
 708-define-aredn-ramips-networks.patch


### PR DESCRIPTION
We were already building for this target, but the radios didnt work. Fix the primary and secondary radio so they work.  As this is a SIMO radio we flag that in the configuration. We have avoided SIMO radios recently as they reduce bandwidth, but there are some good uses for them especially as mesh stations in the field; so reviving this one with a warning in the UI.

Enabling the primary radio required reducing the channel scan payload to fit in the buffer. This is limited on older firmware devices. This required the removal of 4 channels. I chose 48, 52, 56 and 64 as these are not currently in use according to the data from the worldmap.

Debugging the secondary radio problem was aided by Claude Fable 5 High.