### PR TITLE
Drop the default tunnel MTU to 1280.

### DIFF
--- a/files/app/main/status/e/tunnels.ut
+++ b/files/app/main/status/e/tunnels.ut
@@ -279,7 +279,7 @@ This value is used by default, but each tunnel may overide it.")}}
                     <div class="m">Default packet size for tunnels</div>
                 </div>
                 <div style="flex:0">
-                    <input hx-put="{{request.env.REQUEST_URI}}" name="tunnel_mtu" type="text" size="4" placeholder="1420" pattern="(128[0-9]|129[0-9]|13[0-9]{2}|14[01][0-9]|1420)" hx-validate="true" value="{{uciMesh.get("wireguard", "@network[0]", "mtu")}}">
+                    <input hx-put="{{request.env.REQUEST_URI}}" name="tunnel_mtu" type="text" size="4" placeholder="1280" pattern="(128[0-9]|129[0-9]|13[0-9]{2}|14[01][0-9]|1420)" hx-validate="true" value="{{uciMesh.get("wireguard", "@network[0]", "mtu")}}">
                 </div>
             </div>
             {{_H("The default packet (MTU) size for all tunnels. This can be set between 1280 and 1420 if your WAN network requires smaller packets than usual.

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -486,7 +486,7 @@ for (let i = 0; i < length(cnetworks); i++) {
 }
 
 // Generate the tunnel configurations
-const wg_mtu = min(int(cfg.wan_mtu || 1500) - 80, int(cm.get("wireguard", "@network[0]", "mtu") || 1420));
+const wg_mtu = min(int(cfg.wan_mtu || 1500) - 80, int(cm.get("wireguard", "@network[0]", "mtu") || 1280));
 const def_tun_cost = tonumber(cm.get("wireguard", "@network[0]", "cost") || cm.get("babel", "tunnel", "rxcost") || 300) || 300;
 cm.foreach("wireguard", "client",
     function(s) {


### PR DESCRIPTION
This is the minimum we need for AREDN tunnels. Going low initially avoids many problems people see where their ISP dont use the default of 1500, or do but then fragement packets when no one is looking. This makes wireguard sad. An Advanced Tunnel Option exists already to change the default.