### PR TITLE
Disable publishing LAN subnet to Babel when LAN DHCP is disabled.

### DIFF
--- a/files/app/partial/internal-services.ut
+++ b/files/app/partial/internal-services.ut
@@ -52,7 +52,7 @@
     const pou = uci.get("aredn", "@usb[0]", "passthrough") === "0" ? "disabled" : "active";
     const rr = uci.get("aredn", "@remoterf[0]", "enable") === "0" ? "disabled" : "active";
     const wm = (uci.get("aredn", "@wan[0]", "mesh_to_local_wan") == "1" || uci.get("aredn", "@wan[0]", "lan_dhcp_route") == "1") && uci.get("aredn", "@wan[0]", "passthrough") == "0" && (uci.get("aredn", "@wan[0]", "monitor1") || uci.get("aredn", "@wan[0]", "monitor2")) ? "active": "disabled";
-    const lm = "active";
+    const lm = configuration.getSettingAsInt("lan_dhcp") == 0 ? "disabled" : "active";
 %}
 <div class="ctrl" hx-get="status/e/internal-services" hx-target="#ctrl-modal">
     <div class="section-title">Internal Services</div>

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -542,7 +542,7 @@ fs.mkdir("/tmp/new_config");
 const md = fs.opendir("/etc/config.mesh");
 if (md) {
     for (let bfile = md.read(); bfile; bfile = md.read()) {
-        if (bfile == "setup" || bfile == "wireguard" || bfile == "xlink" || bfile == "firewall.user") {
+        if (bfile == "wireguard" || bfile == "xlink" || bfile == "firewall.user") {
             // Don't copy these
         }
         else {
@@ -1255,6 +1255,7 @@ const restarters = {
         "setup.globals.dmz_mode": "reboot",
         "setup.globals.dmz_lan_ip": "reboot",
         "setup.globals.dmz_lan_mask": "reboot",
+        "setup.globals.lan_dhcp": [ "lan_monitor", "babel" ],
         "setup.globals.lan_ip": "reboot",
         "setup.globals.lan_mask": "reboot",
         "setup.@ntp[0].period": (o, n) => {

--- a/files/usr/local/mgr/lan_monitor.uc
+++ b/files/usr/local/mgr/lan_monitor.uc
@@ -31,6 +31,12 @@
  * version
  */
 
+services.resetValidation();
+
+if (uci.cursor("/etc/config.mesh").get("setup", "globals", "lan_dhcp") != "1") {
+    return exitApp();
+}
+
 let last_hosts = null;
 let last_services = null;
 


### PR DESCRIPTION
This helps to declutter the IP namespace babel publishes.