### PR TITLE
Show available memory rather than free.

### DIFF
--- a/files/app/partial/health.ut
+++ b/files/app/partial/health.ut
@@ -44,7 +44,7 @@
     }
     const ld = split(fs.readfile("/proc/loadavg"), " ");
     const meminfo = fs.readfile("/proc/meminfo");
-    const ram = int(match(meminfo, /MemFree: +(\d+) kB/)[1]) / 1000.0;
+    const ram = int(match(meminfo, /MemAvailable: +(\d+) kB/)[1]) / 1000.0;
     const totram = int(match(meminfo, /MemTotal: +(\d+) kB/)[1]) / 1000;
     const f = fs.popen("exec /bin/df /");
     let flash = "-";
@@ -81,7 +81,7 @@
         </div>
         <div>
             <div class="t">{{ram}} MB</div>
-            <div class="s">free ram</div>
+            <div class="s">available ram</div>
         </div>
         <div>
             <div class="t">{{totram}} MB</div>


### PR DESCRIPTION
It's a more realistic representation of what ram is available in the system for immediate use by applications, etc.