### PR TITLE
Support multi channel stations

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -213,6 +213,7 @@ CONFIG_PACKAGE_wifi-scripts=y
 CONFIG_PACKAGE_wireguard=y
 CONFIG_PACKAGE_wireguard-tools=y
 CONFIG_PACKAGE_wpad-basic-mbedtls=y
+CONFIG_PACKAGE_wpa-cli=y
 CONFIG_PACKAGE_xinetd=n
 CONFIG_PACKAGE_zlib=m
 CONFIG_PACKAGE_zram-swap=m

--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -69,9 +69,20 @@ if (request.env.REQUEST_METHOD === "PUT") {
                     chan = chanfilter[length(chanfilter) - 1] + 1;
                 }
                 configuration.setSettingAsString("radio0_channel", chan);
+                configuration.setSettingAsString("radio0_channels", []);
             }
             if ("radio0_channel" in request.args) {
-                configuration.setSettingAsString("radio0_channel", request.args.radio0_channel);
+                let channel = request.args.radio0_channel;
+                if (type(channel) === "array") {
+                    channel = sort(uniq(channel));
+                    configuration.setSettingAsList("radio0_channels", length(channel) > 1 ? channel : []);
+                    configuration.setSettingAsString("radio0_channel", channel[0]);
+
+                }
+                else {
+                    configuration.setSettingAsList("radio0_channels", []);
+                    configuration.setSettingAsString("radio0_channel", channel);
+                }
             }
             if ("radio0_peer" in request.args) {
                 configuration.setSettingAsString("radio0_peer", request.args.radio0_peer);
@@ -92,6 +103,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
         case radios.RADIO_LAN:
             if (configuration.setSettingAsString("radio0_mode", radio0_mode)) {
                 configuration.setSettingAsString("radio0_channel", wlan[0].mode.channel || wlan[0].def.channel);
+                configuration.setSettingAsString("radio0_channels", []);
                 if (hexdec(configuration.getSettingAsString("radio0_ssid")) === null) {
                     configuration.setSettingAsString("radio0_ssid", hexenc("AREDN-LAN"));
                     configuration.setSettingAsString("radio0_encryption", "none");
@@ -100,6 +112,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
             }
             if ("radio0_channel" in request.args) {
                 configuration.setSettingAsString("radio0_channel", request.args.radio0_channel);
+                configuration.setSettingAsString("radio0_channels", []);
             }
             if ("radio0_password" in request.args) {
                 configuration.setSettingAsString("radio0_key", hexenc(request.args.radio0_password));
@@ -149,9 +162,20 @@ if (request.env.REQUEST_METHOD === "PUT") {
                     chan = chanfilter[length(chanfilter) - 1] + 1;
                 }
                 configuration.setSettingAsString("radio1_channel", chan);
+                configuration.setSettingAsString("radio1_channels", []);
             }
             if ("radio1_channel" in request.args) {
-                configuration.setSettingAsString("radio1_channel", request.args.radio1_channel);
+                let channel = request.args.radio1_channel;
+                if (type(channel) === "array") {
+                    channel = sort(uniq(channel));
+                    configuration.setSettingAsList("radio1_channels", length(channel) > 1 ? channel : []);
+                    configuration.setSettingAsString("radio1_channel", channel[0]);
+
+                }
+                else {
+                    configuration.setSettingAsList("radio1_channels", []);
+                    configuration.setSettingAsString("radio1_channel", channel);
+                }
             }
             if ("radio1_peer" in request.args) {
                 configuration.setSettingAsString("radio1_peer", request.args.radio1_peer);
@@ -172,6 +196,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
         case radios.RADIO_LAN:
             if (configuration.setSettingAsString("radio1_mode", radio1_mode)) {
                 configuration.setSettingAsString("radio1_channel", wlan[1].mode.channel || wlan[1].def.channel);
+                configuration.setSettingAsString("radio1_channels", []);
                 if (hexdec(configuration.getSettingAsString("radio1_ssid")) === null) {
                     configuration.setSettingAsString("radio1_ssid", hexenc("AREDN-LAN"));
                     configuration.setSettingAsString("radio1_encryption", "none");
@@ -180,6 +205,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
             }
             if ("radio1_channel" in request.args) {
                 configuration.setSettingAsString("radio1_channel", request.args.radio1_channel);
+                configuration.setSettingAsString("radio1_channels", []);
             }
             if ("radio1_password" in request.args) {
                 configuration.setSettingAsString("radio1_key", hexenc(request.args.radio1_password));
@@ -277,6 +303,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                 const ssid_wan = ismesh || !ssid_decoded ? "MyWiFi" : ssid_decoded;
                 const ssid_mesh = !ismesh || ssid_decoded ? "AREDN" : wlan[w].mode.ssid;
                 const channel = wlan[w].mode.channel || wlan[w].def.channel;
+                const channels = wlan[w].mode.channels;
                 const bandwidth = wlan[w].mode.bandwidth || wlan[w].def.bandwidth;
                 const txpower = wlan[w].mode.txpower;
                 const encryption = wlan[w].mode.encryption || "none";
@@ -331,7 +358,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
             </div>
             {{_H("MAC address of this radio.")}}
             <div class="hideable1 hideable4 hideable5 hideable6" {{length(wlan) > 1 ? "style='padding-left:10px'" : ""}}>
-                <div class="cols">
+                <div class="cols hideable1 hideable4 hideable5">
                     <div>
                         <div class="o">Channel</div>
                         <div class="m">Channel and frequency of this connection</div>
@@ -340,14 +367,60 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                         <select hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="{{prefix}}channel" style="direction:ltr" class="mesh-channel">
                         {%
                             const chanfilter = mode === radios.RADIO_MESHPTMP || mode === radios.RADIO_MESHPTP || mode ===  radios.RADIO_MESHSTA ? wlan[w].managedOOB : null;
-                            const channels = wlan[w].channels[bandwidth] || [];
-                            for (let i = 0; i < length(channels); i++) {
-                                if (!chanfilter || index(chanfilter, channels[i].number) === -1) {
-                                    print(`<option value="${channels[i].number}" ${channels[i].number == channel ? "selected" : ""}>${channels[i].label}</option>`);
+                            const achannels = wlan[w].channels[bandwidth] || [];
+                            for (let i = 0; i < length(achannels); i++) {
+                                if (!chanfilter || index(chanfilter, achannels[i].number) === -1) {
+                                    print(`<option value="${achannels[i].number}" ${achannels[i].number == channel ? "selected" : ""}>${achannels[i].label}</option>`);
                                 }
                             }
                         %}
                         </select>
+                    </div>
+                </div>
+                <div class="cols hideable6 sta-channels" hx-include="this">
+                    <div>
+                        <div class="o">Channels</div>
+                        <div class="m">Channel and frequency of this connection</div>
+                    </div>
+                    <div style="flex:0" class="channels">
+                        <div style="white-space:nowrap">
+                            {%
+                                const chanfilter = mode === radios.RADIO_MESHPTMP || mode === radios.RADIO_MESHPTP || mode ===  radios.RADIO_MESHSTA ? wlan[w].managedOOB : null;
+                                const achannels = wlan[w].channels[bandwidth] || [];
+                            %}
+                            <select hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="{{prefix}}channel" style="direction:ltr" class="mesh-channel">
+                            {%
+                                for (let i = 0; i < length(achannels); i++) {
+                                    if (!chanfilter || index(chanfilter, achannels[i].number) === -1) {
+                                        print(`<option value="${achannels[i].number}" ${achannels[i].number == channel ? "selected" : ""}>${achannels[i].label}</option>`);
+                                    }
+                                }
+                            %}
+                            </select>
+                            <button>+</button>
+                        </div>
+                        {%
+                            if (channels) {
+                                for (let xchannel in channels) {
+                                    if (xchannel != channel) {
+                        %}
+                        <div style="white-space:nowrap;margin-bottom:4px" class="xtra-channel">
+                            <select hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="{{prefix}}channel" style="direction:ltr" class="mesh-channel">
+                        {%
+                                        for (let i = 0; i < length(achannels); i++) {
+                                            if (!chanfilter || index(chanfilter, achannels[i].number) === -1) {
+                                                print(`<option value="${achannels[i].number}" ${achannels[i].number == xchannel ? "selected" : ""}>${achannels[i].label}</option>`);
+                                            }
+                                        }
+                        %}
+                            </select>
+                            <button>-</button>
+                        </div>
+                        {%
+                                    }
+                                }
+                            } 
+                        %}
                     </div>
                 </div>
                 {{_H("Select the central channel/frequency for the radio.")}}
@@ -402,7 +475,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                         <div class="m">AREDN mesh identifier</div>
                     </div>
                     <div style="flex:0;white-space:nowrap">
-                        <input hx-put="{{request.env.REQUEST_URI}}" name="{{prefix}}ssid" type="text" size="10" maxlength="20" pattern="[^!#;+\]\/"\t\-][^+\]\/"\t\-]{0,18}[^ !#;+\]\/"\t\-]$|^[^ !#;+\]\/"\t\-]" hx-validate="true" value="{{ssid_mesh}}"><span style="color:var(--ctrl-modal-fg-color)">{{nochan ? "" : `-${channel}`}}-{{bandwidth}}-v3</span>
+                        <input hx-put="{{request.env.REQUEST_URI}}" name="{{prefix}}ssid" type="text" size="10" maxlength="20" pattern="[^!#;+\]\/"\t\-][^+\]\/"\t\-]{0,18}[^ !#;+\]\/"\t\-]$|^[^ !#;+\]\/"\t\-]" hx-validate="true" value="{{ssid_mesh}}"><span style="color:var(--ctrl-modal-fg-color)">{{nochan ? "" : `-${channels ? "X" : channel}`}}-{{bandwidth}}-v3</span>
                     </div>
                 </div>
                 {% if (hardware.supportsFeature("max-distance", wlan[w].iface)) { %}
@@ -644,6 +717,8 @@ if (request.env.REQUEST_METHOD === "DELETE") {
         const radio{{w}} = htmx.find("#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_mode]");
         const chan{{w}} = htmx.find("#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_channel]");
         const lanchan{{w}} = htmx.find("#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_channel].lan");
+        const stachans{{w}} = htmx.find("#ctrl-modal .dialog.radio-and-antenna #radio{{w}} .sta-channels");
+        const stachan{{w}} = htmx.find(stachans{{w}}, "select[name=radio{{w}}_channel]");
         const bws{{w}} = htmx.find(`#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_bandwidth]`);
         const lanbws{{w}} = htmx.find(`#ctrl-modal .dialog.radio-and-antenna select[name=radio{{w}}_bandwidth].lan`);
         const bwssid{{w}} = htmx.find(`#ctrl-modal .dialog.radio-and-antenna input[name=radio{{w}}_ssid] + span`);
@@ -671,23 +746,71 @@ if (request.env.REQUEST_METHOD === "DELETE") {
             }
             chan{{w}}.value = nchannel;
             chan{{w}}.innerHTML = options;
+            stachan{{w}}.value = nchannel;
+            stachan{{w}}.innerHTML = options;
             if (lanchan{{w}}) {
                 lanchan{{w}}.value = nchannel;
                 lanchan{{w}}.innerHTML = options;
             }
-            if (radio{{w}}.value == "4" || radio{{w}}.value == "5" || radio{{w}}.value == "6" || (halow{{w}} && radio{{w}}.value == "1")) {
+            if (e.target == radio{{w}} || e.target == bws{{w}} || e.target == lanbws{{w}}) {
+                const xtra = htmx.findAll(stachans{{w}}, ".xtra-channel");
+                for (let i = 0; i < xtra.length; i++) {
+                    xtra[i].remove();
+                }
+            }
+            if (radio{{w}}.value == "4" || radio{{w}}.value == "5" || (halow{{w}} && radio{{w}}.value == "1")) {
                 bwssid{{w}}.innerHTML = `-${nchannel}-${bandwidth}-v3`;
+            }
+            else if (radio{{w}}.value == "6") {
+                if (htmx.findAll(stachans{{w}}, "select[name=radio{{w}}_channel]").length === 1) {
+                    bwssid{{w}}.innerHTML = `-${nchannel}-${bandwidth}-v3`;
+                }
+                else {
+                    bwssid{{w}}.innerHTML = `-X-${bandwidth}-v3`;
+                }
             }
             else {
                 bwssid{{w}}.innerHTML = `-${bandwidth}-v3`;
             }
         }
+        function click{{w}}(e) {
+            if (e.target.nodeName === "BUTTON") {
+                switch (e.target.innerText) {
+                    case "+":
+                    {
+                        let xchan = `<div style="white-space:nowrap;margin-bottom:4px" class="xtra-channel">
+                            <select hx-put="{{request.env.REQUEST_URI}}" hx-swap="none" name="radio{{w}}_channel" style="direction:ltr" class="mesh-channel">`;
+                        const bandwidth = parseInt(bws{{w}}.value);
+                        const channels = ({{wlan[w].channels || []}})[bandwidth] || [];
+                        const chanfilter = {{wlan[w].managedOOB || []}};
+                        for (let i = 0; i < channels.length; i++) {
+                            if (!chanfilter || chanfilter.indexOf(channels[i].number) === -1) {
+                                xchan += `<option value="${channels[i].number}">${channels[i].label}</option>`;
+                            }
+                        }
+                        xchan += `</select> <button>-</button></div>`;
+                        const div = document.createElement("div");
+                        div.innerHTML = xchan;
+                        htmx.process(htmx.find(stachans{{w}}, ".channels").appendChild(div.firstElementChild));
+                        break;
+                    }
+                    case "-":
+                        htmx.closest(e.target, ".xtra-channel").remove();
+                        break;
+                    default:
+                        break;
+                }
+                htmx.trigger(stachan{{w}}, "change");
+            }
+        }
         bws{{w}}.addEventListener("change", change{{w}});
         chan{{w}}.addEventListener("change", change{{w}});
+        stachan{{w}}.addEventListener("change", change{{w}});
         if (lanbws{{w}}) {
             lanbws{{w}}.addEventListener("change", change{{w}});
         }
         radio{{w}}.addEventListener("change", change{{w}});
+        stachans{{w}}.addEventListener("click", click{{w}});
     {% }
     if (length(wlan) > 1) { %}
         htmx.on(radio0, "htmx:beforeRequest", function() {

--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -74,7 +74,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
             if ("radio0_channel" in request.args) {
                 let channel = request.args.radio0_channel;
                 if (type(channel) === "array") {
-                    channel = uniq(channel);
+                    channel = sort(uniq(channel), (a, b) => int(a) - int(b));
                     configuration.setSettingAsList("radio0_channels", length(channel) > 1 ? channel : []);
                     configuration.setSettingAsString("radio0_channel", channel[0]);
 
@@ -167,7 +167,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
             if ("radio1_channel" in request.args) {
                 let channel = request.args.radio1_channel;
                 if (type(channel) === "array") {
-                    channel = uniq(channel);
+                    channel = sort(uniq(channel), (a, b) => int(a) - int(b));
                     configuration.setSettingAsList("radio1_channels", length(channel) > 1 ? channel : []);
                     configuration.setSettingAsString("radio1_channel", channel[0]);
 

--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -731,7 +731,7 @@ if (request.env.REQUEST_METHOD === "DELETE") {
         const halow{{w}} = {{hardware.getRadioType(wlan[w].iface) === "halow"}};
         function change{{w}}(e) {
             const bandwidth = parseInt(e.target == lanbws{{w}} ? lanbws{{w}}.value : bws{{w}}.value);
-            const channel = parseInt(chan{{w}}.value);
+            const channel = parseInt(e.target === chan{{w}} ? chan{{w}}.value : stachan{{w}}.value);
             let options = "";
             const chanfilter = radio{{w}}.value == "4" || radio{{w}}.value == "5" || radio{{w}}.value == "6" ? {{wlan[w].managedOOB || []}} : null;
             const channels = ({{wlan[w].channels || []}})[bandwidth] || [];

--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -74,7 +74,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
             if ("radio0_channel" in request.args) {
                 let channel = request.args.radio0_channel;
                 if (type(channel) === "array") {
-                    channel = sort(uniq(channel));
+                    channel = uniq(channel);
                     configuration.setSettingAsList("radio0_channels", length(channel) > 1 ? channel : []);
                     configuration.setSettingAsString("radio0_channel", channel[0]);
 
@@ -167,7 +167,7 @@ if (request.env.REQUEST_METHOD === "PUT") {
             if ("radio1_channel" in request.args) {
                 let channel = request.args.radio1_channel;
                 if (type(channel) === "array") {
-                    channel = sort(uniq(channel));
+                    channel = uniq(channel);
                     configuration.setSettingAsList("radio1_channels", length(channel) > 1 ? channel : []);
                     configuration.setSettingAsString("radio1_channel", channel[0]);
 

--- a/files/app/main/status/e/radio-and-antenna.ut
+++ b/files/app/main/status/e/radio-and-antenna.ut
@@ -377,10 +377,13 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                         </select>
                     </div>
                 </div>
+                <div class="cols hideable1 hideable4 hideable5">
+                    {{_H("Select the central channel/frequency for the radio.")}}
+                </div>
                 <div class="cols hideable6 sta-channels" hx-include="this">
                     <div>
                         <div class="o">Channels</div>
-                        <div class="m">Channel and frequency of this connection</div>
+                        <div class="m">Channels and frequencies of this connection</div>
                     </div>
                     <div style="flex:0" class="channels">
                         <div style="white-space:nowrap">
@@ -423,7 +426,10 @@ if (request.env.REQUEST_METHOD === "DELETE") {
                         %}
                     </div>
                 </div>
-                {{_H("Select the central channel/frequency for the radio.")}}
+                <div class="cols hideable6">
+                    {{_H("Select the central channels/frequencies for the radio. When more than one is selected the node will connect
+                          to the strongest signal.")}}
+                </div>
                 <div class="cols">
                     <div>
                         <div class="o">Channel Width</div>

--- a/files/app/partial/radio-and-antenna.ut
+++ b/files/app/partial/radio-and-antenna.ut
@@ -77,18 +77,26 @@
         <div class="s">model</div>
     </div>
     {% if (midx1 !== -1) {
-        const r = radio[midx1].mode; %}
+        const r = radio[midx1].mode;
+        const chs = r.mode === "meshsta" && configuration.getSettingAsList(`radio${midx1}_channels`); %}
     <div class="section-title">{{r.mode === "mesh" ? "Mesh" : r.mode === "meshap" ? "Mesh PTMP" : r.mode === "meshptp" ? "Mesh PTP" : "Mesh Station"}}</div>
     <div class="section">
         <div class="cols">
             <div>
-                <div class="t">{{r.channel}}{{r.mode === "meshsta" && configuration.getSettingAsList(`radio${midx1}_channels`) ? "+" : ""}}</div>
-                <div class="s">channel</div>
+                <div class="t">{{r.channel}}{{chs ? "+" : ""}}</div>
+                <div class="s">channel{{chs ? "s" : ""}}</div>
             </div>
+            {% if (chs) { %}
+            <div>
+                <div class="t">{{hardware.getDefaultChannel(radio[midx1].iface).band}}</div>
+                <div class="s">band</div>
+            </div>
+            {% } else { %}
             <div>
                 <div class="t">{{hardware.getChannelFrequencyRange(radio[midx1].iface, r.channel, r.bandwidth)}}</div>
                 <div class="s">frequencies</div>
             </div>
+            {% } %}
             <div>
                 <div class="t">{{r.bandwidth}} MHz</div>
                 <div class="s">bandwidth</div>
@@ -112,18 +120,26 @@
     </div>
     {% }
     if (midx2 !== -1) {
-        const r = radio[midx2].mode; %}
+        const r = radio[midx2].mode;
+        const chs = r.mode === "meshsta" && configuration.getSettingAsList(`radio${midx2}_channels`); %}
     <div class="section-title">{{r.mode === "mesh" ? "Mesh" : r.mode === "meshap" ? "Mesh PTMP" : r.mode === "meshptp" ? "Mesh PTP" : "Mesh Station"}}</div>
     <div class="section">
         <div class="cols">
             <div>
-                <div class="t">{{r.channel}}{{r.mode === "meshsta" && configuration.getSettingAsList(`radio${midx2}_channels`) ? "+" : ""}}</div>
-                <div class="s">channel</div>
+                <div class="t">{{r.channel}}{{chs ? "+" : ""}}</div>
+                <div class="s">channel{{chs ? "s" : ""}}</div>
             </div>
+            {% if (chs) { %}
+            <div>
+                <div class="t">{{hardware.getDefaultChannel(radio[midx2].iface).band}}</div>
+                <div class="s">band</div>
+            </div>
+            {% } else { %}
             <div>
                 <div class="t">{{hardware.getChannelFrequencyRange(radio[midx2].iface, r.channel, r.bandwidth)}}</div>
                 <div class="s">frequencies</div>
             </div>
+            {% } %}
             <div>
                 <div class="t">{{r.bandwidth}} MHz</div>
                 <div class="s">bandwidth</div>

--- a/files/app/partial/radio-and-antenna.ut
+++ b/files/app/partial/radio-and-antenna.ut
@@ -82,7 +82,7 @@
     <div class="section">
         <div class="cols">
             <div>
-                <div class="t">{{r.channel}}</div>
+                <div class="t">{{r.channel}}{{r.mode === "meshsta" && configuration.getSettingAsList(`radio${midx1}_channels`) ? "+" : ""}}</div>
                 <div class="s">channel</div>
             </div>
             <div>
@@ -117,7 +117,7 @@
     <div class="section">
         <div class="cols">
             <div>
-                <div class="t">{{r.channel}}</div>
+                <div class="t">{{r.channel}}{{r.mode === "meshsta" && configuration.getSettingAsList(`radio${midx2}_channels`) ? "+" : ""}}</div>
                 <div class="s">channel</div>
             </div>
             <div>

--- a/files/app/resource/css/admin.css
+++ b/files/app/resource/css/admin.css
@@ -457,7 +457,15 @@ label.switch
 #ctrl-modal .hideable[data-hideable] > .hideable6,
 #ctrl-modal .hideable[data-hideable] > .hideable7,
 #ctrl-modal .hideable-g[data-hideable] .hideable0-g,
-#ctrl-modal .hideable-g[data-hideable] .hideable1-g
+#ctrl-modal .hideable-g[data-hideable] .hideable1-g,
+#ctrl-modal .hideable[data-hideable] > .hideable0 > .hideable0,
+#ctrl-modal .hideable[data-hideable] > .hideable1 > .hideable1,
+#ctrl-modal .hideable[data-hideable] > .hideable2 > .hideable2,
+#ctrl-modal .hideable[data-hideable] > .hideable3 > .hideable3,
+#ctrl-modal .hideable[data-hideable] > .hideable4 > .hideable4,
+#ctrl-modal .hideable[data-hideable] > .hideable5 > .hideable5,
+#ctrl-modal .hideable[data-hideable] > .hideable6 > .hideable6,
+#ctrl-modal .hideable[data-hideable] > .hideable7 > .hideable7
 {
     display: none;
 }
@@ -475,6 +483,19 @@ label.switch
 #ctrl-modal .hideable-g[data-hideable="on"] .hideable1-g
 {
     display: block;
+}
+#ctrl-modal .hideable[data-hideable="off"] > .hideable0 > .hideable-,
+#ctrl-modal .hideable[data-hideable="0"] > .hideable0 > .hideable0,
+#ctrl-modal .hideable[data-hideable="on"] > .hideable1 > .hideable1,
+#ctrl-modal .hideable[data-hideable="1"] > .hideable1 > .hideable1,
+#ctrl-modal .hideable[data-hideable="2"] > .hideable2 > .hideable2,
+#ctrl-modal .hideable[data-hideable="3"] > .hideable3 > .hideable3,
+#ctrl-modal .hideable[data-hideable="4"] > .hideable4 > .hideable4,
+#ctrl-modal .hideable[data-hideable="5"] > .hideable5 > .hideable5,
+#ctrl-modal .hideable[data-hideable="6"] > .hideable6 > .hideable6,
+#ctrl-modal .hideable[data-hideable="7"] > .hideable7 > .hideable7
+{
+    display: flex;
 }
 
 #location-edit-map
@@ -542,6 +563,14 @@ label.switch
     display: none;
 }
 #ctrl-modal .radio-and-antenna .hideable[data-hideable="5"] .peer.hideable5
+{
+    display: flex;
+}
+#ctrl-modal .radio-and-antenna .channel.hideable5
+{
+    display: none;
+}
+#ctrl-modal .radio-and-antenna .hideable[data-hideable="5"] .channel.hideable5
 {
     display: flex;
 }

--- a/files/app/root.ut
+++ b/files/app/root.ut
@@ -529,7 +529,13 @@ global.handle_request = function(env)
                 for (let i = 0; i < length(v); i++) {
                     const kv = split(v[i], "=");
                     const k = uhttpd.urldecode(kv[0]);
-                    if (!(k in args)) {
+                    if (k in args) {
+                        if (type(args[k]) !== "array") {
+                            args[k] = [ args[k] ];
+                        }
+                        push(args[k], uhttpd.urldecode(kv[1]));
+                    }
+                    else {
                         args[k] = uhttpd.urldecode(kv[1]);
                     }
                 }

--- a/files/etc/hotplug.d/net/20-extra-channels
+++ b/files/etc/hotplug.d/net/20-extra-channels
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+CTRL="/var/run/wpa_supplicant"
+
+if [ "${ACTION}" = "add" -a "$(uci -q get wireless.${DEVICENAME}.network)" = "wifi" -a "$(uci -q get wireless.${DEVICENAME}.mode)" = "sta" ]; then
+    radio=$(echo ${DEVICENAME} | sed s/wlan/radio/)
+    channels="$(uci -q -c /etc/config.mesh get setup.globals.${radio}_channels)"
+    if [ "${channels}" != "${channels#* }" ]; then
+        # Wait for the socket to become available
+        count=0
+        while [ ! -S "${CTRL}/${DEVICENAME}" -a ${count} -lt 10 ]; do
+            sleep 1
+            count=$((count+1))
+        done
+        if [ -S "${CTRL}/${DEVICENAME}" ]; then
+            # Once it is, add the ssids for the channel selection
+            bandwidth="$(uci -q -c /etc/config.mesh get setup.globals.${radio}_bandwidth)"
+            ssid="$(uci -q -c /etc/config.mesh get setup.globals.${radio}_ssid)"
+            wpa_cli -i "${DEVICENAME}" -p "${CTRL}" remove_network all
+            for channel in ${channels}
+            do
+                id=$(wpa_cli -i "${DEVICENAME}" -p "${CTRL}" add_network | tail -1)
+                wpa_cli -i "${DEVICENAME}" -p "${CTRL}" set_network "${id}" ssid "\"${ssid}-${channel}-${bandwidth}-v3\""
+                wpa_cli -i "${DEVICENAME}" -p "${CTRL}" set_network "${id}" key_mgmt NONE
+                wpa_cli -i "${DEVICENAME}" -p "${CTRL}" enable_network "${id}"
+            done
+            wpa_cli -i "${DEVICENAME}" -p "${CTRL}" reassociate
+        fi
+    fi
+fi

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -1280,7 +1280,9 @@ const restarters = {
                 default:
                     break;
             }
-        }
+        },
+        "setup.globals.radio0_channels": "wireless",
+        "setup.globals.radio1_channels": "wireless"
     },
     "system": [ "log", "system", "ntp" ],
     "wireless": {

--- a/files/usr/share/ucode/aredn/radios.uc
+++ b/files/usr/share/ucode/aredn/radios.uc
@@ -266,6 +266,7 @@ export function getConfiguration()
         radio[0].mode = {
             mode: mode,
             channel: configuration.getSettingAsInt("radio0_channel"),
+            channels: configuration.getSettingAsList("radio0_channels"),
             bandwidth: configuration.getSettingAsInt("radio0_bandwidth"),
             ssid: configuration.getSettingAsString("radio0_ssid"),
             txpower: configuration.getSettingAsInt("radio0_txpower"),
@@ -281,6 +282,7 @@ export function getConfiguration()
         radio[1].mode = {
             mode: mode,
             channel: configuration.getSettingAsInt("radio1_channel"),
+            channels: configuration.getSettingAsList("radio1_channels"),
             bandwidth: configuration.getSettingAsInt("radio1_bandwidth"),
             ssid: configuration.getSettingAsString("radio1_ssid"),
             txpower: configuration.getSettingAsInt("radio1_txpower"),


### PR DESCRIPTION
When in Mesh Station mode, you can now add a group of channels rather
than a single one. The device will then select the best (highest SNR)
to connect to. This is useful if you're using a mobile node and know
there are a bunch of PtMP AREDN nodes in your area on different channels.